### PR TITLE
disable bundle scans

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - MOLCertificate (1.5)
   - MOLCodesignChecker (1.5):
     - MOLCertificate (~> 1.3)
-  - MOLFCMClient (1.1):
+  - MOLFCMClient (1.2):
     - MOLAuthenticatingURLSession (~> 2.1)
   - OCMock (3.3.1)
 
@@ -24,9 +24,9 @@ SPEC CHECKSUMS:
   MOLAuthenticatingURLSession: 2f0fd35f641bc857ee1b026021dbd759955adaa3
   MOLCertificate: c39cae866d24d36fbc78032affff83d401b5384a
   MOLCodesignChecker: fc9c64147811d7b0d0739127003e0630dff9213a
-  MOLFCMClient: f1684219facbffdb060ff4ab18b1825bcd4c75bc
+  MOLFCMClient: ac305053a3fba548e2255dee06f20ce144872fdb
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
 
 PODFILE CHECKSUM: b20628b5933f54525daf0dcc5534512b1cb134c8
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.2.0

--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -1200,7 +1200,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		376E230296F6EA7A4DA8BBF0 /* [CP] Check Pods Manifest.lock */ = {
@@ -1215,7 +1215,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		435B0E246EE25ACC763D684C /* [CP] Copy Pods Resources */ = {
@@ -1245,7 +1245,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		A3D478EF1D48EA118AF176E9 /* [CP] Check Pods Manifest.lock */ = {
@@ -1260,7 +1260,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		B3EB60284D47F89140F5A033 /* [CP] Copy Pods Resources */ = {

--- a/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.h
@@ -18,6 +18,4 @@
 
 - (BOOL)uploadEvents:(NSArray *)events;
 
-- (BOOL)syncBundleEvents;
-
 @end

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -317,24 +317,11 @@ static void reachabilityHandler(
   SNTCommandSyncRuleDownload *p = [[SNTCommandSyncRuleDownload alloc] initWithState:syncState];
   if ([p sync]) {
     LOGD(@"Rule download complete");
-    if (syncState.bundleBinaryRequests.count) {
-      return [self eventUploadBundleBinariesWithSyncState:syncState];
-    }
     return [self postflightWithSyncState:syncState];
   } else {
     LOGE(@"Rule download failed, aborting run");
     if (!syncState.daemon) exit(1);
   }
-}
-
-- (void)eventUploadBundleBinariesWithSyncState:(SNTCommandSyncState *)syncState {
-  SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc] initWithState:syncState];
-  if ([p syncBundleEvents]) {
-    LOGD(@"Event upload for bundle binaries complete");
-  } else {
-    LOGW(@"Event upload for bundle binary search failed");
-  }
-  return [self postflightWithSyncState:syncState];
 }
 
 - (void)postflightWithSyncState:(SNTCommandSyncState *)syncState {

--- a/Tests/LogicTests/SNTCommandSyncTest.m
+++ b/Tests/LogicTests/SNTCommandSyncTest.m
@@ -344,28 +344,6 @@
   XCTAssertEqual(requestCount, 2);
 }
 
-- (void)testEventUploadBundleSearch {
-  SNTCommandSyncEventUpload *sut = [[SNTCommandSyncEventUpload alloc] initWithState:self.syncState];
-  self.syncState.eventBatchSize = 128;
-  self.syncState.bundleBinaryRequests = @[ @"/Applications/Safari.app"];
-  sut = OCMPartialMock(sut);
-
-  [self stubRequestBody:nil response:nil error:nil validateBlock:^BOOL(NSURLRequest *req) {
-    NSDictionary *requestDict = [self dictFromRequest:req];
-    NSArray *events = requestDict[kEvents];
-
-    XCTAssertGreaterThanOrEqual(events.count, 3);
-
-    for (NSDictionary *event in events) {
-      XCTAssertEqualObjects(event[kDecision], kDecisionBundleBinary);
-    }
-
-    return YES;
-  }];
-
-  [sut syncBundleEvents];
-}
-
 #pragma mark - SNTCommandSyncRuleDownload Tests
 
 - (void)testRuleDownload {


### PR DESCRIPTION
*  santactl/sync: disable sync server bundle scan requests. This feature, as implemented, won't complete scans because santactl runs as `nobody`. Additionally there have been reports of strange santactl crashes with Foundation backtraces. I suspect because of the `nobody` user. Remove the code path. A full featured implementation will be in https://github.com/google/santa/pull/145.
*  config: update to cocoapods-1.2.0 and molfcmclient 1.2
