### PR TITLE
santactl sync: reachability and notification updates santad: syncd xpc updates

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
@@ -70,15 +70,15 @@
   LOGI(@"Added %lu rules", self.syncState.downloadedRules.count);
 
   if (self.syncState.targetedRuleSync) {
-    NSString *fileName;
     for (SNTRule *r in self.syncState.downloadedRules) {
-      fileName = [[self.syncState.ruleSyncCache objectForKey:r.shasum] copy];
+      NSString *fileName = [[self.syncState.ruleSyncCache objectForKey:r.shasum] copy];
       [self.syncState.ruleSyncCache removeObjectForKey:r.shasum];
-      if (fileName) break;
+      if (fileName) {
+        NSString *message = [NSString stringWithFormat:@"%@ can now be run", fileName];
+        [[self.daemonConn remoteObjectProxy]
+            postRuleSyncNotificationWithCustomMessage:message reply:^{}];
+      }
     }
-    NSString *message = fileName ? [NSString stringWithFormat:@"%@ can now be run", fileName] : nil;
-    [[self.daemonConn remoteObjectProxy]
-        postRuleSyncNotificationWithCustomMessage:message reply:^{}];
   }
 
   return YES;

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -184,10 +184,13 @@ double watchdogRAMPeak = 0;
 #pragma mark syncd Ops
 
 - (void)setSyncdListener:(NSXPCListenerEndpoint *)listener {
+  // Only allow one active syncd connection
+  if (self.syncdQueue.syncdConnection) return;
   SNTXPCConnection *c = [[SNTXPCConnection alloc] initClientWithListener:listener];
   c.remoteInterface = [SNTXPCSyncdInterface syncdInterface];
   c.invalidationHandler = ^{
     [self.syncdQueue stopSyncingEvents];
+    self.syncdQueue.syncdConnection = nil;
     self.syncdQueue.invalidationHandler();
   };
   c.acceptedHandler = ^{


### PR DESCRIPTION
*  `santactl sync`: Retry failed full syncs once the url is reachable
*  `santactl sync`: rule_sync action messages contain a hash and the name of the binary rule generated for the machine. That data is cached and looked up later during the rule download phase. To avoid potentially displaying the wrong name for a current user action, I propose we display all downloaded rules names that can be found in the cache. We then remove each cached item as we go through the list. This will give more accurate feedback and mitigate laptops waking from sleep from displaying an older cached name in response to a current user action. If there are multiple rules generated while a machine is asleep, upon wake the notifications are grouped like so.
![screen shot 2017-01-04 at 2 22 52 pm](https://cloud.githubusercontent.com/assets/2117646/21659767/322ff74c-d29a-11e6-8275-55777eae14dd.png)
*  `santad`: Allow only one syncd connection at any given time to be set.
