### PR TITLE
santactl/sync: use the new fcm-stream format

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ target :santactl do
   pod 'MOLAuthenticatingURLSession'
   pod 'MOLCertificate'
   pod 'MOLCodesignChecker'
-  pod 'MOLFCMClient'
+  pod 'MOLFCMClient', '~> 1.3'
 end
 
 target :LogicTests do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - MOLCertificate (1.5)
   - MOLCodesignChecker (1.5):
     - MOLCertificate (~> 1.3)
-  - MOLFCMClient (1.2):
+  - MOLFCMClient (1.3):
     - MOLAuthenticatingURLSession (~> 2.1)
   - OCMock (3.3.1)
 
@@ -16,7 +16,7 @@ DEPENDENCIES:
   - MOLAuthenticatingURLSession
   - MOLCertificate
   - MOLCodesignChecker
-  - MOLFCMClient
+  - MOLFCMClient (~> 1.3)
   - OCMock
 
 SPEC CHECKSUMS:
@@ -24,9 +24,9 @@ SPEC CHECKSUMS:
   MOLAuthenticatingURLSession: 2f0fd35f641bc857ee1b026021dbd759955adaa3
   MOLCertificate: c39cae866d24d36fbc78032affff83d401b5384a
   MOLCodesignChecker: fc9c64147811d7b0d0739127003e0630dff9213a
-  MOLFCMClient: ac305053a3fba548e2255dee06f20ce144872fdb
+  MOLFCMClient: 13d8b42db9d750e772f09cc38fc453922fece09f
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
 
-PODFILE CHECKSUM: b20628b5933f54525daf0dcc5534512b1cb134c8
+PODFILE CHECKSUM: 1728b86e95e7cdb481dd91ab9c38af38e060a023
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
*  MOLFCMClient has been updated in v1.3 to use fcm-stream
*  Handle the new message content of `foo:bar` instead of `{key:foo, value:bar}`