### PR TITLE
SNTCommandFileInfo global json bool shared between class and instance methods

### DIFF
--- a/Tests/LogicTests/SNTCommandFileInfoTest.m
+++ b/Tests/LogicTests/SNTCommandFileInfoTest.m
@@ -27,8 +27,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *);
 + (NSArray *)signingChainKeys;
 - (SNTAttributeBlock)codeSigned;
 - (instancetype)initWithFilePath:(NSString *)filePath
-                daemonConnection:(SNTXPCConnection *)daemonConn
-                      jsonOutput:(BOOL)jsonOutput;
+                daemonConnection:(SNTXPCConnection *)daemonConn;
 + (void)parseArguments:(NSArray *)args
                 forKey:(NSString **)key
              certIndex:(NSNumber **)certIndex
@@ -49,7 +48,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *);
 - (void)setUp {
   [super setUp];
 
-  self.cfi = [[SNTCommandFileInfo alloc] initWithFilePath:nil daemonConnection:nil jsonOutput:NO];
+  self.cfi = [[SNTCommandFileInfo alloc] initWithFilePath:nil daemonConnection:nil];
   self.cscMock = OCMClassMock([MOLCodesignChecker class]);
   OCMStub([self.cscMock alloc]).andReturn(self.cscMock);
 }


### PR DESCRIPTION
  *  https://github.com/google/santa/issues/112 Add missing pretty output check around the clear line escape sequence
  *  Collapses all pretty output checks to a single function
  *  Only run isatty() once saving some time
