### PR TITLE
Common: Don't crash if ClientMode key is not an integer.

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -100,7 +100,13 @@ static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {
-  NSInteger cm = [self.configData[kClientModeKey] longValue];
+  NSInteger cm = SNTClientModeUnknown;
+
+  id mode = self.configData[kClientModeKey];
+  if ([mode respondsToSelector:@selector(longLongValue)]) {
+    cm = (NSInteger)[mode longLongValue];
+  }
+
   if (cm == SNTClientModeMonitor || cm == SNTClientModeLockdown) {
     return (SNTClientMode)cm;
   } else {


### PR DESCRIPTION
NSString has longLongValue but not longValue, so switch to that then cast down. Check that the receiver responds to longLongValue before calling it just in case someone tries to set it to an NSData or something.

Fixes #102 