### PR TITLE
santactl/sync: fixed exception when file_name is None / NSNull

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -34,6 +34,11 @@
 #import "SNTXPCControlInterface.h"
 #import "SNTXPCSyncdInterface.h"
 
+static NSString *const kFCMActionKey = @"action";
+static NSString *const kFCMFileHashKey = @"file_hash";
+static NSString *const kFCMFileNameKey = @"file_name";
+static NSString *const kFCMTargetHostIDKey = @"target_host_id";
+
 @interface SNTCommandSyncManager () {
   SCNetworkReachabilityRef _reachability;
 }
@@ -199,48 +204,40 @@ static void reachabilityHandler(
 }
 
 - (void)processFCMMessage:(NSDictionary *)FCMmessage withMachineID:(NSString *)machineID {
-  NSData *messageData = [self extractMessageDataFrom:FCMmessage];
+  NSDictionary *message = [self messageFromMessageData:[self messageDataFromFCMmessage:FCMmessage]];
 
-  if (!messageData) {
+  if (!message) {
     LOGD(@"Push notification message is not in the expected format...dropping message");
     return;
   }
 
-  NSError *error;
-  NSDictionary *actionMessage = [NSJSONSerialization JSONObjectWithData:messageData
-                                                                options:0
-                                                                  error:&error];
-  if (!actionMessage) {
-    LOGD(@"Unable to parse push notification message value: %@", error);
+  NSString *action = message[kFCMActionKey];
+  if (!action) {
+    LOGD(@"Push notification message contains no action");
     return;
   }
 
   // Store the file name and hash in a cache. When the rule is actually added, use the cache
   // to build a user notification.
-  NSString *fileHash = actionMessage[@"file_hash"];
-  NSString *fileName = actionMessage[@"file_name"];
-  if (fileName.length && fileHash.length) {
-    [self.ruleSyncCache setObject:fileName forKey:fileHash];
-  }
-
-  NSString *action = actionMessage[@"action"];
-  if (action) {
-    LOGD(@"Push notification action: %@ received", action);
-  } else {
-    LOGD(@"Push notification message contains no action");
+  NSString *fileHash = message[kFCMFileHashKey];
+  NSString *fileName = message[kFCMFileNameKey];
+  if (fileName && fileHash) {
+    [self.ruleSyncCache setObject:[fileName copy] forKey:[fileHash copy]];
   }
 
   if ([action isEqualToString:kFullSync]) {
+    LOGD(@"Push notification action: %@ received", kFullSync);
     [self fullSync];
   } else if ([action isEqualToString:kRuleSync]) {
-    NSString *targetMachineID = actionMessage[@"target_host_id"];
-    if (![targetMachineID isKindOfClass:[NSNull class]] &&
-        [targetMachineID.lowercaseString isEqualToString:machineID.lowercaseString]) {
+    LOGD(@"Push notification action: %@ received", kRuleSync);
+    NSString *targetHostID = message[kFCMTargetHostIDKey];
+    if ([targetHostID.lowercaseString isEqualToString:machineID.lowercaseString]) {
+      LOGD(@"Targeted rule_sync for host_id: %@", targetHostID);
       self.targetedRuleSync = YES;
       [self ruleSync];
     } else {
       uint32_t delaySeconds = arc4random_uniform((uint32_t)self.FCMGlobalRuleSyncDeadline);
-      LOGD(@"Staggering rule download: %u second delay", delaySeconds);
+      LOGD(@"Global rule_sync, staggering: %u second delay", delaySeconds);
       [self ruleSyncSecondsFromNow:delaySeconds];
     }
   } else if ([action isEqualToString:kConfigSync]) {
@@ -252,10 +249,31 @@ static void reachabilityHandler(
   }
 }
 
-- (NSData *)extractMessageDataFrom:(NSDictionary *)FCMmessage {
+- (NSData *)messageDataFromFCMmessage:(NSDictionary *)FCMmessage {
   if (![FCMmessage[@"data"] isKindOfClass:[NSDictionary class]]) return nil;
   if (![FCMmessage[@"data"][@"blob"] isKindOfClass:[NSString class]]) return nil;
   return [FCMmessage[@"data"][@"blob"] dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+- (NSDictionary *)messageFromMessageData:(NSData *)messageData {
+  NSError *error;
+  NSDictionary *rawMessage = [NSJSONSerialization JSONObjectWithData:messageData
+                                                          options:0
+                                                            error:&error];
+  if (!rawMessage) {
+    LOGD(@"Unable to parse push notification message data: %@", error);
+    return nil;
+  }
+
+  // Create a new message dropping unexpected values
+  NSArray *allowedKeys = @[ kFCMActionKey, kFCMFileHashKey, kFCMFileNameKey, kFCMTargetHostIDKey ];
+  NSMutableDictionary *message = [NSMutableDictionary dictionaryWithCapacity:allowedKeys.count];
+  for (NSString *key in allowedKeys) {
+    if ([rawMessage[key] isKindOfClass:[NSString class]] && [rawMessage[key] length]) {
+      message[key] = rawMessage[key];
+    }
+  }
+  return message.count ? [message copy] : nil;
 }
 
 #pragma mark sync timer control


### PR DESCRIPTION
Fixes an issue where l222 (old) would crash if the message decoded NSNull for file_name. 

```
Application Specific Information:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull length]: unrecognized selector sent to instance 0x7fff94e830e0'
abort() called
terminating with uncaught exception of type NSException

Application Specific Backtrace 1:
0   CoreFoundation                      0x00007fff79ab957b __exceptionPreprocess + 171
1   libobjc.A.dylib                     0x00007fff8ecfd1da objc_exception_throw + 48
2   CoreFoundation                      0x00007fff79b39f14 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
3   CoreFoundation                      0x00007fff79a2cc93 ___forwarding___ + 1059
4   CoreFoundation                      0x00007fff79a2c7e8 _CF_forwarding_prep_0 + 120
5   santactl                            0x000000010d70ef69 -[SNTCommandSyncManager processFCMMessage:withMachineID:] + 473
6   santactl                            0x000000010d70ea86 __65-[SNTCommandSyncManager listenForPushNotificationsWithSyncState:]_block_invoke + 374
7   santactl                            0x000000010d74a737 -[MOLFCMClient processMessagesFromData:] + 1095
8   santactl                            0x000000010d74ac60 __43-[MOLFCMClient dataTaskDidReceiveDataBlock]_block_invoke + 144
9   santactl                            0x000000010d73f587 -[MOLAuthenticatingURLSession URLSession:dataTask:didReceiveData:] + 215
10  CFNetwork                           0x00007fff78d68ce6 __67-[NSURLSession delegate_dataTask:didReceiveData:completionHandler:]_block_invoke.219 + 38
11  Foundation                          0x00007fff7b4831a9 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 7
12  Foundation                          0x00007fff7b482e8c -[NSBlockOperation main] + 101
13  Foundation                          0x00007fff7b4815b4 -[__NSOperationInternal _start:] + 672
14  Foundation                          0x00007fff7b47d46b __NSOQSchedule_f + 201
15  libdispatch.dylib                   0x00007fff8f5a88fc _dispatch_client_callout + 8
16  libdispatch.dylib                   0x00007fff8f5be9a0 _dispatch_queue_serial_drain + 896
17  libdispatch.dylib                   0x00007fff8f5b1306 _dispatch_queue_invoke + 1046
18  libdispatch.dylib                   0x00007fff8f5aa6b5 _dispatch_root_queue_drain + 476
19  libdispatch.dylib                   0x00007fff8f5aa48c _dispatch_worker_thread3 + 99
20  libsystem_pthread.dylib             0x00007fff8f7f75a2 _pthread_wqthread + 1299
21  libsystem_pthread.dylib             0x00007fff8f7f707d start_wqthread + 13
```