### PR TITLE
santad: Update SNTFileWatcher to fix broken dispatch source.

### DIFF
--- a/Source/common/SNTFileWatcher.m
+++ b/Source/common/SNTFileWatcher.m
@@ -76,9 +76,7 @@
     });
 
     dispatch_source_set_cancel_handler(self.source, ^{
-      STRONGIFY(self);
-      int fd = (int)dispatch_source_get_handle(self.source);
-      if (fd > 0) close(fd);
+      close(fd);
     });
 
     dispatch_resume(self.source);
@@ -87,13 +85,7 @@
 
 - (void)stopWatchingFile {
   if (!self.source) return;
-
-  int fd = (int)dispatch_source_get_handle(self.source);
   dispatch_source_set_event_handler_f(self.source, NULL);
-  dispatch_source_set_cancel_handler(self.source, ^{
-    close(fd);
-  });
-
   dispatch_source_cancel(self.source);
   self.source = nil;
 }


### PR DESCRIPTION
I'm not certain if this is a Sierra change or just that it was more rare before but changing a cancel handler on a dispatch source no longer seems to have any effect. This meant the file descriptor for the currently-active source was being closed instead of the one for the source that was just cancelled. It wasn't actually necessary to get the file handle from the source, we can just rely on capturing it in the block, which works just as well.