### PR TITLE
santad: modified execution log format to show path & args at end

### DIFF
--- a/Source/santad/SNTEventLog.m
+++ b/Source/santad/SNTEventLog.m
@@ -181,11 +181,7 @@
     [outLog appendFormat:@"|explain=%@", cd.decisionExtra];
   }
 
-  [outLog appendFormat:@"|sha256=%@|path=%@", cd.sha256, [self sanitizeString:@(message.path)]];
-
-  if (logArgs) {
-    [self addArgsForPid:message.pid toString:outLog];
-  }
+  [outLog appendFormat:@"|sha256=%@", cd.sha256];
 
   if (cd.certSHA256) {
     [outLog appendFormat:@"|cert_sha256=%@|cert_cn=%@", cd.certSHA256,
@@ -206,11 +202,15 @@
       mode = @"U"; break;
   }
 
-  [outLog appendFormat:@"|pid=%d|ppid=%d|uid=%d|user=%@|gid=%d|group=%@|mode=%@",
+  [outLog appendFormat:@"|pid=%d|ppid=%d|uid=%d|user=%@|gid=%d|group=%@|mode=%@|path=%@",
                        message.pid, message.ppid,
                        message.uid, [self nameForUID:message.uid],
                        message.gid, [self nameForGID:message.gid],
-                       mode];
+                       mode, [self sanitizeString:@(message.path)]];
+
+  if (logArgs) {
+    [self addArgsForPid:message.pid toString:outLog];
+  }
 
   LOGI(@"%@", outLog);
 }


### PR DESCRIPTION
Fixed problem where extremely long path/args obscured other log info.