### PR TITLE
santad: Modified log output format.

### DIFF
--- a/Source/santad/SNTEventLog.m
+++ b/Source/santad/SNTEventLog.m
@@ -99,10 +99,8 @@
 
   // init the string with 2k capacity to avoid reallocs
   NSMutableString *outStr = [NSMutableString stringWithCapacity:2048];
-  [outStr appendFormat:@"action=%@|path=%@", action, [self sanitizeString:path]];
-  if (newpath) {
-    [outStr appendFormat:@"|newpath=%@", [self sanitizeString:newpath]];
-  }
+  [outStr appendFormat:@"action=%@", action];
+
   char ppath[PATH_MAX] = "(null)";
   proc_pidpath(message.pid, ppath, PATH_MAX);
 
@@ -110,6 +108,11 @@
                        message.pid, message.ppid, message.pname, ppath,
                        message.uid, [self nameForUID:message.uid],
                        message.gid, [self nameForGID:message.gid]];
+
+  [outStr appendFormat:@"|path=%@", [self sanitizeString:path]];
+  if (newpath) {
+    [outStr appendFormat:@"|newpath=%@", [self sanitizeString:newpath]];
+  }
   LOGI(@"%@", outStr);
 }
 
@@ -181,21 +184,6 @@
     [outLog appendFormat:@"|explain=%@", cd.decisionExtra];
   }
 
-  [outLog appendFormat:@"|sha256=%@|path=%@", cd.sha256, [self sanitizeString:@(message.path)]];
-
-  if (logArgs) {
-    [self addArgsForPid:message.pid toString:outLog];
-  }
-
-  if (cd.certSHA256) {
-    [outLog appendFormat:@"|cert_sha256=%@|cert_cn=%@", cd.certSHA256,
-                         [self sanitizeString:cd.certCommonName]];
-  }
-
-  if (cd.quarantineURL) {
-    [outLog appendFormat:@"|quarantine_url=%@", [self sanitizeString:cd.quarantineURL]];
-  }
-
   NSString *mode;
   switch ([[SNTConfigurator configurator] clientMode]) {
     case SNTClientModeMonitor:
@@ -211,6 +199,21 @@
                        message.uid, [self nameForUID:message.uid],
                        message.gid, [self nameForGID:message.gid],
                        mode];
+
+  [outLog appendFormat:@"|sha256=%@|path=%@", cd.sha256, [self sanitizeString:@(message.path)]];
+
+  if (logArgs) {
+    [self addArgsForPid:message.pid toString:outLog];
+  }
+
+  if (cd.certSHA256) {
+    [outLog appendFormat:@"|cert_sha256=%@|cert_cn=%@", cd.certSHA256,
+                         [self sanitizeString:cd.certCommonName]];
+  }
+
+  if (cd.quarantineURL) {
+    [outLog appendFormat:@"|quarantine_url=%@", [self sanitizeString:cd.quarantineURL]];
+  }
 
   LOGI(@"%@", outLog);
 }


### PR DESCRIPTION
Moved path and args info to the end of the log output so that
extremely long path strings don't obscure process information.