### PR TITLE
SantaGUI: Don't show pop-up notifications for empty filenames

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -219,7 +219,7 @@ static void reachabilityHandler(
   // to build a user notification.
   NSString *fileHash = actionMessage[@"file_hash"];
   NSString *fileName = actionMessage[@"file_name"];
-  if (fileName && fileHash) {
+  if (fileName.length && fileHash.length) {
     [self.ruleSyncCache setObject:fileName forKey:fileHash];
   }
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.m
@@ -79,7 +79,7 @@
     for (SNTRule *r in self.syncState.downloadedRules) {
       NSString *fileName = [[self.syncState.ruleSyncCache objectForKey:r.shasum] copy];
       [self.syncState.ruleSyncCache removeObjectForKey:r.shasum];
-      if (fileName) {
+      if (fileName.length) {
         NSString *message = [NSString stringWithFormat:@"%@ can now be run", fileName];
         [[self.daemonConn remoteObjectProxy]
             postRuleSyncNotificationWithCustomMessage:message reply:^{}];


### PR DESCRIPTION
The FCM notifications include both file_name and file_hash keys but in
some cases file_name is actually a 0-length string. Regardless, checking
an NSString's length property is the best way to check for both nil and
0 length so let's just do that.