### PR TITLE
Fix application deadlock.

### DIFF
--- a/Source/SantaGUI/SNTAppDelegate.m
+++ b/Source/SantaGUI/SNTAppDelegate.m
@@ -71,7 +71,7 @@
 #pragma mark Connection handling
 
 - (void)createConnection {
-  dispatch_sync(dispatch_get_main_queue(), ^{
+  dispatch_async(dispatch_get_main_queue(), ^{
     __weak __typeof(self) weakSelf = self;
 
     self.listener = [[SNTXPCConnection alloc] initClientWithName:[SNTXPCNotifierInterface serviceId]


### PR DESCRIPTION
Fix application deadlock by asynchronously dispatching to the main queue in -[SNTAppDelegate createConnection].