### PR TITLE
Project: Add DevelopmentTeam configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Santa.xcodeproj/xcuserdata
 Santa.xcodeproj/project.xcworkspace
 Santa.xcworkspace/xcuserdata
 Santa.xcworkspace/xcshareddata
+Source/DevelopmentTeam.xcconfig

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - FMDB (2.6.2):
     - FMDB/standard (= 2.6.2)
   - FMDB/standard (2.6.2)
-  - MOLAuthenticatingURLSession (2.1):
+  - MOLAuthenticatingURLSession (2.2):
     - MOLCertificate (~> 1.5)
   - MOLCertificate (1.5)
   - MOLCodesignChecker (1.5):
     - MOLCertificate (~> 1.3)
   - MOLFCMClient (1.3):
     - MOLAuthenticatingURLSession (~> 2.1)
-  - OCMock (3.3.1)
+  - OCMock (3.4)
 
 DEPENDENCIES:
   - FMDB
@@ -21,11 +21,11 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   FMDB: 854a0341b4726e53276f2a8996f06f1b80f9259a
-  MOLAuthenticatingURLSession: 2f0fd35f641bc857ee1b026021dbd759955adaa3
+  MOLAuthenticatingURLSession: 5a5e31eb73248c3e92c79b9a285f031194e8404c
   MOLCertificate: c39cae866d24d36fbc78032affff83d401b5384a
   MOLCodesignChecker: fc9c64147811d7b0d0739127003e0630dff9213a
   MOLFCMClient: 13d8b42db9d750e772f09cc38fc453922fece09f
-  OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
+  OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
 
 PODFILE CHECKSUM: 1728b86e95e7cdb481dd91ab9c38af38e060a023
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'openssl'
+
 WORKSPACE           = 'Santa.xcworkspace'
 DEFAULT_SCHEME      = 'All'
 OUTPUT_PATH         = 'Build'
@@ -5,6 +7,8 @@ BINARIES            = ['Santa.app', 'santa-driver.kext']
 DSYMS               = ['Santa.app.dSYM', 'santa-driver.kext.dSYM', 'santad.dSYM', 'santactl.dSYM']
 XCPRETTY_DEFAULTS   = '-sc'
 XCODEBUILD_DEFAULTS = "-workspace #{WORKSPACE} -derivedDataPath #{OUTPUT_PATH} -parallelizeTargets"
+DEVTEAM_FILE        = 'Source/DevelopmentTeam.xcconfig'
+DEVTEAM_CERT_CN     = 'Mac Developer'
 $DISABLE_XCPRETTY   = false
 
 task :default do
@@ -44,6 +48,13 @@ task :init do
     puts "xcpretty is not installed. Install with 'sudo gem install xcpretty'"
     $DISABLE_XCPRETTY = true
   end
+  cert_pem = `security find-certificate -p -c '#{DEVTEAM_CERT_CN}'`
+  cert = OpenSSL::X509::Certificate.new cert_pem
+  team_id = cert.subject.to_a.find {|f| f[0] == "OU"}[1]
+  File.open(DEVTEAM_FILE, 'w') { |f|
+    f.puts("// This file is auto-generated. Do not edit manually")
+    f.puts("DEVELOPMENT_TEAM = #{team_id}")
+  }
 end
 
 task :remove_existing do

--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -154,11 +154,11 @@
 		0DEFB7C81ACF0BFE00B92AAE /* SNTFileWatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C71ACF0BFE00B92AAE /* SNTFileWatcherTest.m */; };
 		0DF395641AB76A7900CBC520 /* NSData+Zlib.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DF395631AB76A7900CBC520 /* NSData+Zlib.m */; };
 		0DF395661AB76ABC00CBC520 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DF395651AB76ABC00CBC520 /* libz.dylib */; };
-		1C299D1C789489996FF9E081 /* libPods-Santa.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 87D1CEAEDF1FA6819A855559 /* libPods-Santa.a */; };
-		29C490B1720D4FD576F93519 /* libPods-LogicTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 17D03B346587131C45A8DA67 /* libPods-LogicTests.a */; };
-		2BA4AE89AA2447E29DA2E85C /* libPods-santactl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE53E1EAE84D54E7FCB22FD5 /* libPods-santactl.a */; };
 		4092327A1A51B66400A04527 /* SNTCommandRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 409232791A51B65D00A04527 /* SNTCommandRule.m */; };
-		A60673DE57680AC450A3B0B2 /* libPods-santad.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BE438428F17C09C6A9D0802 /* libPods-santad.a */; };
+		42805FED981952EC9F0E4272 /* libPods-santactl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC914D8DD0F5C0E21DA45150 /* libPods-santactl.a */; };
+		7E396F5897B914399A568D27 /* libPods-Santa.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FE66FA803110026A2A57C59 /* libPods-Santa.a */; };
+		8E6BE2EABCDF090F0FCEA980 /* libPods-santad.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E57A355BC439804E082B9C0A /* libPods-santad.a */; };
+		C4F8326EEB58061C1A579F0D /* libPods-LogicTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EAD1E725C5F299F58F754D7 /* libPods-LogicTests.a */; };
 		C714F8B11D8044D400700EDF /* SNTCommandFileInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD5FBE1909D64A006B445C /* SNTCommandFileInfo.m */; };
 		C714F8B21D8044FE00700EDF /* SNTCommandController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D35BDAB18FD7CFD00921A21 /* SNTCommandController.m */; };
 		C72E8D941D7F399900C86DD3 /* SNTCommandFileInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C72E8D931D7F399900C86DD3 /* SNTCommandFileInfoTest.m */; };
@@ -247,6 +247,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		07B44952FAAF4CA056FC4A62 /* Pods-santad.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santad.debug.xcconfig"; path = "Pods/Target Support Files/Pods-santad/Pods-santad.debug.xcconfig"; sourceTree = "<group>"; };
 		0D0016A2192BCD3C005E7FCD /* KernelTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = KernelTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D0016A5192BCD3C005E7FCD /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		0D0A1EC1191998C900B8450F /* SNTCommandSyncRuleDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTCommandSyncRuleDownload.h; sourceTree = "<group>"; };
@@ -262,6 +263,7 @@
 		0D202D1D1CDD479400A88F16 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		0D202D1F1CE4E90E00A88F16 /* sync_preflight_basic.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = sync_preflight_basic.json; sourceTree = "<group>"; };
 		0D202D231CE5071600A88F16 /* SantaCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SantaCache.h; sourceTree = "<group>"; };
+		0D2429471E787655005C6FC9 /* DevelopmentTeam.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DevelopmentTeam.xcconfig; sourceTree = "<group>"; };
 		0D260DAC18B68E12002A0B55 /* LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D260DB118B68E12002A0B55 /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
 		0D28E5E119269B3600280F87 /* SNTLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SNTLogging.h; sourceTree = "<group>"; };
@@ -384,22 +386,14 @@
 		0DF395621AB76A7900CBC520 /* NSData+Zlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Zlib.h"; sourceTree = "<group>"; };
 		0DF395631AB76A7900CBC520 /* NSData+Zlib.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Zlib.m"; sourceTree = "<group>"; };
 		0DF395651AB76ABC00CBC520 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
-		17D03B346587131C45A8DA67 /* libPods-LogicTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LogicTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2B9F8A80C0F8D34D98135F36 /* Pods-santactl.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santactl.release.xcconfig"; path = "Pods/Target Support Files/Pods-santactl/Pods-santactl.release.xcconfig"; sourceTree = "<group>"; };
+		3EAD1E725C5F299F58F754D7 /* libPods-LogicTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LogicTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		409232791A51B65D00A04527 /* SNTCommandRule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCommandRule.m; sourceTree = "<group>"; };
-		4D9D2DDDCD92DBB948D38B11 /* Pods-Santa.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.release.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.release.xcconfig"; sourceTree = "<group>"; };
-		4E43227BA5B261FF33141AFC /* Pods-LogicTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LogicTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests.debug.xcconfig"; sourceTree = "<group>"; };
-		556108C12FC29E329D82D4CB /* libPods-santactl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santactl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		60A9B66BB0F7404D1F61D518 /* libPods-santad.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santad.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		691189054F4E484D030CF831 /* Pods-santactl.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santactl.debug.xcconfig"; path = "Pods/Target Support Files/Pods-santactl/Pods-santactl.debug.xcconfig"; sourceTree = "<group>"; };
-		7C9CC3CDF2609E78E6A9C601 /* Pods-santad.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santad.release.xcconfig"; path = "Pods/Target Support Files/Pods-santad/Pods-santad.release.xcconfig"; sourceTree = "<group>"; };
-		821428941753678DB772D761 /* Pods-LogicTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LogicTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests.release.xcconfig"; sourceTree = "<group>"; };
-		873978BCE4B0DBD2A89C99D1 /* libPods-LogicTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LogicTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		87D1CEAEDF1FA6819A855559 /* libPods-Santa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Santa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		95B378553DCD86290341B8E4 /* Pods-santad.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santad.debug.xcconfig"; path = "Pods/Target Support Files/Pods-santad/Pods-santad.debug.xcconfig"; sourceTree = "<group>"; };
-		9BE438428F17C09C6A9D0802 /* libPods-santad.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santad.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B2B9044B79DD2E4DEC5D3B7A /* libPods-Santa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Santa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BE53E1EAE84D54E7FCB22FD5 /* libPods-santactl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santactl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5123AB484639A3640D62CB67 /* Pods-santactl.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santactl.release.xcconfig"; path = "Pods/Target Support Files/Pods-santactl/Pods-santactl.release.xcconfig"; sourceTree = "<group>"; };
+		5B0D17672432F610DE7F14EA /* Pods-LogicTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LogicTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6519E416CC4D06EE85DDB34B /* Pods-Santa.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.release.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.release.xcconfig"; sourceTree = "<group>"; };
+		6A947802FC1698EC37A47F5C /* Pods-santactl.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santactl.debug.xcconfig"; path = "Pods/Target Support Files/Pods-santactl/Pods-santactl.debug.xcconfig"; sourceTree = "<group>"; };
+		8FE66FA803110026A2A57C59 /* libPods-Santa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Santa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5C68436912C0F98A7DE3BFA /* Pods-LogicTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LogicTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests.release.xcconfig"; sourceTree = "<group>"; };
 		C72E8D931D7F399900C86DD3 /* SNTCommandFileInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCommandFileInfoTest.m; sourceTree = "<group>"; };
 		C76614EB1D142D3C00D150C1 /* SNTCommandCheckCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCommandCheckCache.m; sourceTree = "<group>"; };
 		C776A1051DEE160500A56616 /* SNTCommandSyncManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTCommandSyncManager.h; sourceTree = "<group>"; };
@@ -410,7 +404,10 @@
 		C7FB56F51DBFB480004E14EF /* SNTXPCSyncdInterface.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTXPCSyncdInterface.m; sourceTree = "<group>"; };
 		C7FB56FE1DBFC213004E14EF /* SNTSyncdQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTSyncdQueue.h; sourceTree = "<group>"; };
 		C7FB56FF1DBFC213004E14EF /* SNTSyncdQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTSyncdQueue.m; sourceTree = "<group>"; };
-		D227889DF327E7D3532FE00B /* Pods-Santa.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.debug.xcconfig"; sourceTree = "<group>"; };
+		DC914D8DD0F5C0E21DA45150 /* libPods-santactl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santactl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E57A355BC439804E082B9C0A /* libPods-santad.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santad.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1E491F3C201A2362E04FF81 /* Pods-santad.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santad.release.xcconfig"; path = "Pods/Target Support Files/Pods-santad/Pods-santad.release.xcconfig"; sourceTree = "<group>"; };
+		F25BED2D82EB26743AD59464 /* Pods-Santa.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -426,7 +423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D202D1E1CDD479400A88F16 /* libz.tbd in Frameworks */,
-				29C490B1720D4FD576F93519 /* libPods-LogicTests.a in Frameworks */,
+				C4F8326EEB58061C1A579F0D /* libPods-LogicTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -435,7 +432,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0DF395661AB76ABC00CBC520 /* libz.dylib in Frameworks */,
-				2BA4AE89AA2447E29DA2E85C /* libPods-santactl.a in Frameworks */,
+				42805FED981952EC9F0E4272 /* libPods-santactl.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -443,7 +440,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C299D1C789489996FF9E081 /* libPods-Santa.a in Frameworks */,
+				7E396F5897B914399A568D27 /* libPods-Santa.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -451,7 +448,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A60673DE57680AC450A3B0B2 /* libPods-santad.a in Frameworks */,
+				8E6BE2EABCDF090F0FCEA980 /* libPods-santad.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -611,8 +608,8 @@
 				0DB77FDC1CD262F5004DF060 /* Source */,
 				0D789F9F1940F26D0036F7C4 /* Tests */,
 				0D91BCB5174E8A7E00131A7D /* Products */,
-				57575205DAC12A357F9EF899 /* Pods */,
-				9A8F78FCF1FF5934C80FB9B4 /* Frameworks */,
+				32B59E26727EF7DC0FC6A1C2 /* Pods */,
+				8ADEC8FA6FDD43E921A3E0D6 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -641,10 +638,6 @@
 				0D91BCB8174E8A7E00131A7D /* Kernel.framework */,
 				0D9A7F3E1759330500035EB5 /* Foundation.framework */,
 				0D385DB7180DE4A900418BC6 /* Cocoa.framework */,
-				17D03B346587131C45A8DA67 /* libPods-LogicTests.a */,
-				87D1CEAEDF1FA6819A855559 /* libPods-Santa.a */,
-				BE53E1EAE84D54E7FCB22FD5 /* libPods-santactl.a */,
-				9BE438428F17C09C6A9D0802 /* libPods-santad.a */,
 			);
 			name = Frameworks;
 			path = ../..;
@@ -774,32 +767,33 @@
 				0D9A7F401759330500035EB5 /* santad */,
 				0D35BDA018FD71CE00921A21 /* santactl */,
 				0D385DBD180DE4A900418BC6 /* SantaGUI */,
+				0D2429471E787655005C6FC9 /* DevelopmentTeam.xcconfig */,
 			);
 			path = Source;
 			sourceTree = "<group>";
 		};
-		57575205DAC12A357F9EF899 /* Pods */ = {
+		32B59E26727EF7DC0FC6A1C2 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4E43227BA5B261FF33141AFC /* Pods-LogicTests.debug.xcconfig */,
-				821428941753678DB772D761 /* Pods-LogicTests.release.xcconfig */,
-				D227889DF327E7D3532FE00B /* Pods-Santa.debug.xcconfig */,
-				4D9D2DDDCD92DBB948D38B11 /* Pods-Santa.release.xcconfig */,
-				691189054F4E484D030CF831 /* Pods-santactl.debug.xcconfig */,
-				2B9F8A80C0F8D34D98135F36 /* Pods-santactl.release.xcconfig */,
-				95B378553DCD86290341B8E4 /* Pods-santad.debug.xcconfig */,
-				7C9CC3CDF2609E78E6A9C601 /* Pods-santad.release.xcconfig */,
+				5B0D17672432F610DE7F14EA /* Pods-LogicTests.debug.xcconfig */,
+				A5C68436912C0F98A7DE3BFA /* Pods-LogicTests.release.xcconfig */,
+				F25BED2D82EB26743AD59464 /* Pods-Santa.debug.xcconfig */,
+				6519E416CC4D06EE85DDB34B /* Pods-Santa.release.xcconfig */,
+				6A947802FC1698EC37A47F5C /* Pods-santactl.debug.xcconfig */,
+				5123AB484639A3640D62CB67 /* Pods-santactl.release.xcconfig */,
+				07B44952FAAF4CA056FC4A62 /* Pods-santad.debug.xcconfig */,
+				F1E491F3C201A2362E04FF81 /* Pods-santad.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		9A8F78FCF1FF5934C80FB9B4 /* Frameworks */ = {
+		8ADEC8FA6FDD43E921A3E0D6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				873978BCE4B0DBD2A89C99D1 /* libPods-LogicTests.a */,
-				B2B9044B79DD2E4DEC5D3B7A /* libPods-Santa.a */,
-				556108C12FC29E329D82D4CB /* libPods-santactl.a */,
-				60A9B66BB0F7404D1F61D518 /* libPods-santad.a */,
+				3EAD1E725C5F299F58F754D7 /* libPods-LogicTests.a */,
+				8FE66FA803110026A2A57C59 /* libPods-Santa.a */,
+				DC914D8DD0F5C0E21DA45150 /* libPods-santactl.a */,
+				E57A355BC439804E082B9C0A /* libPods-santad.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -841,13 +835,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0D260DBC18B68E12002A0B55 /* Build configuration list for PBXNativeTarget "LogicTests" */;
 			buildPhases = (
-				376E230296F6EA7A4DA8BBF0 /* [CP] Check Pods Manifest.lock */,
+				C22A218D691E062A00781563 /* [CP] Check Pods Manifest.lock */,
 				0D673DAD18FC9017009C5B06 /* Delete existing coverage files */,
 				0D260DA818B68E12002A0B55 /* Sources */,
 				0D260DA918B68E12002A0B55 /* Frameworks */,
 				0D260DAA18B68E12002A0B55 /* Resources */,
-				1D12555F0F4EF323B11E40F9 /* [CP] Embed Pods Frameworks */,
-				0C5C7A6AB763BCE7F760FAFF /* [CP] Copy Pods Resources */,
+				9F946EAD2A73FDCBE3FA3454 /* [CP] Embed Pods Frameworks */,
+				43EC969A89E13A43B4161035 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -862,11 +856,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0D35BDA918FD71CE00921A21 /* Build configuration list for PBXNativeTarget "santactl" */;
 			buildPhases = (
-				5F1504EA0D172767F2BCAAEB /* [CP] Check Pods Manifest.lock */,
+				8EF1E72D9F742F663ABE8DCD /* [CP] Check Pods Manifest.lock */,
 				0DD98E671A5DD02000A754C6 /* Update Version Info */,
 				0D35BD9A18FD71CE00921A21 /* Sources */,
 				0D35BD9B18FD71CE00921A21 /* Frameworks */,
-				E50DD7319E04737B040B69EC /* [CP] Copy Pods Resources */,
+				3AA84DD536CCE6A50E24E85E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -881,13 +875,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0D385DE3180DE4A900418BC6 /* Build configuration list for PBXNativeTarget "Santa" */;
 			buildPhases = (
-				373591F801D7B22635DAD7A0 /* [CP] Check Pods Manifest.lock */,
+				D5EF20F46A8F8B36E63D1709 /* [CP] Check Pods Manifest.lock */,
 				0DD98E681A5DD03E00A754C6 /* Update Version Info */,
 				0D385DB2180DE4A900418BC6 /* Sources */,
 				0D385DB3180DE4A900418BC6 /* Frameworks */,
 				0D385DB4180DE4A900418BC6 /* Resources */,
-				31CD7EDCDEBD95322ED67F63 /* [CP] Embed Pods Frameworks */,
-				B3EB60284D47F89140F5A033 /* [CP] Copy Pods Resources */,
+				50E59E61A01D3126C43D49BB /* [CP] Embed Pods Frameworks */,
+				F1D2415B87633FA13FC7AA29 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -924,11 +918,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0D9A7F471759330500035EB5 /* Build configuration list for PBXNativeTarget "santad" */;
 			buildPhases = (
-				A3D478EF1D48EA118AF176E9 /* [CP] Check Pods Manifest.lock */,
+				828CFA7B34B9061FAFA68503 /* [CP] Check Pods Manifest.lock */,
 				0DD98E661A5DCED300A754C6 /* Update Version Info */,
 				0D9A7F391759330400035EB5 /* Sources */,
 				0D9A7F3A1759330400035EB5 /* Frameworks */,
-				435B0E246EE25ACC763D684C /* [CP] Copy Pods Resources */,
+				999D3C0A9B06CC3DFFB45CEA /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1006,21 +1000,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0C5C7A6AB763BCE7F760FAFF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		0D45F4271A5DCB7A00BF4375 /* Update Version Info */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1114,22 +1093,37 @@
 			shellPath = /bin/sh;
 			shellScript = "GIT_TAG=$(git describe --abbrev=0 --tags)\nsed -i '' \"s/TO.BE.FILLED/${GIT_TAG}/\" ${DERIVED_FILE_DIR}/santa-driver_info.c";
 		};
-		1D12555F0F4EF323B11E40F9 /* [CP] Embed Pods Frameworks */ = {
+		3AA84DD536CCE6A50E24E85E /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-santactl/Pods-santactl-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		31CD7EDCDEBD95322ED67F63 /* [CP] Embed Pods Frameworks */ = {
+		43EC969A89E13A43B4161035 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		50E59E61A01D3126C43D49BB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1144,7 +1138,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Santa/Pods-Santa-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		373591F801D7B22635DAD7A0 /* [CP] Check Pods Manifest.lock */ = {
+		828CFA7B34B9061FAFA68503 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1159,7 +1153,7 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		376E230296F6EA7A4DA8BBF0 /* [CP] Check Pods Manifest.lock */ = {
+		8EF1E72D9F742F663ABE8DCD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1174,7 +1168,7 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		435B0E246EE25ACC763D684C /* [CP] Copy Pods Resources */ = {
+		999D3C0A9B06CC3DFFB45CEA /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1189,7 +1183,22 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-santad/Pods-santad-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5F1504EA0D172767F2BCAAEB /* [CP] Check Pods Manifest.lock */ = {
+		9F946EAD2A73FDCBE3FA3454 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C22A218D691E062A00781563 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1204,7 +1213,7 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		A3D478EF1D48EA118AF176E9 /* [CP] Check Pods Manifest.lock */ = {
+		D5EF20F46A8F8B36E63D1709 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1219,7 +1228,7 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		B3EB60284D47F89140F5A033 /* [CP] Copy Pods Resources */ = {
+		F1D2415B87633FA13FC7AA29 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1232,21 +1241,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Santa/Pods-Santa-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E50DD7319E04737B040B69EC /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-santactl/Pods-santactl-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1536,7 +1530,7 @@
 		};
 		0D260DBA18B68E12002A0B55 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4E43227BA5B261FF33141AFC /* Pods-LogicTests.debug.xcconfig */;
+			baseConfigurationReference = 5B0D17672432F610DE7F14EA /* Pods-LogicTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1584,7 +1578,7 @@
 		};
 		0D260DBB18B68E12002A0B55 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 821428941753678DB772D761 /* Pods-LogicTests.release.xcconfig */;
+			baseConfigurationReference = A5C68436912C0F98A7DE3BFA /* Pods-LogicTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1627,7 +1621,7 @@
 		};
 		0D35BDA718FD71CE00921A21 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 691189054F4E484D030CF831 /* Pods-santactl.debug.xcconfig */;
+			baseConfigurationReference = 6A947802FC1698EC37A47F5C /* Pods-santactl.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1665,7 +1659,7 @@
 		};
 		0D35BDA818FD71CE00921A21 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2B9F8A80C0F8D34D98135F36 /* Pods-santactl.release.xcconfig */;
+			baseConfigurationReference = 5123AB484639A3640D62CB67 /* Pods-santactl.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1698,7 +1692,7 @@
 		};
 		0D385DE4180DE4A900418BC6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D227889DF327E7D3532FE00B /* Pods-Santa.debug.xcconfig */;
+			baseConfigurationReference = F25BED2D82EB26743AD59464 /* Pods-Santa.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1737,7 +1731,7 @@
 		};
 		0D385DE5180DE4A900418BC6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D9D2DDDCD92DBB948D38B11 /* Pods-Santa.release.xcconfig */;
+			baseConfigurationReference = 6519E416CC4D06EE85DDB34B /* Pods-Santa.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1771,6 +1765,7 @@
 		};
 		0D91BCAC174E8A6500131A7D /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D2429471E787655005C6FC9 /* DevelopmentTeam.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
@@ -1798,6 +1793,7 @@
 		};
 		0D91BCAD174E8A6500131A7D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D2429471E787655005C6FC9 /* DevelopmentTeam.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
@@ -1911,7 +1907,7 @@
 		};
 		0D9A7F481759330500035EB5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 95B378553DCD86290341B8E4 /* Pods-santad.debug.xcconfig */;
+			baseConfigurationReference = 07B44952FAAF4CA056FC4A62 /* Pods-santad.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1945,7 +1941,7 @@
 		};
 		0D9A7F491759330500035EB5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7C9CC3CDF2609E78E6A9C601 /* Pods-santad.release.xcconfig */;
+			baseConfigurationReference = F1E491F3C201A2362E04FF81 /* Pods-santad.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/Source/santa-driver/SantaCache.h
+++ b/Source/santa-driver/SantaCache.h
@@ -247,7 +247,7 @@ template<class T> class SantaCache {
   /**
     Holder for a 'zero' entry for the current type
   */
-  T zero_ = {};
+  const T zero_ = T(0);
 
   /**
     Special bucket used when automatically clearing due to size

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -16,6 +16,8 @@
 
 @import IOKit.kext;
 
+#include <mach/mach_port.h>
+
 #import "SNTLogging.h"
 
 @interface SNTDriverManager ()

--- a/Source/santad/main.m
+++ b/Source/santad/main.m
@@ -16,6 +16,7 @@
 
 #include "SNTLogging.h"
 
+#include <mach/task.h>
 #include <pthread/pthread.h>
 #include <sys/resource.h>
 


### PR DESCRIPTION
This is a generated xcconfig in the Rakefile which gets included by the project
to set the DEVELOPMENT_TEAM key to keep Xcode 8 happy. The development team is
figured based on the available “Mac Developer” certificate.

Also update the way SantaCache declares a ‘zero’ value, update the
OCMock and MOLAuthenticatingURLSession pods and add a few missing includes.