### PR TITLE
santad: Handle case where there are multiple rules for req'd certs

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -148,7 +148,7 @@
     NSArray *requiredHashes = [rules filteredArrayUsingPredicate:p];
     p = [NSPredicate predicateWithFormat:@"SELF.state == %d", SNTRuleStateWhitelist];
     NSArray *requiredHashesWhitelist = [requiredHashes filteredArrayUsingPredicate:p];
-    if ((cleanSlate && requiredHashesWhitelist.count != 2) ||
+    if ((cleanSlate && requiredHashesWhitelist.count < 2) ||
         (requiredHashes.count != requiredHashesWhitelist.count)) {
       LOGE(@"Received request to remove whitelist for launchd/santad certificates.");
       [self fillError:error code:SNTRuleTableErrorMissingRequiredRule message:nil];


### PR DESCRIPTION
Otherwise the required rule protection breaks.