### PR TITLE
santactl/sync: use hostname for reachability

### DIFF
--- a/Source/common/SNTXPCConnection.m
+++ b/Source/common/SNTXPCConnection.m
@@ -138,12 +138,7 @@
 - (BOOL)listener:(NSXPCListener *)listener shouldAcceptNewConnection:(NSXPCConnection *)connection {
   pid_t pid = connection.processIdentifier;
   MOLCodesignChecker *otherCS = [[MOLCodesignChecker alloc] initWithPID:pid];
-  MOLCodesignChecker *myCS = [[MOLCodesignChecker alloc] initWithSelf];
-  if (![otherCS signingInformationMatches:myCS]
-#ifdef DEBUG  // allow no certs on both sides of the connection.
-      && ! [[[NSProcessInfo processInfo] arguments] containsObject:@"--nochecksignatures"]
-#endif
-      ) {
+  if (![otherCS signingInformationMatches:[[MOLCodesignChecker alloc] initWithSelf]]) {
     return NO;
   }
 

--- a/Source/santactl/Commands/SNTCommandCheckCache.m
+++ b/Source/santactl/Commands/SNTCommandCheckCache.m
@@ -33,8 +33,8 @@ REGISTER_COMMAND_NAME(@"checkcache")
   return NO;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return [SNTXPCControlInterface configuredConnection];
++ (BOOL)requiresDaemonConn {
+  return YES;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -370,8 +370,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   return NO;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return nil;
++ (BOOL)requiresDaemonConn {
+  return NO;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/SNTCommandFlushCache.m
+++ b/Source/santactl/Commands/SNTCommandFlushCache.m
@@ -31,8 +31,8 @@ REGISTER_COMMAND_NAME(@"flushcache")
   return YES;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return [SNTXPCControlInterface configuredConnection];
++ (BOOL)requiresDaemonConn {
+  return YES;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -37,8 +37,8 @@ REGISTER_COMMAND_NAME(@"rule")
   return YES;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return [SNTXPCControlInterface configuredConnection];
++ (BOOL)requiresDaemonConn {
+  return YES;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -29,8 +29,8 @@ REGISTER_COMMAND_NAME(@"status")
   return NO;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return [SNTXPCControlInterface configuredConnection];
++ (BOOL)requiresDaemonConn {
+  return YES;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/SNTCommandVersion.m
+++ b/Source/santactl/Commands/SNTCommandVersion.m
@@ -32,8 +32,8 @@ REGISTER_COMMAND_NAME(@"version")
   return NO;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return nil;
++ (BOOL)requiresDaemonConn {
+  return NO;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/sync/SNTCommandSync.m
+++ b/Source/santactl/Commands/sync/SNTCommandSync.m
@@ -36,8 +36,8 @@ REGISTER_COMMAND_NAME(@"sync")
   return NO;
 }
 
-+ (SNTXPCConnection *)daemonConnectionIfNeeded {
-  return [SNTXPCControlInterface configuredConnection];
++ (BOOL)requiresDaemonConn {
+  return NO;
 }
 
 + (NSString *)shortHelpText {

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -52,14 +52,17 @@ const uint64_t kGlobalRuleSyncLeeway = 600;
 @end
 
 // Called when the network state changes
-static void reachabilityHandler(
-    SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info) {
-  SNTCommandSyncManager *commandSyncManager = (__bridge SNTCommandSyncManager *)info;
-  // Only call the setter when there is a change. This will filter out the redundant calls to this
-  // callback whenever the network interface states change.
-  if (commandSyncManager.reachable != (flags & kSCNetworkReachabilityFlagsReachable)) {
-    commandSyncManager.reachable = (flags & kSCNetworkReachabilityFlagsReachable);
-  }
+static void reachabilityHandler(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags,
+                                void *info) {
+  // Ensure state changes are processed in order.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    SNTCommandSyncManager *commandSyncManager = (__bridge SNTCommandSyncManager *)info;
+    // Only call the setter when there is a change. This will filter out the redundant calls to this
+    // callback whenever the network interface states change.
+    if (commandSyncManager.reachable != (flags & kSCNetworkReachabilityFlagsReachable)) {
+      commandSyncManager.reachable = (flags & kSCNetworkReachabilityFlagsReachable);
+    }
+  });
 }
 
 @implementation SNTCommandSyncManager
@@ -437,7 +440,7 @@ static void reachabilityHandler(
 // Start listening for network state changes on a background thread
 - (void)startReachability {
   if (_reachability) return;
-  const char *nodename = [[SNTConfigurator configurator] syncBaseURL].absoluteString.UTF8String;
+  const char *nodename = [[SNTConfigurator configurator] syncBaseURL].host.UTF8String;
   _reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, nodename);
   SCNetworkReachabilityContext context = {
     .info = (__bridge void *)self
@@ -454,7 +457,7 @@ static void reachabilityHandler(
 - (void)stopReachability {
   if (_reachability) {
     SCNetworkReachabilitySetDispatchQueue(_reachability, NULL);
-    CFRelease(_reachability);
+    if (_reachability) CFRelease(_reachability);
     _reachability = NULL;
   }
 }

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -52,8 +52,8 @@ const uint64_t kGlobalRuleSyncLeeway = 600;
 @end
 
 // Called when the network state changes
-static void reachabilityHandler(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags,
-                                void *info) {
+static void reachabilityHandler(
+    SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info) {
   // Ensure state changes are processed in order.
   dispatch_async(dispatch_get_main_queue(), ^{
     SNTCommandSyncManager *commandSyncManager = (__bridge SNTCommandSyncManager *)info;

--- a/Source/santactl/SNTCommandController.h
+++ b/Source/santactl/SNTCommandController.h
@@ -25,12 +25,9 @@
 + (BOOL)requiresRoot;
 
 ///
-///  @return an (SNTXPCConnection *) if command requires connection to a daemon.
-/// The connection should be in a suspended state.
-/// If an invalidation handler is provided in the connection, it needs to properly exit instead of
-/// waiting forever.  If none is provided, a default invalidation handler is installed.
+///  @return YES if command requires connection to santad.
 ///
-+ (SNTXPCConnection *)daemonConnectionIfNeeded;
++ (BOOL)requiresDaemonConn;
 
 ///
 ///  A small summary of the command, to be printed with the list of available commands

--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -15,6 +15,7 @@
 #import "SNTCommandController.h"
 
 #import "SNTXPCConnection.h"
+#import "SNTXPCControlInterface.h"
 
 @implementation SNTCommandController
 
@@ -46,9 +47,8 @@ static NSMutableDictionary *registeredCommands;
     [helpText appendFormat:@"\t%*s - %@\n", longestCommandName,
                            [cmdName UTF8String], [cmd shortHelpText]];
   }
-  NSString *appName = [[NSProcessInfo processInfo] processName];
-  [helpText appendFormat:@"\nSee '%@ help <command>' to read about a specific subcommand.",
-      appName];
+
+  [helpText appendFormat:@"\nSee 'santactl help <command>' to read about a specific subcommand."];
   return helpText;
 }
 
@@ -68,14 +68,14 @@ static NSMutableDictionary *registeredCommands;
   return nil;
 }
 
-+ (SNTXPCConnection *)configureConnection:(SNTXPCConnection *)daemonConn {
-  if (daemonConn) {
-    if (!daemonConn.invalidationHandler) {
-      daemonConn.invalidationHandler = ^{
-        printf("An error occurred communicating with the daemon, is it running?\n");
-        exit(1);
-      };
-    }
++ (SNTXPCConnection *)connectToDaemonRequired:(BOOL)required {
+  SNTXPCConnection *daemonConn = [SNTXPCControlInterface configuredConnection];
+
+  if (required) {
+    daemonConn.invalidationHandler = ^{
+      printf("An error occurred communicating with the daemon, is it running?\n");
+      exit(1);
+    };
     [daemonConn resume];
   }
   return daemonConn;
@@ -93,7 +93,7 @@ static NSMutableDictionary *registeredCommands;
     exit(2);
   }
 
-  SNTXPCConnection *daemonConn = [self configureConnection:[command daemonConnectionIfNeeded]];
+  SNTXPCConnection *daemonConn = [self connectToDaemonRequired:[command requiresDaemonConn]];
   [command runWithArguments:arguments daemonConnection:daemonConn];
 
   // The command is responsible for quitting.


### PR DESCRIPTION
*  santactl/sync: use hostname for reachability of the sync service
*  Also revert #141 - this change provided little benefit and is actually less flexible