### PR TITLE
santactl/rule: add --check flag

### DIFF
--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -58,13 +58,13 @@
 ///  @param filePath A Path to the file, can be nil.
 ///  @param fileSHA256 The pre-calculated SHA256 hash for the file, can be nil. If nil the hash will
 ///                    be calculated by this method from the filePath.
-///  @param signingCertificate A MOLCertificate object, can be nil.
+///  @param certificateSHA256 A SHA256 hash of the signing certificate, can be nil.
 ///  @note If fileInfo and signingCertificate are both passed in, the most specific rule will be
 ///        returned. Binary rules take precedence over cert rules.
 ///
 - (void)decisionForFilePath:(NSString *)filePath
                  fileSHA256:(NSString *)fileSHA256
-         signingCertificate:(MOLCertificate *)signingCertificate
+          certificateSHA256:(NSString *)certificateSHA256
                       reply:(void (^)(SNTEventState))reply;
 
 ///

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -281,7 +281,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     }
     [[fi.daemonConn remoteObjectProxy] decisionForFilePath:fi.path(fi)
                                                 fileSHA256:fi.propertyMap[kSHA256](fi)
-                                        signingCertificate:fi.csc.leafCertificate
+                                         certificateSHA256:fi.csc.leafCertificate.SHA256
                                                      reply:^(SNTEventState state) {
       if (state) s = state;
       dispatch_semaphore_signal(sema);

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -115,11 +115,11 @@ double watchdogRAMPeak = 0;
 
 - (void)decisionForFilePath:(NSString *)filePath
                  fileSHA256:(NSString *)fileSHA256
-         signingCertificate:(MOLCertificate *)signingCertificate
+          certificateSHA256:(NSString *)certificateSHA256
                       reply:(void (^)(SNTEventState))reply {
   reply([self.policyProcessor decisionForFilePath:filePath
                                        fileSHA256:fileSHA256
-                               signingCertificate:signingCertificate].decision);
+                                certificateSHA256:certificateSHA256].decision);
 }
 
 #pragma mark Config Ops

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -115,7 +115,8 @@
   // Actually make the decision.
   SNTCachedDecision *cd = [self.policyProcessor decisionForFileInfo:binInfo
                                                          fileSHA256:nil
-                                                 signingCertificate:csInfo.leafCertificate];
+                                                  certificateSHA256:csInfo.leafCertificate.SHA256];
+  cd.certCommonName = csInfo.leafCertificate.commonName;
   cd.vnodeId = message.vnode_id;
 
   // Formulate an action from the decision

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -39,22 +39,24 @@
 ///  @param fileInfo A SNTFileInfo object.
 ///  @param fileSHA256 The pre-calculated SHA256 hash for the file, can be nil. If nil the hash will
 ///                    be calculated by this method from the filePath.
-///  @param signingCertificate A MOLCertificate object, can be nil.
-///  @note If fileInfo and signingCertificate are both passed in, the most specific rule will be
+///  @param certificateSHA256 A SHA256 hash of the signing certificate, can be nil.
+///  @note If fileSHA256 and certificateSHA256 are both passed in, the most specific rule will be
 ///        returned. Binary rules take precedence over cert rules.
+///  @note This method can also be used to generate a SNTCachedDecision object without any
+///        artifacts on disk. Simply pass nil to fileInfo and pass in the desired SHA256s.
 ///
-- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
+- (nonnull SNTCachedDecision *)decisionForFileInfo:(nullable SNTFileInfo *)fileInfo
                                         fileSHA256:(nullable NSString *)fileSHA256
-                                signingCertificate:(nullable MOLCertificate *)signingCertificate;
+                                 certificateSHA256:(nullable NSString *)certificateSHA256;
 
 ///
-///  A wrapper for decisionForFileInfo:fileSHA256:signingCertificate:. This method is slower as it
+///  A wrapper for decisionForFileInfo:fileSHA256:certificateSHA256:. This method is slower as it
 ///  has to create the SNTFileInfo object. This is mainly used by the santactl binary because
 ///  SNTFileInfo is not SecureCoding compliant. If the SHA256 hash of the file has already been
 ///  calculated, use the fileSHA256 parameter to save a second calculation of the hash.
 ///
-- (nonnull SNTCachedDecision *)decisionForFilePath:(nonnull NSString *)filePath
+- (nonnull SNTCachedDecision *)decisionForFilePath:(nullable NSString *)filePath
                                         fileSHA256:(nullable NSString *)fileSHA256
-                                signingCertificate:(nullable MOLCertificate *)signingCertificate;
+                                 certificateSHA256:(nullable NSString *)certificateSHA256;
 
 @end

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -38,14 +38,11 @@
 
 - (SNTCachedDecision *)decisionForFileInfo:(SNTFileInfo *)fileInfo
                                 fileSHA256:(NSString *)fileSHA256
-                        signingCertificate:(MOLCertificate *)signingCertificate {
+                         certificateSHA256:(NSString *)certificateSHA256 {
   SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
   cd.sha256 = fileSHA256 ?: fileInfo.SHA256;
+  cd.certSHA256 = certificateSHA256;
   cd.quarantineURL = fileInfo.quarantineDataURL;
-  if (signingCertificate) {
-    cd.certCommonName = signingCertificate.commonName;
-    cd.certSHA256 = signingCertificate.SHA256;
-  }
 
   SNTRule *rule = [self.ruleTable ruleForBinarySHA256:cd.sha256
                                     certificateSHA256:cd.certSHA256];
@@ -113,13 +110,16 @@
 
 - (SNTCachedDecision *)decisionForFilePath:(NSString *)filePath
                                 fileSHA256:(NSString *)fileSHA256
-                        signingCertificate:(MOLCertificate *)signingCertificate {
-  NSError *error;
-  SNTFileInfo *fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
-  if (!fileInfo) LOGW(@"Failed to read file %@: %@", filePath, error.localizedDescription);
+                         certificateSHA256:(NSString *)certificateSHA256 {
+  SNTFileInfo *fileInfo;
+  if (filePath) {
+    NSError *error;
+    fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
+    if (!fileInfo) LOGW(@"Failed to read file %@: %@", filePath, error.localizedDescription);
+  }
   return [self decisionForFileInfo:fileInfo
                         fileSHA256:fileSHA256
-                signingCertificate:signingCertificate];
+                 certificateSHA256:certificateSHA256];
 }
 
 ///


### PR DESCRIPTION
Add the ability to check the status of arbitrary sha256 hashes without on-disk artifacts. This duplicates some pretty printing code from fileinfo. At some point we should make a class to handle santactl output.

Example:

Check the status of the`/usr/bin/yes` binary.
```
sudo santactl rule --check --sha256 e8e3e5700e9e023d09aa85f0dbd7f2f53e83bcd6f7380edbf9666e7f470f0c50
Blacklisted (Binary)
```

Check the status of the Apple Software Signing certificate.
```
sudo santactl rule --check --certificate --sha256 2aa4b9973b7ba07add447ee4da8b5337c3ee2c3a991911e80e7282e8a751fc32
Whitelisted (Certificate)
```