### PR TITLE
santa-driver: Fix deadlocking on Sierra

### DIFF
--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -134,9 +134,7 @@ IOReturn SantaDriverClient::allow_binary(
   if (!me) return kIOReturnBadArgument;
 
   const uint64_t vnode_id = static_cast<const uint64_t>(*arguments->scalarInput);
-
   me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_ALLOW);
-  wakeup((void *)vnode_id);
 
   return kIOReturnSuccess;
 }
@@ -147,9 +145,7 @@ IOReturn SantaDriverClient::deny_binary(
   if (!me) return kIOReturnBadArgument;
 
   const uint64_t vnode_id = static_cast<const uint64_t>(*arguments->scalarInput);
-
   me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_DENY);
-  wakeup((void *)vnode_id);
 
   return kIOReturnSuccess;
 }


### PR DESCRIPTION
1. Don't RemoveFromCache for advisory access by santad itself.
2. wakeup sleeping threads when removing from cache
3. Move the vnode type check earlier in the process for the vnode scope