### PR TITLE
Use machine ids as the targeted sync indicator

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -32,7 +32,6 @@ extern NSString *const kBlacklistRegex;
 extern NSString *const kBinaryRuleCount;
 extern NSString *const kCertificateRuleCount;
 extern NSString *const kFCMToken;
-extern NSString *const kFCMBroadcastTopic;
 
 extern NSString *const kEvents;
 extern NSString *const kFileSHA256;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -34,7 +34,6 @@ NSString *const kBlacklistRegex = @"blacklist_regex";
 NSString *const kBinaryRuleCount = @"binary_rule_count";
 NSString *const kCertificateRuleCount = @"certificate_rule_count";
 NSString *const kFCMToken = @"fcm_token";
-NSString *const kFCMBroadcastTopic = @"fcm_broadcast_topic";
 
 NSString *const kEvents = @"events";
 NSString *const kFileSHA256 = @"file_sha256";

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -75,7 +75,6 @@
   if (!resp) return NO;
 
   self.syncState.FCMToken = resp[kFCMToken];
-  self.syncState.FCMBroadcastTopic = resp[kFCMBroadcastTopic];
 
   self.syncState.eventBatchSize = [resp[kBatchSize] intValue] ?: 50;
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
@@ -69,7 +69,7 @@
 
   LOGI(@"Added %lu rules", self.syncState.downloadedRules.count);
 
-  if (self.syncState.ruleSyncOnly) {
+  if (self.syncState.targetedRuleSync) {
     NSString *fileName;
     for (SNTRule *r in self.syncState.downloadedRules) {
       fileName = [[self.syncState.ruleSyncCache objectForKey:r.shasum] copy];

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -35,9 +35,6 @@
 /// A FCM token to subscribe to push notifications.
 @property(copy) NSString *FCMToken;
 
-/// A FCM broadcast topic. Used to determine origins of a fcm message.
-@property(copy) NSString *FCMBroadcastTopic;
-
 /// Machine identifier and owner.
 @property(copy) NSString *machineID;
 @property(copy) NSString *machineOwner;
@@ -65,8 +62,8 @@
 /// Returns YES if the santactl session is running as a daemon, returns NO otherwise.
 @property BOOL daemon;
 
-/// Returns YES if the session is a stand-alone rule sync, returns NO otherwise.
-@property BOOL ruleSyncOnly;
+/// Returns YES if the session is targeted for this machine, returns NO otherwise.
+@property BOOL targetedRuleSync;
 
 /// Reference to the sync manager's ruleSyncCache. Used to lookup binary names for notifications.
 @property(weak) NSCache *ruleSyncCache;


### PR DESCRIPTION
*  Provides better assurance that a notification is mapped to the requesting machine.
*  Defaults to staggered rule downloads if machine ids do not match.