### PR TITLE
santactl status: add last successful rule sync date

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -143,9 +143,14 @@ extern NSString *const kDefaultConfigFilePath;
 @property(readonly, nonatomic) NSString *machineOwner;
 
 ///
-///  The last date of successful sync.
+///  The last date of a successful full sync.
 ///
 @property(nonatomic) NSDate *syncLastSuccess;
+
+///
+///  The last date of a successful rule sync.
+///
+@property(nonatomic) NSDate *ruleSyncLastSuccess;
 
 ///
 ///  If YES a clean sync is required.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -145,7 +145,7 @@ extern NSString *const kDefaultConfigFilePath;
 ///
 ///  The last date of a successful full sync.
 ///
-@property(nonatomic) NSDate *syncLastSuccess;
+@property(nonatomic) NSDate *fullSyncLastSuccess;
 
 ///
 ///  The last date of a successful rule sync.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -52,7 +52,7 @@ static NSString *const kModeNotificationMonitor = @"ModeNotificationMonitor";
 static NSString *const kModeNotificationLockdown = @"ModeNotificationLockdown";
 
 static NSString *const kSyncBaseURLKey = @"SyncBaseURL";
-static NSString *const kSyncLastSuccess = @"SyncLastSuccess";
+static NSString *const kFullSyncLastSuccess = @"FullSyncLastSuccess";
 static NSString *const kRuleSyncLastSuccess = @"RuleSyncLastSuccess";
 static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 static NSString *const kClientAuthCertificateFileKey = @"ClientAuthCertificateFile";
@@ -260,18 +260,18 @@ static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
   return self.configData[kServerAuthRootsFileKey];
 }
 
-- (NSDate *)syncLastSuccess {
-  return self.configData[kSyncLastSuccess];
+- (NSDate *)fullSyncLastSuccess {
+  return self.configData[kFullSyncLastSuccess];
 }
 
 - (NSDate *)ruleSyncLastSuccess {
   return self.configData[kRuleSyncLastSuccess];
 }
 
-- (void)setSyncLastSuccess:(NSDate *)syncLastSuccess {
-  self.configData[kSyncLastSuccess] = syncLastSuccess;
+- (void)setFullSyncLastSuccess:(NSDate *)fullSyncLastSuccess {
+  self.configData[kFullSyncLastSuccess] = fullSyncLastSuccess;
   [self saveConfigToDisk];
-  self.ruleSyncLastSuccess = syncLastSuccess;
+  self.ruleSyncLastSuccess = fullSyncLastSuccess;
 }
 
 - (void)setRuleSyncLastSuccess:(NSDate *)ruleSyncLastSuccess {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -53,6 +53,7 @@ static NSString *const kModeNotificationLockdown = @"ModeNotificationLockdown";
 
 static NSString *const kSyncBaseURLKey = @"SyncBaseURL";
 static NSString *const kSyncLastSuccess = @"SyncLastSuccess";
+static NSString *const kRuleSyncLastSuccess = @"RuleSyncLastSuccess";
 static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 static NSString *const kClientAuthCertificateFileKey = @"ClientAuthCertificateFile";
 static NSString *const kClientAuthCertificatePasswordKey = @"ClientAuthCertificatePassword";
@@ -263,8 +264,18 @@ static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
   return self.configData[kSyncLastSuccess];
 }
 
+- (NSDate *)ruleSyncLastSuccess {
+  return self.configData[kRuleSyncLastSuccess];
+}
+
 - (void)setSyncLastSuccess:(NSDate *)syncLastSuccess {
   self.configData[kSyncLastSuccess] = syncLastSuccess;
+  [self saveConfigToDisk];
+  self.ruleSyncLastSuccess = syncLastSuccess;
+}
+
+- (void)setRuleSyncLastSuccess:(NSDate *)ruleSyncLastSuccess {
+  self.configData[kRuleSyncLastSuccess] = ruleSyncLastSuccess;
   [self saveConfigToDisk];
 }
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -264,14 +264,14 @@ static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
   return self.configData[kFullSyncLastSuccess];
 }
 
-- (NSDate *)ruleSyncLastSuccess {
-  return self.configData[kRuleSyncLastSuccess];
-}
-
 - (void)setFullSyncLastSuccess:(NSDate *)fullSyncLastSuccess {
   self.configData[kFullSyncLastSuccess] = fullSyncLastSuccess;
   [self saveConfigToDisk];
   self.ruleSyncLastSuccess = fullSyncLastSuccess;
+}
+
+- (NSDate *)ruleSyncLastSuccess {
+  return self.configData[kRuleSyncLastSuccess];
 }
 
 - (void)setRuleSyncLastSuccess:(NSDate *)ruleSyncLastSuccess {

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -73,6 +73,7 @@
 - (void)xsrfToken:(void (^)(NSString *))reply;
 - (void)setXsrfToken:(NSString *)token reply:(void (^)())reply;
 - (void)setSyncLastSuccess:(NSDate *)date reply:(void (^)())reply;
+- (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)())reply;
 - (void)setSyncCleanRequired:(BOOL)cleanReqd reply:(void (^)())reply;
 - (void)setWhitelistPathRegex:(NSString *)pattern reply:(void (^)())reply;
 - (void)setBlacklistPathRegex:(NSString *)pattern reply:(void (^)())reply;

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -104,6 +104,9 @@ REGISTER_COMMAND_NAME(@"status")
   dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
   NSDate *lastSyncSuccess = [[SNTConfigurator configurator] syncLastSuccess];
   NSString *lastSyncSuccessStr = [dateFormatter stringFromDate:lastSyncSuccess] ?: @"Never";
+  NSDate *lastRuleSyncSuccess = [[SNTConfigurator configurator] ruleSyncLastSuccess];
+  NSString *lastRuleSyncSuccessStr =
+      [dateFormatter stringFromDate:lastRuleSyncSuccess] ?: lastSyncSuccessStr;
   BOOL syncCleanReqd = [[SNTConfigurator configurator] syncCleanRequired];
   __block BOOL pushNotifications;
   dispatch_group_enter(group);
@@ -138,8 +141,9 @@ REGISTER_COMMAND_NAME(@"status")
       @"sync" : @{
         @"server" : syncURLStr ?: @"null",
         @"clean_required" : @(syncCleanReqd),
-        @"last_successful" : lastSyncSuccessStr ?: @"null",
-        @"push_notifications" : pushNotifications ? @"true" : @"false"
+        @"last_successful_full" : lastSyncSuccessStr ?: @"null",
+        @"last_successful_rule" : lastRuleSyncSuccessStr ?: @"null",
+        @"push_notifications" : pushNotifications ? @"Connected" : @"Disconnected"
       },
     };
     NSData *statsData = [NSJSONSerialization dataWithJSONObject:stats
@@ -149,23 +153,25 @@ REGISTER_COMMAND_NAME(@"status")
     printf("%s\n", [statsStr UTF8String]);
   } else {
     printf(">>> Daemon Info\n");
-    printf("  %-22s | %s\n", "Mode", [clientMode UTF8String]);
-    printf("  %-22s | %s\n", "File Logging", (fileLogging ? "Yes" : "No"));
-    printf("  %-22s | %lld  (Peak: %.2f%%)\n", "Watchdog CPU Events", cpuEvents, cpuPeak);
-    printf("  %-22s | %lld  (Peak: %.2fMB)\n", "Watchdog RAM Events", ramEvents, ramPeak);
+    printf("  %-25s | %s\n", "Mode", [clientMode UTF8String]);
+    printf("  %-25s | %s\n", "File Logging", (fileLogging ? "Yes" : "No"));
+    printf("  %-25s | %lld  (Peak: %.2f%%)\n", "Watchdog CPU Events", cpuEvents, cpuPeak);
+    printf("  %-25s | %lld  (Peak: %.2fMB)\n", "Watchdog RAM Events", ramEvents, ramPeak);
     printf(">>> Kernel Info\n");
-    printf("  %-22s | %lld\n", "Kernel cache count", cacheCount);
+    printf("  %-25s | %lld\n", "Kernel cache count", cacheCount);
     printf(">>> Database Info\n");
-    printf("  %-22s | %lld\n", "Binary Rules", binaryRuleCount);
-    printf("  %-22s | %lld\n", "Certificate Rules", certRuleCount);
-    printf("  %-22s | %lld\n", "Events Pending Upload", eventCount);
+    printf("  %-25s | %lld\n", "Binary Rules", binaryRuleCount);
+    printf("  %-25s | %lld\n", "Certificate Rules", certRuleCount);
+    printf("  %-25s | %lld\n", "Events Pending Upload", eventCount);
 
     if (syncURLStr) {
       printf(">>> Sync Info\n");
-      printf("  %-22s | %s\n", "Sync Server", [syncURLStr UTF8String]);
-      printf("  %-22s | %s\n", "Clean Sync Required", (syncCleanReqd ? "Yes" : "No"));
-      printf("  %-22s | %s\n", "Last Successful Sync", [lastSyncSuccessStr UTF8String]);
-      printf("  %-22s | %s\n", "Push Notifications", (pushNotifications ? "Yes" : "No"));
+      printf("  %-25s | %s\n", "Sync Server", [syncURLStr UTF8String]);
+      printf("  %-25s | %s\n", "Clean Sync Required", (syncCleanReqd ? "Yes" : "No"));
+      printf("  %-25s | %s\n", "Last Successful Full Sync", [lastSyncSuccessStr UTF8String]);
+      printf("  %-25s | %s\n", "Last Successful Rule Sync", [lastRuleSyncSuccessStr UTF8String]);
+      printf("  %-25s | %s\n", "Push Notifications",
+             (pushNotifications ? "Connected" : "Disconnected"));
     }
   }
 

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -102,7 +102,7 @@ REGISTER_COMMAND_NAME(@"status")
   NSString *syncURLStr = [[[SNTConfigurator configurator] syncBaseURL] absoluteString];
   NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
   dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
-  NSDate *lastSyncSuccess = [[SNTConfigurator configurator] syncLastSuccess];
+  NSDate *lastSyncSuccess = [[SNTConfigurator configurator] fullSyncLastSuccess];
   NSString *lastSyncSuccessStr = [dateFormatter stringFromDate:lastSyncSuccess] ?: @"Never";
   NSDate *lastRuleSyncSuccess = [[SNTConfigurator configurator] ruleSyncLastSuccess];
   NSString *lastRuleSyncSuccessStr =

--- a/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
@@ -67,6 +67,12 @@
     return NO;
   }
 
+  sema = dispatch_semaphore_create(0);
+  [[self.daemonConn remoteObjectProxy] setRuleSyncLastSuccess:[NSDate date] reply:^{
+    dispatch_semaphore_signal(sema);
+  }];
+  dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+
   LOGI(@"Added %lu rules", self.syncState.downloadedRules.count);
 
   if (self.syncState.targetedRuleSync) {

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -143,7 +143,7 @@ double watchdogRAMPeak = 0;
 }
 
 - (void)setSyncLastSuccess:(NSDate *)date reply:(void (^)())reply {
-  [[SNTConfigurator configurator] setSyncLastSuccess:date];
+  [[SNTConfigurator configurator] setFullSyncLastSuccess:date];
   reply();
 }
 

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -147,6 +147,11 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
+- (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)())reply {
+  [[SNTConfigurator configurator] setRuleSyncLastSuccess:date];
+  reply();
+}
+
 - (void)setSyncCleanRequired:(BOOL)cleanReqd reply:(void (^)())reply {
   [[SNTConfigurator configurator] setSyncCleanRequired:cleanReqd];
   reply();


### PR DESCRIPTION
Note there is a change to the `santactl status --json` api under the `sync` key.
* Change `last_successful` --> `last_successful_full`
* Add `last_successful_rule`
