### PR TITLE
santactl/sync: upload file bundle executable relative path

### DIFF
--- a/Source/SantaGUI/SNTNotificationManager.m
+++ b/Source/SantaGUI/SNTNotificationManager.m
@@ -235,6 +235,7 @@ static NSString * const silencedNotificationsKey = @"SilencedNotifications";
     event.fileBundleHash = bh;
     event.fileBundleBinaryCount = @(events.count);
     event.fileBundleHashMilliseconds = ms;
+    event.fileBundleExecutableRelPath = [events.firstObject fileBundleExecutableRelPath];
     for (SNTStoredEvent *se in events) {
       se.fileBundleHash = bh;
       se.fileBundleBinaryCount = @(events.count);

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -70,6 +70,11 @@
 @property NSString *fileBundlePath;
 
 ///
+///  The relative path to the bundle's main executable.
+///
+@property NSString *fileBundleExecutableRelPath;
+
+///
 ///  If the executed file was part of the bundle, this is the CFBundleID.
 ///
 @property NSString *fileBundleID;

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -39,6 +39,7 @@
   ENCODE(self.fileBundleBinaryCount, @"fileBundleBinaryCount");
   ENCODE(self.fileBundleName, @"fileBundleName");
   ENCODE(self.fileBundlePath, @"fileBundlePath");
+  ENCODE(self.fileBundleExecutableRelPath, @"fileBundleExecutableRelPath");
   ENCODE(self.fileBundleID, @"fileBundleID");
   ENCODE(self.fileBundleVersion, @"fileBundleVersion");
   ENCODE(self.fileBundleVersionString, @"fileBundleVersionString");
@@ -82,6 +83,7 @@
     _fileBundleBinaryCount = DECODE(NSNumber, @"fileBundleBinaryCount");
     _fileBundleName = DECODE(NSString, @"fileBundleName");
     _fileBundlePath = DECODE(NSString, @"fileBundlePath");
+    _fileBundleExecutableRelPath = DECODE(NSString, @"fileBundleExecutableRelPath");
     _fileBundleID = DECODE(NSString, @"fileBundleID");
     _fileBundleVersion = DECODE(NSString, @"fileBundleVersion");
     _fileBundleVersionString = DECODE(NSString, @"fileBundleVersionString");

--- a/Source/santabs/SNTBundleService.m
+++ b/Source/santabs/SNTBundleService.m
@@ -108,6 +108,12 @@
     event.fileBundleVersion = b.bundleVersion;
     event.fileBundleVersionString = b.bundleShortVersionString;
 
+    // For most apps this should be "Contents/MacOS/AppName"
+    if (b.bundle.executablePath.length > b.bundlePath.length) {
+      event.fileBundleExecutableRelPath =
+          [b.bundle.executablePath substringFromIndex:b.bundlePath.length + 1];
+    }
+
     NSDictionary *relatedEvents = [self findRelatedBinaries:event progress:progress];
     NSString *bundleHash = [self calculateBundleHashFromSHA256Hashes:relatedEvents.allKeys
                                                             progress:progress];
@@ -227,6 +233,7 @@
       se.decision = SNTEventStateBundleBinary;
 
       se.fileBundlePath = event.fileBundlePath;
+      se.fileBundleExecutableRelPath = event.fileBundleExecutableRelPath;
       se.fileBundleID = event.fileBundleID;
       se.fileBundleName = event.fileBundleName;
       se.fileBundleVersion = event.fileBundleVersion;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -59,6 +59,7 @@ extern NSString *const kLoggedInUsers;
 extern NSString *const kCurrentSessions;
 extern NSString *const kFileBundleID;
 extern NSString *const kFileBundlePath;
+extern NSString *const kFileBundleExecutableRelPath;
 extern NSString *const kFileBundleName;
 extern NSString *const kFileBundleVersion;
 extern NSString *const kFileBundleShortVersionString;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -59,6 +59,7 @@ NSString *const kLoggedInUsers = @"logged_in_users";
 NSString *const kCurrentSessions = @"current_sessions";
 NSString *const kFileBundleID = @"file_bundle_id";
 NSString *const kFileBundlePath = @"file_bundle_path";
+NSString *const kFileBundleExecutableRelPath = @"file_bundle_executable_rel_path";
 NSString *const kFileBundleName = @"file_bundle_name";
 NSString *const kFileBundleVersion = @"file_bundle_version";
 NSString *const kFileBundleShortVersionString = @"file_bundle_version_string";

--- a/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.m
@@ -109,6 +109,7 @@
 
   ADDKEY(newEvent, kFileBundleID, event.fileBundleID);
   ADDKEY(newEvent, kFileBundlePath, event.fileBundlePath);
+  ADDKEY(newEvent, kFileBundleExecutableRelPath, event.fileBundleExecutableRelPath);
   ADDKEY(newEvent, kFileBundleName, event.fileBundleName);
   ADDKEY(newEvent, kFileBundleVersion, event.fileBundleVersion);
   ADDKEY(newEvent, kFileBundleShortVersionString, event.fileBundleVersionString);


### PR DESCRIPTION
Do this for bundle events to allow a sync-server to determine the main executable.