### PR TITLE
Update bundleBinaryRequests on Event Upload

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.m
@@ -57,6 +57,9 @@
   NSDictionary *r = [self performRequest:[self requestWithDictionary:@{ kEvents: uploadEvents }]];
   if (!r) return NO;
 
+  // A list of bundle hashes that require their related binary events to be uploaded.		
+  self.syncState.bundleBinaryRequests = r[kEventUploadBundleBinaries];
+
   LOGI(@"Uploaded %lu events", uploadEvents.count);
 
   // Remove event IDs. For Bundle Events the ID is 0 so nothing happens.


### PR DESCRIPTION
The `bundleBinaryRequests` property holds an array of bundle hashes for a given sync session. These hashes represent a fulfillment request from the sync server. If the client has the corresponding bundle hash and released events, it will begin uploading them.