### PR TITLE
Work on client certificates

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -46,6 +46,13 @@
 
 # pragma mark Client Auth Settings
 
+/// If set, this contains the location of a pkcs#12 certificate to be used for
+/// sync authentication.
+@property(readonly) NSString *syncClientAuthCertificateFile;
+
+/// Contains the password for the pkcs#12 certificate.
+@property(readonly) NSString *syncClientAuthCertificatePassword;
+
 /// If set, this is the Common Name of a certificate in the System keychain to be used for
 /// sync authentication. The corresponding private key must also be in the keychain.
 @property(readonly) NSString *syncClientAuthCertificateCn;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -141,11 +141,27 @@ static NSString * const kMachineIDPlistKeyKey = @"MachineIDKey";
 }
 
 - (void)reloadConfigData {
-  _configData = [[NSDictionary dictionaryWithContentsOfFile:kConfigFilePath] mutableCopy];
+  NSError* error = nil;
 
-  if (!_configData) {
-    _configData = [NSMutableDictionary dictionary];
+  NSData *readData = [NSData dataWithContentsOfFile:kConfigFilePath options:0 error:&error];
+
+  if (error) {
+    fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not open configuration file %@: %@", kConfigFilePath, [error localizedDescription]] UTF8String]);
+
+    exit(1);
   }
+
+  CFErrorRef parseError = NULL;
+
+  NSDictionary *dictionary = (__bridge_transfer NSDictionary *)CFPropertyListCreateWithData(kCFAllocatorDefault, (__bridge CFDataRef)readData, kCFPropertyListImmutable, NULL, (CFErrorRef *)&parseError);
+
+  if (parseError) {
+    fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not parse configuration file %@: %@", kConfigFilePath, [(__bridge NSError *)parseError localizedDescription]] UTF8String]);
+
+    exit(1);
+  }
+
+  _configData = [dictionary mutableCopy];
 }
 
 @end

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -159,7 +159,8 @@ static NSString * const kMachineIDPlistKeyKey = @"MachineIDKey";
     fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not open configuration file %@: %@", 
             kConfigFilePath, [error localizedDescription]] UTF8String]);
 
-    exit(1);
+    _configData = [NSMutableDictionary dictionary];
+    return;
   }
 
   CFErrorRef parseError = NULL;
@@ -171,7 +172,8 @@ static NSString * const kMachineIDPlistKeyKey = @"MachineIDKey";
     fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not parse configuration file %@: %@", 
             kConfigFilePath, [(__bridge NSError *)parseError localizedDescription]] UTF8String]);
 
-    exit(1);
+    _configData = [NSMutableDictionary dictionary];
+    return;
   }
 
   _configData = [dictionary mutableCopy];

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -156,17 +156,20 @@ static NSString * const kMachineIDPlistKeyKey = @"MachineIDKey";
   NSData *readData = [NSData dataWithContentsOfFile:kConfigFilePath options:0 error:&error];
 
   if (error) {
-    fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not open configuration file %@: %@", kConfigFilePath, [error localizedDescription]] UTF8String]);
+    fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not open configuration file %@: %@", 
+            kConfigFilePath, [error localizedDescription]] UTF8String]);
 
     exit(1);
   }
 
   CFErrorRef parseError = NULL;
 
-  NSDictionary *dictionary = (__bridge_transfer NSDictionary *)CFPropertyListCreateWithData(kCFAllocatorDefault, (__bridge CFDataRef)readData, kCFPropertyListImmutable, NULL, (CFErrorRef *)&parseError);
+  NSDictionary *dictionary = (__bridge_transfer NSDictionary *)CFPropertyListCreateWithData(kCFAllocatorDefault, 
+          (__bridge CFDataRef)readData, kCFPropertyListImmutable, NULL, (CFErrorRef *)&parseError);
 
   if (parseError) {
-    fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not parse configuration file %@: %@", kConfigFilePath, [(__bridge NSError *)parseError localizedDescription]] UTF8String]);
+    fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"Could not parse configuration file %@: %@", 
+            kConfigFilePath, [(__bridge NSError *)parseError localizedDescription]] UTF8String]);
 
     exit(1);
   }

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -27,6 +27,8 @@ static NSString * const kConfigFilePath = @"/var/db/santa/config.plist";
 
 /// The keys in the config file
 static NSString * const kSyncBaseURLKey = @"SyncBaseURL";
+static NSString * const kClientAuthCertificateFileKey = @"ClientAuthCertificateFile";
+static NSString * const kClientAuthCertificatePasswordKey = @"ClientAuthCertificatePassword";
 static NSString * const kClientAuthCertificateCNKey = @"ClientAuthCertificateCN";
 static NSString * const kClientAuthCertificateIssuerKey = @"ClientAuthCertificateIssuerCN";
 static NSString * const kServerAuthRootsDataKey = @"ServerAuthRootsData";
@@ -66,6 +68,14 @@ static NSString * const kMachineIDPlistKeyKey = @"MachineIDKey";
 
 - (NSURL *)syncBaseURL {
   return [NSURL URLWithString:self.configData[kSyncBaseURLKey]];
+}
+
+- (NSString *)syncClientAuthCertificateFile {
+  return self.configData[kClientAuthCertificateFileKey];
+}
+
+- (NSString *)syncClientAuthCertificatePassword {
+  return self.configData[kClientAuthCertificatePasswordKey];
 }
 
 - (NSString *)syncClientAuthCertificateCn {

--- a/Source/santactl/sync/SNTAuthenticatingURLSession.h
+++ b/Source/santactl/sync/SNTAuthenticatingURLSession.h
@@ -31,6 +31,14 @@
 /// certificate chain. This will override the trusted roots in the System Roots.
 @property(nonatomic) NSData *serverRootsPemData;
 
+/// If set and client certificate authentication is needed, the pkcs#12 file will be
+/// loaded
+@property(nonatomic) NSString *clientCertFile;
+
+/// If set and client certificate authentication is needed, the password being used for
+/// loading the clientCertFile
+@property(nonatomic) NSString *clientCertPassword;
+
 /// If set and client certificate authentication is needed, will search the keychain for a
 /// certificate matching this common name and use that for authentication
 /// @note: Not case sensitive

--- a/Source/santactl/sync/SNTAuthenticatingURLSession.m
+++ b/Source/santactl/sync/SNTAuthenticatingURLSession.m
@@ -98,7 +98,7 @@
       completionHandler(NSURLSessionAuthChallengeUseCredential, cred);
       return;
     } else {
-      LOGE(@"Servers asks for client authentication, no usable client certificate found.");
+      LOGE(@"Server asks for client authentication, no usable client certificate found.");
       completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
       return;
     }

--- a/Source/santactl/sync/SNTAuthenticatingURLSession.m
+++ b/Source/santactl/sync/SNTAuthenticatingURLSession.m
@@ -82,7 +82,7 @@
 
   NSString *authMethod = [protectionSpace authenticationMethod];
 
-  if (authMethod == NSURLAuthenticationMethodClientCertificate && NO) {
+  if (authMethod == NSURLAuthenticationMethodClientCertificate) {
     NSURLCredential *cred = [self clientCredentialForProtectionSpace:protectionSpace];
     if (cred) {
       completionHandler(NSURLSessionAuthChallengeUseCredential, cred);

--- a/Source/santactl/sync/SNTAuthenticatingURLSession.m
+++ b/Source/santactl/sync/SNTAuthenticatingURLSession.m
@@ -88,6 +88,7 @@
       completionHandler(NSURLSessionAuthChallengeUseCredential, cred);
       return;
     } else {
+      LOGE(@"Servers asks for client authentication, no usable client certificates found.");
       completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
       return;
     }
@@ -97,6 +98,7 @@
       completionHandler(NSURLSessionAuthChallengeUseCredential, cred);
       return;
     } else {
+      LOGE(@"Servers asks for client authentication, no usable client certificates found.");
       completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
       return;
     }
@@ -228,7 +230,7 @@
     // Set this array of certs as the anchors to trust.
     err = SecTrustSetAnchorCertificates(serverTrust, (__bridge CFArrayRef)certRefs);
     if (err != errSecSuccess) {
-      LOGE(@"Server Trust: Could not set anchor certificates");
+      LOGE(@"Server Trust: Could not set anchor certificates: %d");
       return nil;
     }
   }
@@ -237,7 +239,7 @@
   SecTrustResultType result = kSecTrustResultInvalid;
   err = SecTrustEvaluate(serverTrust, &result);
   if (err != errSecSuccess) {
-    LOGE(@"Server Trust: Unable to evaluate certificate chain for server");
+    LOGE(@"Server Trust: Unable to evaluate certificate chain for server: %d", err);
     return nil;
   }
 

--- a/Source/santactl/sync/SNTCommandSync.m
+++ b/Source/santactl/sync/SNTCommandSync.m
@@ -77,9 +77,9 @@ REGISTER_COMMAND_NAME(@"sync");
 
   // Configure server auth
   if ([config syncServerAuthRootsFile]) {
-    NSError* error = nil;
+    NSError *error = nil;
 
-    NSData *rootsData = [NSData dataWithContentsOfFile:[config syncServerAuthRootsFile] options: 0 error: &error];
+    NSData *rootsData = [NSData dataWithContentsOfFile:[config syncServerAuthRootsFile] options:0 error:&error];
     authURLSession.serverRootsPemData = rootsData;
       
     if (rootsData == nil) {

--- a/Source/santactl/sync/SNTCommandSync.m
+++ b/Source/santactl/sync/SNTCommandSync.m
@@ -91,7 +91,10 @@ REGISTER_COMMAND_NAME(@"sync");
   }
 
   // Configure client auth
-  if ([config syncClientAuthCertificateCn]) {
+  if ([config syncClientAuthCertificateFile]) {
+    authURLSession.clientCertFile = [config syncClientAuthCertificateFile];
+    authURLSession.clientCertPassword = [config syncClientAuthCertificatePassword];
+  } else if ([config syncClientAuthCertificateCn]) {
     authURLSession.clientCertCommonName = [config syncClientAuthCertificateCn];
   } else if ([config syncClientAuthCertificateIssuer]) {
     authURLSession.clientCertIssuerCn = [config syncClientAuthCertificateIssuer];

--- a/Source/santactl/sync/SNTCommandSync.m
+++ b/Source/santactl/sync/SNTCommandSync.m
@@ -77,8 +77,15 @@ REGISTER_COMMAND_NAME(@"sync");
 
   // Configure server auth
   if ([config syncServerAuthRootsFile]) {
-    NSData *rootsData = [NSData dataWithContentsOfFile:[config syncServerAuthRootsFile]];
+    NSError* error = nil;
+
+    NSData *rootsData = [NSData dataWithContentsOfFile:[config syncServerAuthRootsFile] options: 0 error: &error];
     authURLSession.serverRootsPemData = rootsData;
+      
+    if (rootsData == nil) {
+        LOGE(@"Couldn't open server root certificate file %@ with error: %@.", [config syncServerAuthRootsFile], [error localizedDescription]);
+        exit(1);
+    }
   } else if ([config syncServerAuthRootsData]) {
     authURLSession.serverRootsPemData = [config syncServerAuthRootsData];
   }


### PR DESCRIPTION
* improved logging
* exit with error when configuration file couldn't be opened
* removed hardcoded NO for using client certificates
* added support for pkcs#12 files
* fixed issue with ignoring client certificate configuration