### PR TITLE
SantaCache fix 0 init

### DIFF
--- a/Source/santa-driver/SantaCache.h
+++ b/Source/santa-driver/SantaCache.h
@@ -247,7 +247,7 @@ template<class T> class SantaCache {
   /**
     Holder for a 'zero' entry for the current type
   */
-  const T zero_ = T(0);
+  const T zero_ = T();
 
   /**
     Special bucket used when automatically clearing due to size


### PR DESCRIPTION
Initializing T with 0 when T is `std::string` crashes. We don't use SantaCache with strings in any of the production code, but there is a test that does. The default initialization for `uint64_t` and `std::string` seems to work fine.

Alternatively we can remove the test and update the wording in SantaCache to only support int style types.