### PR TITLE
santa-driver: Don't filter advisory vnode_write notifications

### DIFF
--- a/Source/common/SNTKernelCommon.h
+++ b/Source/common/SNTKernelCommon.h
@@ -29,8 +29,8 @@
 #define USERCLIENT_ID "com.google.santa-driver"
 
 // Branch prediction
-#define likely(x)   __builtin_expect((x), 1)
-#define unlikely(x) __builtin_expect((x), 0)
+#define likely(x)   __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
 
 // List of methods supported by the driver.
 enum SantaDriverMethods {


### PR DESCRIPTION
Also force the likely/unlikely macros into boolean comparison and force the idata/sdm checks after casting.