### PR TITLE
make bundle support configurable from a sync server

### DIFF
--- a/Source/SantaGUI/Resources/MessageWindow.xib
+++ b/Source/SantaGUI/Resources/MessageWindow.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="6300" identifier="xcode"/>
@@ -200,9 +200,9 @@
                             </userDefinedRuntimeAttributes>
                         </textFieldCell>
                         <connections>
-                            <binding destination="-2" name="hidden" keyPath="self.event.fileBundleHash" id="v0N-pG-ulX">
+                            <binding destination="-2" name="hidden" keyPath="self.event.needsBundleHash" id="2kb-3z-Kyn">
                                 <dictionary key="options">
-                                    <string key="NSValueTransformerName">NSIsNil</string>
+                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
                                 </dictionary>
                             </binding>
                         </connections>

--- a/Source/SantaGUI/SNTMessageWindowController.m
+++ b/Source/SantaGUI/SNTMessageWindowController.m
@@ -91,7 +91,7 @@
     }
   }
 
-  if (!self.event.fileBundleHash) {
+  if (!self.event.needsBundleHash) {
     [self.bundleHashLabel removeFromSuperview];
     [self.hashingIndicator removeFromSuperview];
     [self.foundFileCountLabel removeFromSuperview];

--- a/Source/SantaGUI/SNTNotificationManager.m
+++ b/Source/SantaGUI/SNTNotificationManager.m
@@ -65,7 +65,7 @@ static NSString * const silencedNotificationsKey = @"SilencedNotifications";
   if ([self.pendingNotifications count]) {
     self.currentWindowController = [self.pendingNotifications firstObject];
     [self.currentWindowController showWindow:self];
-    if (self.currentWindowController.event.fileBundleHash) {
+    if (self.currentWindowController.event.needsBundleHash) {
       dispatch_async(self.hashBundleBinariesQueue, ^{
         [self hashBundleBinariesForEvent:self.currentWindowController.event];
       });
@@ -157,7 +157,7 @@ static NSString * const silencedNotificationsKey = @"SilencedNotifications";
     if (!self.currentWindowController) {
       self.currentWindowController = pendingMsg;
       [pendingMsg showWindow:nil];
-      if (self.currentWindowController.event.fileBundleHash) {
+      if (self.currentWindowController.event.needsBundleHash) {
         dispatch_async(self.hashBundleBinariesQueue, ^{
           [self hashBundleBinariesForEvent:self.currentWindowController.event];
         });

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -158,6 +158,12 @@ extern NSString *const kDefaultConfigFilePath;
 ///
 @property(readonly, nonatomic) NSString *machineID;
 
+///
+///  If YES, enables bundle detection for blocked events. This property is not stored on disk.
+///  Its value is set by a sync server that supports bundles. Defaults to NO.
+///
+@property BOOL bundlesEnabled;
+
 #pragma mark Server Auth Settings
 
 ///

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -37,6 +37,12 @@
 @property NSString *filePath;
 
 ///
+///  Set to YES if the event is a part of a bundle. When an event is passed to SantaGUI this propery
+///  will be used as an indicator to to kick off bundle hashing as necessary. Default value is NO.
+///
+@property BOOL needsBundleHash;
+
+///
 ///  If the executed file was part of a bundle, this is the calculated hash of all the nested
 ///  executables within the bundle.
 ///

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -33,6 +33,7 @@
   ENCODE(self.fileSHA256, @"fileSHA256");
   ENCODE(self.filePath, @"filePath");
 
+  ENCODE(@(self.needsBundleHash), @"needsBundleHash");
   ENCODE(self.fileBundleHash, @"fileBundleHash");
   ENCODE(self.fileBundleHashMilliseconds, @"fileBundleHashMilliseconds");
   ENCODE(self.fileBundleBinaryCount, @"fileBundleBinaryCount");
@@ -75,6 +76,7 @@
     _fileSHA256 = DECODE(NSString, @"fileSHA256");
     _filePath = DECODE(NSString, @"filePath");
 
+    _needsBundleHash = [DECODE(NSNumber, @"needsBundleHash") boolValue];
     _fileBundleHash = DECODE(NSString, @"fileBundleHash");
     _fileBundleHashMilliseconds = DECODE(NSNumber, @"fileBundleHashMilliseconds");
     _fileBundleBinaryCount = DECODE(NSNumber, @"fileBundleBinaryCount");

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -80,6 +80,8 @@
 - (void)setSyncCleanRequired:(BOOL)cleanReqd reply:(void (^)())reply;
 - (void)setWhitelistPathRegex:(NSString *)pattern reply:(void (^)())reply;
 - (void)setBlacklistPathRegex:(NSString *)pattern reply:(void (^)())reply;
+- (void)bundlesEnabled:(void (^)(BOOL))reply;
+- (void)setBundlesEnabled:(BOOL)bundlesEnabled reply:(void (^)())reply;
 
 ///
 ///  GUI Ops

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -36,6 +36,7 @@ extern NSString *const kCertificateRuleCount;
 extern NSString *const kFCMToken;
 extern NSString *const kFCMFullSyncInterval;
 extern NSString *const kFCMGlobalRuleSyncDeadline;
+extern NSString *const kBundlesEnabled;
 
 extern NSString *const kEvents;
 extern NSString *const kFileSHA256;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -36,6 +36,7 @@ NSString *const kCertificateRuleCount = @"certificate_rule_count";
 NSString *const kFCMToken = @"fcm_token";
 NSString *const kFCMFullSyncInterval = @"fcm_full_sync_interval";
 NSString *const kFCMGlobalRuleSyncDeadline = @"fcm_global_rule_sync_deadline";
+NSString *const kBundlesEnabled = @"bundles_enabled";
 
 NSString *const kEvents = @"events";
 NSString *const kFileSHA256 = @"file_sha256";

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -74,6 +74,11 @@
 
   if (!resp) return NO;
 
+  dispatch_group_enter(group);
+  [[self.daemonConn remoteObjectProxy] setBundlesEnabled:[resp[kBundlesEnabled] boolValue] reply:^{
+    dispatch_group_leave(group);
+  }];
+
   self.syncState.eventBatchSize = [resp[kBatchSize] unsignedIntegerValue] ?: kDefaultEventBatchSize;
   self.syncState.FCMToken = resp[kFCMToken];
 
@@ -106,6 +111,7 @@
     self.syncState.cleanSync = YES;
   }
 
+  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
   return YES;
 }
 

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -124,6 +124,10 @@ double watchdogRAMPeak = 0;
 
 #pragma mark Config Ops
 
+- (void)watchdogInfo:(void (^)(uint64_t, uint64_t, double, double))reply {
+  reply(watchdogCPUEvents, watchdogRAMEvents, watchdogCPUPeak, watchdogRAMPeak);
+}
+
 - (void)clientMode:(void (^)(SNTClientMode))reply {
   reply([[SNTConfigurator configurator] clientMode]);
 }
@@ -180,8 +184,13 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
-- (void)watchdogInfo:(void (^)(uint64_t, uint64_t, double, double))reply {
-  reply(watchdogCPUEvents, watchdogRAMEvents, watchdogCPUPeak, watchdogRAMPeak);
+- (void)bundlesEnabled:(void (^)(BOOL))reply {
+  reply([SNTConfigurator configurator].bundlesEnabled);
+}
+
+- (void)setBundlesEnabled:(BOOL)bundlesEnabled reply:(void (^)())reply {
+  [[SNTConfigurator configurator] setBundlesEnabled:bundlesEnabled];
+  reply();
 }
 
 #pragma mark GUI Ops

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -176,12 +176,12 @@
     if (action != ACTION_RESPOND_ALLOW) {
       [_eventLog logDeniedExecution:cd withMessage:message];
 
-      if (binInfo.bundle && [[SNTConfigurator configurator] syncBaseURL]) {
+      if ([[SNTConfigurator configurator] bundlesEnabled] && binInfo.bundle) {
         // If the binary is apart of a bundle, find and hash all the related binaries in the bundle.
         // Let the GUI know hashing is needed. Once the hashing is complete the GUI will send a
         // message to santad to perform the upload logic for bundles.
         // See syncBundleEvent:relatedEvents: for more info.
-        se.fileBundleHash = @"Calculating...";
+        se.needsBundleHash = YES;
       } else if ([[SNTConfigurator configurator] syncBaseURL]) {
         // So the server has something to show the user straight away, initiate an event
         // upload for the blocked binary rather than waiting for the next sync.


### PR DESCRIPTION
This pull is branched from https://github.com/google/santa/pull/168, ensure that 168 has been submitted before processing this request. I am mainly doing this now as to not forget.

*  santactl/sync: sync server enables/disables client bundle support