### PR TITLE
santactl/sync: Sync Server to set FCM interval and deadline

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -158,24 +158,6 @@ extern NSString *const kDefaultConfigFilePath;
 ///
 @property(readonly, nonatomic) NSString *machineID;
 
-///
-///  The number of seconds in-between full syncs while connected to FCM
-///
-///  @note The default value is 14400.
-///  @note The minimum value is 600.
-///
-@property(readonly, nonatomic) NSInteger FCMFullSyncInterval;
-
-///
-///  The maximum number of seconds to wait before a rule sync when
-///  receiving a global rule sync message. Each client will choose a random
-///  number of seconds between 0 and FCMGlobalRuleLeeway.
-///
-///  @note The default value is 600.
-///  @note The minimum value is 60.
-///
-@property(readonly, nonatomic) NSInteger FCMGlobalRuleLeeway;
-
 #pragma mark Server Auth Settings
 
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -71,9 +71,6 @@ static NSString *const kMachineOwnerPlistKeyKey = @"MachineOwnerKey";
 static NSString *const kMachineIDPlistFileKey = @"MachineIDPlist";
 static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
-static NSString *const kFCMFullSyncInterval = @"FCMFullSyncInterval";
-static NSString *const kFCMGlobalRuleLeeway = @"FCMGlobalRuleLeeway";
-
 - (instancetype)initWithFilePath:(NSString *)filePath {
   self = [super init];
   if (self) {
@@ -327,16 +324,6 @@ static NSString *const kFCMGlobalRuleLeeway = @"FCMGlobalRuleLeeway";
   }
 
   return machineId;
-}
-
-- (NSInteger)FCMFullSyncInterval {
-  NSInteger interval = [self.configData[kFCMFullSyncInterval] integerValue];
-  return (interval < 600) ? 1440 : interval;
-}
-
-- (NSInteger)FCMGlobalRuleLeeway {
-  NSInteger leeway = [self.configData[kFCMGlobalRuleLeeway] integerValue];
-  return (leeway < 60) ? 600 : leeway;
 }
 
 - (void)reloadConfigData {

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -91,7 +91,6 @@
 ///  Syncd Ops
 ///
 - (void)setSyncdListener:(NSXPCListenerEndpoint *)listener;
-- (void)setNextSyncInterval:(uint64_t)seconds reply:(void (^)())reply;
 - (void)pushNotifications:(void (^)(BOOL))reply;
 - (void)postRuleSyncNotificationWithCustomMessage:(NSString *)message reply:(void (^)())reply;
 

--- a/Source/common/SNTXPCSyncdInterface.h
+++ b/Source/common/SNTXPCSyncdInterface.h
@@ -23,7 +23,6 @@
 - (void)postEventToSyncServer:(SNTStoredEvent *)event;
 - (void)postBundleEventToSyncServer:(SNTStoredEvent *)event reply:(void (^)(BOOL))reply;
 - (void)postBundleEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events;
-- (void)rescheduleSyncSecondsFromNow:(uint64_t)seconds;
 - (void)isFCMListening:(void (^)(BOOL))reply;
 @end
 

--- a/Source/santactl/Commands/sync/SNTCommandSync.m
+++ b/Source/santactl/Commands/sync/SNTCommandSync.m
@@ -61,6 +61,11 @@ REGISTER_COMMAND_NAME(@"sync")
     exit(1);
   }
 
+  if (![[SNTConfigurator configurator] syncBaseURL]) {
+    LOGE(@"Missing SyncBaseURL. Exiting.");
+    exit(1);
+  }
+
   SNTCommandSync *s = [[self alloc] init];
   [daemonConn resume];
   BOOL daemon = [arguments containsObject:@"--daemon"];

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -103,7 +103,15 @@ extern NSString *const kConfigSync;
 extern NSString *const kLogSync;
 
 extern const NSUInteger kDefaultEventBatchSize;
+
+///
+///  kDefaultFullSyncInterval
+///  kDefaultFCMFullSyncInterval
+///  kDefaultFCMGlobalRuleSyncDeadline
+///
+///  Are represented in seconds
+///
 extern const NSUInteger kDefaultFullSyncInterval;
 extern const NSUInteger kDefaultFCMFullSyncInterval;
-extern const NSUInteger kDefaultFCMGlobalRuleSyncDealine;
+extern const NSUInteger kDefaultFCMGlobalRuleSyncDeadline;
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -35,7 +35,7 @@ extern NSString *const kBinaryRuleCount;
 extern NSString *const kCertificateRuleCount;
 extern NSString *const kFCMToken;
 extern NSString *const kFCMFullSyncInterval;
-extern NSString *const kFCMGlobalRuleDeadline;
+extern NSString *const kFCMGlobalRuleSyncDeadline;
 
 extern NSString *const kEvents;
 extern NSString *const kFileSHA256;
@@ -102,8 +102,8 @@ extern NSString *const kRuleSync;
 extern NSString *const kConfigSync;
 extern NSString *const kLogSync;
 
-extern const NSUInteger kEventBatchSize;
-extern const NSUInteger kFullSyncIntervalSeconds;
-extern const NSUInteger kFCMFullSyncIntervalSeconds;
-extern const NSUInteger kFCMGlobalRuleDealineSeconds;
+extern const NSUInteger kDefaultEventBatchSize;
+extern const NSUInteger kDefaultFullSyncInterval;
+extern const NSUInteger kDefaultFCMFullSyncInterval;
+extern const NSUInteger kDefaultFCMGlobalRuleSyncDealine;
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -34,6 +34,8 @@ extern NSString *const kBlacklistRegex;
 extern NSString *const kBinaryRuleCount;
 extern NSString *const kCertificateRuleCount;
 extern NSString *const kFCMToken;
+extern NSString *const kFCMFullSyncInterval;
+extern NSString *const kFCMGlobalRuleDeadline;
 
 extern NSString *const kEvents;
 extern NSString *const kFileSHA256;
@@ -99,3 +101,9 @@ extern NSString *const kFullSync;
 extern NSString *const kRuleSync;
 extern NSString *const kConfigSync;
 extern NSString *const kLogSync;
+
+extern const NSUInteger kEventBatchSize;
+extern const NSUInteger kFullSyncIntervalSeconds;
+extern const NSUInteger kFCMFullSyncIntervalSeconds;
+extern const NSUInteger kFCMGlobalRuleDealineSeconds;
+

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -105,4 +105,4 @@ NSString *const kLogSync = @"log_sync";
 const NSUInteger kDefaultEventBatchSize = 50;
 const NSUInteger kDefaultFullSyncInterval = 600;
 const NSUInteger kDefaultFCMFullSyncInterval = 14400;
-const NSUInteger kDefaultFCMGlobalRuleSyncDealine = 600;
+const NSUInteger kDefaultFCMGlobalRuleSyncDeadline = 600;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -35,7 +35,7 @@ NSString *const kBinaryRuleCount = @"binary_rule_count";
 NSString *const kCertificateRuleCount = @"certificate_rule_count";
 NSString *const kFCMToken = @"fcm_token";
 NSString *const kFCMFullSyncInterval = @"fcm_full_sync_interval";
-NSString *const kFCMGlobalRuleDeadline = @"fcm_global_rule_deadline";
+NSString *const kFCMGlobalRuleSyncDeadline = @"fcm_global_rule_sync_deadline";
 
 NSString *const kEvents = @"events";
 NSString *const kFileSHA256 = @"file_sha256";
@@ -102,7 +102,7 @@ NSString *const kRuleSync = @"rule_sync";
 NSString *const kConfigSync = @"config_sync";
 NSString *const kLogSync = @"log_sync";
 
-const NSUInteger kEventBatchSize = 50;
-const NSUInteger kFullSyncIntervalSeconds = 600;
-const NSUInteger kFCMFullSyncIntervalSeconds = 14400;
-const NSUInteger kFCMGlobalRuleDealineSeconds = 600;
+const NSUInteger kDefaultEventBatchSize = 50;
+const NSUInteger kDefaultFullSyncInterval = 600;
+const NSUInteger kDefaultFCMFullSyncInterval = 14400;
+const NSUInteger kDefaultFCMGlobalRuleSyncDealine = 600;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -34,6 +34,8 @@ NSString *const kBlacklistRegex = @"blacklist_regex";
 NSString *const kBinaryRuleCount = @"binary_rule_count";
 NSString *const kCertificateRuleCount = @"certificate_rule_count";
 NSString *const kFCMToken = @"fcm_token";
+NSString *const kFCMFullSyncInterval = @"fcm_full_sync_interval";
+NSString *const kFCMGlobalRuleDeadline = @"fcm_global_rule_deadline";
 
 NSString *const kEvents = @"events";
 NSString *const kFileSHA256 = @"file_sha256";
@@ -99,3 +101,8 @@ NSString *const kFullSync = @"full_sync";
 NSString *const kRuleSync = @"rule_sync";
 NSString *const kConfigSync = @"config_sync";
 NSString *const kLogSync = @"log_sync";
+
+const NSUInteger kEventBatchSize = 50;
+const NSUInteger kFullSyncIntervalSeconds = 600;
+const NSUInteger kFCMFullSyncIntervalSeconds = 14400;
+const NSUInteger kFCMGlobalRuleDealineSeconds = 600;

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -45,7 +45,7 @@
 @property(nonatomic) NSCache *ruleSyncCache;
 
 @property NSUInteger FCMFullSyncInterval;
-@property NSUInteger FCMGlobalRuleSyncDealine;
+@property NSUInteger FCMGlobalRuleSyncDeadline;
 @property NSUInteger eventBatchSize;
 
 @property MOLFCMClient *FCMClient;
@@ -110,7 +110,7 @@ static void reachabilityHandler(
 
     _eventBatchSize = kDefaultEventBatchSize;
     _FCMFullSyncInterval = kDefaultFCMFullSyncInterval;
-    _FCMGlobalRuleSyncDealine = kDefaultFCMGlobalRuleSyncDealine;
+    _FCMGlobalRuleSyncDeadline = kDefaultFCMGlobalRuleSyncDeadline;
   }
   return self;
 }
@@ -239,7 +239,7 @@ static void reachabilityHandler(
       self.targetedRuleSync = YES;
       [self ruleSync];
     } else {
-      uint32_t delaySeconds = arc4random_uniform((u_int32_t)self.FCMGlobalRuleSyncDealine);
+      uint32_t delaySeconds = arc4random_uniform((uint32_t)self.FCMGlobalRuleSyncDeadline);
       LOGD(@"Staggering rule download: %u second delay", delaySeconds);
       [self ruleSyncSecondsFromNow:delaySeconds];
     }
@@ -306,7 +306,7 @@ static void reachabilityHandler(
     // Start listening for push notifications with a full sync every FCMFullSyncInterval
     if (syncState.daemon && syncState.FCMToken) {
       self.FCMFullSyncInterval = syncState.FCMFullSyncInterval;
-      self.FCMGlobalRuleSyncDealine = syncState.FCMGlobalRuleSyncDeadline;
+      self.FCMGlobalRuleSyncDeadline = syncState.FCMGlobalRuleSyncDeadline;
       [self listenForPushNotificationsWithSyncState:syncState];
     } else if (syncState.daemon) {
       LOGD(@"FCMToken not provided. Sync every %lu min.", kDefaultFullSyncInterval / 60);

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -34,20 +34,28 @@
 #import "SNTXPCControlInterface.h"
 #import "SNTXPCSyncdInterface.h"
 
-// Syncing time constant
-const uint64_t kFullSyncInterval = 600;
-
 @interface SNTCommandSyncManager () {
   SCNetworkReachabilityRef _reachability;
 }
+
 @property(nonatomic) dispatch_source_t fullSyncTimer;
 @property(nonatomic) dispatch_source_t ruleSyncTimer;
+
 @property(nonatomic) NSCache *dispatchLock;
 @property(nonatomic) NSCache *ruleSyncCache;
+
+@property NSUInteger FCMFullSyncInterval;
+@property NSUInteger FCMGlobalRuleDealine;
+@property NSUInteger eventBatchSize;
+
 @property MOLFCMClient *FCMClient;
+
 @property(nonatomic) SNTXPCConnection *daemonConn;
+
 @property BOOL targetedRuleSync;
+
 @property(nonatomic) BOOL reachable;
+
 @end
 
 // Called when the network state changes
@@ -74,8 +82,7 @@ static void reachabilityHandler(
     _daemonConn = daemonConn;
     _daemon = daemon;
     _fullSyncTimer = [self createSyncTimerWithBlock:^{
-      [self rescheduleTimerQueue:self.fullSyncTimer
-                  secondsFromNow:[SNTConfigurator configurator].FCMFullSyncInterval];
+      [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:self.FCMFullSyncInterval];
       if (![[SNTConfigurator configurator] syncBaseURL]) return;
       [self lockAction:kFullSync];
       [self preflight];
@@ -100,6 +107,10 @@ static void reachabilityHandler(
     }];
     _dispatchLock = [[NSCache alloc] init];
     _ruleSyncCache = [[NSCache alloc] init];
+
+    _eventBatchSize = kEventBatchSize;
+    _FCMFullSyncInterval = kFCMFullSyncIntervalSeconds;
+    _FCMGlobalRuleDealine = kFCMGlobalRuleDealineSeconds;
   }
   return self;
 }
@@ -125,7 +136,7 @@ static void reachabilityHandler(
 
 - (void)postBundleEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events {
   SNTCommandSyncState *syncState = [self createSyncState];
-  syncState.eventBatchSize = 50;
+  syncState.eventBatchSize = self.eventBatchSize;
   SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc] initWithState:syncState];
   if (events && [p uploadEvents:events]) {
     LOGD(@"Bundle events upload complete");
@@ -142,10 +153,6 @@ static void reachabilityHandler(
   } else {
     LOGE(@"Event upload failed");
   }
-}
-
-- (void)rescheduleSyncSecondsFromNow:(uint64_t)seconds {
-  [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:seconds];
 }
 
 - (void)isFCMListening:(void (^)(BOOL))reply {
@@ -181,7 +188,7 @@ static void reachabilityHandler(
     LOGE(@"FCM connection error: %@", error);
     [self.FCMClient disconnect];
     self.FCMClient = nil;
-    [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:kFullSyncInterval];
+    [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:kFullSyncIntervalSeconds];
   };
   
   self.FCMClient.loggingBlock = ^(NSString *log) {
@@ -232,9 +239,8 @@ static void reachabilityHandler(
       self.targetedRuleSync = YES;
       [self ruleSync];
     } else {
-      uint32_t delaySeconds =
-          arc4random_uniform((u_int32_t)[SNTConfigurator configurator].FCMGlobalRuleLeeway);
-      LOGD(@"Staggering rule download, %u second delay for this machine", delaySeconds);
+      uint32_t delaySeconds = arc4random_uniform((u_int32_t)self.FCMGlobalRuleDealine);
+      LOGD(@"Staggering rule download: %u second delay", delaySeconds);
       [self ruleSyncSecondsFromNow:delaySeconds];
     }
   } else if ([action isEqualToString:kConfigSync]) {
@@ -295,15 +301,18 @@ static void reachabilityHandler(
     // Clean up reachability if it was started for a non-network error
     [self stopReachability];
 
-    // Start listening for push notifications with a full sync every kFullSyncFCMInterval or
-    // revert to full syncing every kFullSyncInterval.
+    self.eventBatchSize = syncState.eventBatchSize;
+
+    // Start listening for push notifications with a full sync every FCMFullSyncInterval
     if (syncState.daemon && syncState.FCMToken) {
+      self.FCMFullSyncInterval = syncState.FCMFullSyncInterval;
+      self.FCMGlobalRuleDealine = syncState.kFCMGlobalRuleDeadline;
       [self listenForPushNotificationsWithSyncState:syncState];
     } else if (syncState.daemon) {
-      LOGD(@"FCMToken not provided. Sync every %llu min.", kFullSyncInterval / 60);
+      LOGD(@"FCMToken not provided. Sync every %lu min.", kFullSyncIntervalSeconds / 60);
       [self.FCMClient disconnect];
       self.FCMClient = nil;
-      [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:kFullSyncInterval];
+      [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:kFullSyncIntervalSeconds];
     }
 
     if (syncState.uploadLogURL) {
@@ -402,8 +411,11 @@ static void reachabilityHandler(
     LOGW(@"Missing Machine Owner.");
   }
 
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_group_enter(group);
   [[self.daemonConn remoteObjectProxy] xsrfToken:^(NSString *token) {
     syncState.xsrfToken = token;
+    dispatch_group_leave(group);
   }];
 
   MOLAuthenticatingURLSession *authURLSession = [[MOLAuthenticatingURLSession alloc] init];
@@ -438,7 +450,8 @@ static void reachabilityHandler(
   syncState.session = [authURLSession session];
   syncState.daemonConn = self.daemonConn;
   syncState.daemon = self.daemon;
-  
+
+  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
   return syncState;
 }
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncPostflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPostflight.m
@@ -29,7 +29,7 @@
 }
 
 - (BOOL)sync {
-  NSDictionary *r = [self performRequest:[self requestWithDictionary:nil]];
+  [self performRequest:[self requestWithDictionary:nil]];
 
   dispatch_group_t group = dispatch_group_create();
   void (^replyBlock)() = ^{
@@ -41,14 +41,6 @@
     dispatch_group_enter(group);
     [[self.daemonConn remoteObjectProxy] setClientMode:self.syncState.clientMode
                                                  reply:replyBlock];
-  }
-
-  // Update backoff interval
-  NSString *backoffInterval = r[kBackoffInterval];
-  if (backoffInterval) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setNextSyncInterval:[backoffInterval intValue]
-                                                       reply:replyBlock];
   }
 
   // Remove clean sync flag if we did a clean sync

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -74,9 +74,14 @@
 
   if (!resp) return NO;
 
+  self.syncState.eventBatchSize = [resp[kBatchSize] unsignedIntegerValue] ?: kEventBatchSize;
   self.syncState.FCMToken = resp[kFCMToken];
 
-  self.syncState.eventBatchSize = [resp[kBatchSize] intValue] ?: 50;
+  // Don't let these go too low
+  NSUInteger value = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
+  self.syncState.FCMFullSyncInterval = (value < 600) ? kFCMFullSyncIntervalSeconds : value;
+  value = [resp[kFCMGlobalRuleDeadline] unsignedIntegerValue];
+  self.syncState.kFCMGlobalRuleDeadline = (value < 60) ?  kFCMGlobalRuleDealineSeconds : value;
 
   self.syncState.uploadLogURL = [NSURL URLWithString:resp[kUploadLogsURL]];
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -74,14 +74,15 @@
 
   if (!resp) return NO;
 
-  self.syncState.eventBatchSize = [resp[kBatchSize] unsignedIntegerValue] ?: kEventBatchSize;
+  self.syncState.eventBatchSize = [resp[kBatchSize] unsignedIntegerValue] ?: kDefaultEventBatchSize;
   self.syncState.FCMToken = resp[kFCMToken];
 
   // Don't let these go too low
   NSUInteger value = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
-  self.syncState.FCMFullSyncInterval = (value < 600) ? kFCMFullSyncIntervalSeconds : value;
-  value = [resp[kFCMGlobalRuleDeadline] unsignedIntegerValue];
-  self.syncState.kFCMGlobalRuleDeadline = (value < 60) ?  kFCMGlobalRuleDealineSeconds : value;
+  self.syncState.FCMFullSyncInterval = (value < 600) ? kDefaultFCMFullSyncInterval : value;
+  value = [resp[kFCMGlobalRuleSyncDeadline] unsignedIntegerValue];
+  self.syncState.FCMGlobalRuleSyncDeadline =
+      (value < 60) ?  kDefaultFCMGlobalRuleSyncDealine : value;
 
   self.syncState.uploadLogURL = [NSURL URLWithString:resp[kUploadLogsURL]];
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -79,10 +79,11 @@
 
   // Don't let these go too low
   NSUInteger value = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
-  self.syncState.FCMFullSyncInterval = (value < 600) ? kDefaultFCMFullSyncInterval : value;
+  self.syncState.FCMFullSyncInterval =
+      (value < kDefaultFullSyncInterval) ? kDefaultFCMFullSyncInterval : value;
   value = [resp[kFCMGlobalRuleSyncDeadline] unsignedIntegerValue];
   self.syncState.FCMGlobalRuleSyncDeadline =
-      (value < 60) ?  kDefaultFCMGlobalRuleSyncDealine : value;
+      (value < 60) ?  kDefaultFCMGlobalRuleSyncDeadline : value;
 
   self.syncState.uploadLogURL = [NSURL URLWithString:resp[kUploadLogsURL]];
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -16,6 +16,7 @@
 
 #import "SNTCommonEnums.h"
 
+@class SNTCommandSyncManager;
 @class SNTXPCConnection;
 
 /// An instance of this class is passed to each stage of the sync process for storing data
@@ -34,8 +35,14 @@
 /// An XSRF token to send in the headers with each request.
 @property NSString *xsrfToken;
 
-/// A FCM token to subscribe to push notifications.
+/// An FCM token to subscribe to push notifications.
 @property(copy) NSString *FCMToken;
+
+/// Full sync interval in seconds while listening for FCM messages.
+@property NSUInteger FCMFullSyncInterval;
+
+/// Leeway time in seconds when receiving a global rule sync message.
+@property NSUInteger kFCMGlobalRuleDeadline;
 
 /// Machine identifier and owner.
 @property(copy) NSString *machineID;

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -42,7 +42,7 @@
 @property NSUInteger FCMFullSyncInterval;
 
 /// Leeway time in seconds when receiving a global rule sync message.
-@property NSUInteger kFCMGlobalRuleDeadline;
+@property NSUInteger FCMGlobalRuleSyncDeadline;
 
 /// Machine identifier and owner.
 @property(copy) NSString *machineID;

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -219,11 +219,6 @@ double watchdogRAMPeak = 0;
   self.syncdQueue.syncdConnection = c;
 }
 
-- (void)setNextSyncInterval:(uint64_t)seconds reply:(void (^)())reply {
-  [[self.syncdQueue.syncdConnection remoteObjectProxy] rescheduleSyncSecondsFromNow:seconds];
-  reply();
-}
-
 - (void)pushNotifications:(void (^)(BOOL))reply {
   [self.syncdQueue.syncdConnection.remoteObjectProxy isFCMListening:^(BOOL response) {
     reply(response);


### PR DESCRIPTION
*  Handle `fcm_full_sync_interval` and `fcm_global_rule_deadline` values during preflight
*  If there is no SyncBaseURL exit
*  Remove support for `backoff`