### PR TITLE
santad: Clear cache when regexes change.

### DIFF
--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -162,6 +162,8 @@ double watchdogRAMPeak = 0;
                                                                       options:0
                                                                         error:NULL];
   [[SNTConfigurator configurator] setWhitelistPathRegex:re];
+  LOGI(@"Received new whitelist regex, flushing cache");
+  [self.driverManager flushCache];
   reply();
 }
 
@@ -170,6 +172,8 @@ double watchdogRAMPeak = 0;
                                                                       options:0
                                                                         error:NULL];
   [[SNTConfigurator configurator] setBlacklistPathRegex:re];
+  LOGI(@"Received new blacklist regex, flushing cache");
+  [self.driverManager flushCache];  
   reply();
 }
 


### PR DESCRIPTION
When white/black-list regexes are changed clear the kernel cache so the regexes are able to take effect immediately. Fixes #142