### PR TITLE
Running without a config fixes

### DIFF
--- a/Source/common/SNTFileWatcher.m
+++ b/Source/common/SNTFileWatcher.m
@@ -18,7 +18,7 @@
 
 @interface SNTFileWatcher ()
 @property NSString *filePath;
-@property(strong) void (^handler)(unsigned long);
+@property(copy) void (^handler)(unsigned long);
 
 @property dispatch_source_t source;
 @end
@@ -52,7 +52,8 @@
 
   dispatch_async(queue, ^{
     int fd = -1;
-    while ((fd = open([self.filePath fileSystemRepresentation], O_EVTONLY | O_CLOEXEC)) < 0) {
+    const char *filePath = [self.filePath fileSystemRepresentation];
+    while ((fd = open(filePath, O_EVTONLY | O_CLOEXEC)) < 0) {
       usleep(200000);  // wait 200ms
     }
     self.source = dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE, fd, mask, queue);

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -110,12 +110,15 @@ REGISTER_COMMAND_NAME(@"status")
   NSString *lastRuleSyncSuccessStr =
       [dateFormatter stringFromDate:lastRuleSyncSuccess] ?: lastSyncSuccessStr;
   BOOL syncCleanReqd = [[SNTConfigurator configurator] syncCleanRequired];
-  __block BOOL pushNotifications;
-  dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] pushNotifications:^(BOOL response) {
-    pushNotifications = response;
-    dispatch_group_leave(group);
-  }];
+
+  __block BOOL pushNotifications = FALSE;
+  if ([[SNTConfigurator configurator] syncBaseURL]) {
+    dispatch_group_enter(group);
+    [[daemonConn remoteObjectProxy] pushNotifications:^(BOOL response) {
+      pushNotifications = response;
+      dispatch_group_leave(group);
+    }];
+  }
 
   // Wait a maximum of 5s for stats collected from daemon to arrive.
   if (dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5))) {

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -111,7 +111,7 @@ REGISTER_COMMAND_NAME(@"status")
       [dateFormatter stringFromDate:lastRuleSyncSuccess] ?: lastSyncSuccessStr;
   BOOL syncCleanReqd = [[SNTConfigurator configurator] syncCleanRequired];
 
-  __block BOOL pushNotifications = FALSE;
+  __block BOOL pushNotifications = NO;
   if ([[SNTConfigurator configurator] syncBaseURL]) {
     dispatch_group_enter(group);
     [[daemonConn remoteObjectProxy] pushNotifications:^(BOOL response) {


### PR DESCRIPTION
*  	https://github.com/google/santa/issues/151 common: capture fileSystemRepresentation as a local variable to avoid a leak in it's implementation
    *  A big thanks to @LtMama for reporting this issue and providing memory graphs to track down the issue.
*  	santactl/status: check for instant notification status only when there is a sync server

