### PR TITLE
common: Remove EventDetailBundleURL key

### DIFF
--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -92,20 +92,7 @@
 + (NSURL *)eventDetailURLForEvent:(SNTStoredEvent *)event {
   SNTConfigurator *config = [SNTConfigurator configurator];
 
-  NSString *formatStr, *versionStr;
-  if (config.eventDetailBundleURL.length && event.fileBundleID) {
-    formatStr = config.eventDetailBundleURL;
-    versionStr = event.fileBundleVersion;
-    if (!versionStr) versionStr = event.fileBundleVersionString;
-
-    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%bundle_id%"
-                                                     withString:event.fileBundleID];
-    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%bundle_ver%"
-                                                     withString:versionStr];
-  } else {
-    formatStr = config.eventDetailURL;
-  }
-
+  NSString *formatStr = config.eventDetailURL;
   if (!formatStr.length) return nil;
 
   if (event.fileSHA256) {

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -77,8 +77,6 @@ extern NSString *const kDefaultConfigFilePath;
 ///
 ///  When the user gets a block notification, a button can be displayed which will
 ///  take them to a web page with more information about that event.
-///  There are two properties, one for individual binaries and one for binaries that are part
-///  of a bundle. If the latter is not set the former will be used.
 ///
 ///  This property contains a kind of format string to be turned into the URL to send them to.
 ///  The following sequences will be replaced in the final URL:
@@ -86,15 +84,12 @@ extern NSString *const kDefaultConfigFilePath;
 ///  %file_sha%    -- SHA-256 of the file that was blocked.
 ///  %machine_id%  -- ID of the machine.
 ///  %username%    -- executing user.
-///  %bundle_id%   -- bundle id of the binary, if applicable.
-///  %bundle_ver%  -- bundle version of the binary, if applicable.
 ///
 ///  @note: This is not an NSURL because the format-string parsing is done elsewhere.
 ///
 ///  If this item isn't set, the Open Event button will not be displayed.
 ///
 @property(readonly, nonatomic) NSString *eventDetailURL;
-@property(readonly, nonatomic) NSString *eventDetailBundleURL;
 
 ///
 ///  Related to the above property, this string represents the text to show on the button.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -44,7 +44,6 @@ static NSString *const kEnablePageZeroProtectionKey = @"EnablePageZeroProtection
 
 static NSString *const kMoreInfoURLKey = @"MoreInfoURL";
 static NSString *const kEventDetailURLKey = @"EventDetailURL";
-static NSString *const kEventDetailBundleURLKey = @"EventDetailBundleURL";
 static NSString *const kEventDetailTextKey = @"EventDetailText";
 static NSString *const kUnknownBlockMessage = @"UnknownBlockMessage";
 static NSString *const kBannedBlockMessage = @"BannedBlockMessage";
@@ -200,10 +199,6 @@ static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
 - (NSString *)eventDetailURL {
   return self.configData[kEventDetailURLKey];
-}
-
-- (NSString *)eventDetailBundleURL {
-  return self.configData[kEventDetailBundleURLKey];
 }
 
 - (NSString *)eventDetailText {


### PR DESCRIPTION
The changes to bundle scanning mean this key isn't really necessary anymore - if a server supports bundles it tells the client during preflight, this in turn causes bundle hashes to be generated and these are used in place of the file hash when generating a detail URL. Keying bundles off the ID and version was never really a good idea anyway.