### PR TITLE
santad: Handle UTF-8 in process args.

### DIFF
--- a/Source/santad/SNTEventLog.m
+++ b/Source/santad/SNTEventLog.m
@@ -398,7 +398,7 @@
   if (sanitized) {
     [str appendFormat:@"|args=%@", sanitized];
   } else {
-    [str appendFormat:@"|args=%s", &bytes[stringStart]];
+    [str appendFormat:@"|args=%@", @(&bytes[stringStart])];
   }
 
   if (shouldFree) {


### PR DESCRIPTION
While appendFormat with %s is slightly faster (~1üs) it doesn't handle UTF-8 properly and I can't figure out a better way than this (though I'm sure there is one)