### PR TITLE
Display the binary name in rule sync user notifications

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
@@ -70,10 +70,15 @@
   LOGI(@"Added %lu rules", self.syncState.downloadedRules.count);
 
   if (self.syncState.ruleSyncOnly) {
-    // TODO:(tburgin) Have the sync server send down the sha256 and name of the binary in the FCM
-    // message. Match those items with downloaded rules, making use of the custom message.
+    NSString *fileName;
+    for (SNTRule *r in self.syncState.downloadedRules) {
+      fileName = [[self.syncState.ruleSyncCache objectForKey:r.shasum] copy];
+      [self.syncState.ruleSyncCache removeObjectForKey:r.shasum];
+      if (fileName) break;
+    }
+    NSString *message = fileName ? [NSString stringWithFormat:@"Rule added for %@", fileName] : nil;
     [[self.daemonConn remoteObjectProxy]
-        postRuleSyncNotificationWithCustomMessage:nil reply:^{}];
+        postRuleSyncNotificationWithCustomMessage:message reply:^{}];
   }
 
   return YES;

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -68,4 +68,7 @@
 /// Returns YES if the session is a stand-alone rule sync, returns NO otherwise.
 @property BOOL ruleSyncOnly;
 
+/// Reference to the sync manager's ruleSyncCache. Used to lookup binary names for notifications.
+@property(weak) NSCache *ruleSyncCache;
+
 @end


### PR DESCRIPTION
*  Cache rule metadata contained in FCM message.
*  Search the cache when a rule is applied as a result of a FCM message and add the binary name to the user notification.
![screen shot 2016-12-07 at 4 34 49 pm](https://cloud.githubusercontent.com/assets/2117646/20987673/9246b8ce-bc9b-11e6-8ea1-31b95f931fe1.png)
