### PR TITLE
Using fwrite as we know the length of string

### DIFF
--- a/Source/common/SNTLogging.m
+++ b/Source/common/SNTLogging.m
@@ -52,7 +52,7 @@ void logMessage(LogLevel level, FILE *destination, NSString *format, ...) {
 
   va_list args;
   va_start(args, format);
-  NSString *s = [[NSString alloc] initWithFormat:format arguments:args];
+  NSMutableString *s = [[NSMutableString alloc] initWithFormat:format arguments:args];
   va_end(args);
 
   if (useSyslog) {
@@ -86,6 +86,8 @@ void logMessage(LogLevel level, FILE *destination, NSString *format, ...) {
 
     asl_log(client, NULL, syslogLevel, "%s %s: %s", levelName, binaryName, [s UTF8String]);
   } else {
-    fprintf(destination, "%s\n", [s UTF8String]);
+    [s appendString:@"\n"];
+    size_t len = [s lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+    fwrite([s UTF8String], len, 1, destination);
   }
 }


### PR DESCRIPTION
It is better to use fwrite as it is generally faster and we are not
using any fprintf feature