### PR TITLE
santactl: Recursive fileinfo command

### DIFF
--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		168A4E09A2A5E0B7DF8A2F1A /* libPods-santad.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C11A10A5D6E112788769CF70 /* libPods-santad.a */; };
 		4092327A1A51B66400A04527 /* SNTCommandRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 409232791A51B65D00A04527 /* SNTCommandRule.m */; };
 		59D56CF2D9C5BD9B7E3CC56D /* libPods-santad-santabs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 14B98F4051188ECB7D024331 /* libPods-santad-santabs.a */; };
+		81133DB01F3A76F700917FF9 /* SNTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81133DAF1F3A75CE00917FF9 /* SNTCommand.m */; };
+		81133DB11F3A77C600917FF9 /* SNTCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81133DAF1F3A75CE00917FF9 /* SNTCommand.m */; };
 		B352A545B76783D568A6D0C5 /* libPods-Santa.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 90E9D568200AB9B642E06272 /* libPods-Santa.a */; };
 		C714F8B11D8044D400700EDF /* SNTCommandFileInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD5FBE1909D64A006B445C /* SNTCommandFileInfo.m */; };
 		C714F8B21D8044FE00700EDF /* SNTCommandController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D35BDAB18FD7CFD00921A21 /* SNTCommandController.m */; };
@@ -1425,6 +1427,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81133DB01F3A76F700917FF9 /* SNTCommand.m in Sources */,
 				C714F8B21D8044FE00700EDF /* SNTCommandController.m in Sources */,
 				C7DA62F71E241938009BDF2C /* SNTXPCBundleServiceInterface.m in Sources */,
 				C714F8B11D8044D400700EDF /* SNTCommandFileInfo.m in Sources */,
@@ -1476,6 +1479,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81133DB11F3A77C600917FF9 /* SNTCommand.m in Sources */,
 				0DA73CA21934F88D0056D7C4 /* SNTLogging.m in Sources */,
 				0D35BDB518FD84F600921A21 /* SNTCommandSync.m in Sources */,
 				0DCD5FBF1909D64A006B445C /* SNTCommandFileInfo.m in Sources */,

--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -427,6 +427,8 @@
 		670AD2EB5E3572321B058D02 /* Pods-Santa.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.debug.xcconfig"; sourceTree = "<group>"; };
 		6C489E087A247B24480DB954 /* Pods-LogicTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LogicTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LogicTests/Pods-LogicTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7D949AA996AEAC326A4F6596 /* libPods-LogicTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LogicTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		81133DAE1F3A75CE00917FF9 /* SNTCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTCommand.h; sourceTree = "<group>"; };
+		81133DAF1F3A75CE00917FF9 /* SNTCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCommand.m; sourceTree = "<group>"; };
 		8EF10E4B8C86CED022C72F1B /* Pods-santactl.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-santactl.debug.xcconfig"; path = "Pods/Target Support Files/Pods-santactl/Pods-santactl.debug.xcconfig"; sourceTree = "<group>"; };
 		90E9D568200AB9B642E06272 /* libPods-Santa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Santa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A91785C40257CC156B4F05 /* Pods-Santa.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.release.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.release.xcconfig"; sourceTree = "<group>"; };
@@ -563,6 +565,8 @@
 		0D35BDA018FD71CE00921A21 /* santactl */ = {
 			isa = PBXGroup;
 			children = (
+				81133DAE1F3A75CE00917FF9 /* SNTCommand.h */,
+				81133DAF1F3A75CE00917FF9 /* SNTCommand.m */,
 				0D35BDAA18FD7CFD00921A21 /* SNTCommandController.h */,
 				0D35BDAB18FD7CFD00921A21 /* SNTCommandController.m */,
 				0D35BDA118FD71CE00921A21 /* main.m */,

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -14,6 +14,8 @@
 
 @import Foundation;
 
+@class MOLCodesignChecker;
+
 ///
 ///  Represents a binary on disk, providing access to details about that binary
 ///  such as the SHA-1, SHA-256, Info.plist and the Mach-O data.
@@ -215,5 +217,16 @@
 ///  @return The size of the file in bytes.
 ///
 - (NSUInteger)fileSize;
+
+///
+///  @return Returns an instance of MOLCodeSignChecker initialized with the file's binary path.
+///  The result is cached and returned on subsequent calls.
+///
+- (MOLCodesignChecker *)codesignChecker;
+
+///
+///  If there was an error while calling codesignChecker you can read it from this property.
+///
+@property(nonatomic,readonly) NSError *codesignCheckerError;
 
 @end

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -124,6 +124,11 @@
 - (BOOL)isDMG;
 
 ///
+///  @return NSString describing the kind of file (executable, bundle, script, etc.)
+///
+- (NSString *)humanReadableFileType;
+
+///
 ///  @return YES if this file has a bad/missing __PAGEZERO .
 ///
 - (BOOL)isMissingPageZero;

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -76,12 +76,6 @@
 - (NSString *)SHA256;
 
 ///
-///  Computes SHA1 and SHA256, caching the results.  This is slightly faster than computing each
-//   hash separately if you need them both.
-///
-- (void)precomputeSecureHashes;
-
-///
 ///  @return The architectures included in this binary (e.g. x86_64, ppc).
 ///
 - (NSArray *)architectures;

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -215,7 +215,7 @@
 ///
 ///  @return Returns an instance of MOLCodeSignChecker initialized with the file's binary path.
 ///  Both the MOLCodesignChecker and any resulting NSError are cached and returned on subsequent
-///  calls.  You may pass in nil for the error if you don't care to receive it.
+///  calls.  You may pass in NULL for the error if you don't care to receive it.
 ///
 - (MOLCodesignChecker *)codesignCheckerWithError:(NSError **)error;
 

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -220,13 +220,9 @@
 
 ///
 ///  @return Returns an instance of MOLCodeSignChecker initialized with the file's binary path.
-///  The result is cached and returned on subsequent calls.
+///  Both the MOLCodesignChecker and any resulting NSError are cached and returned on subsequent
+///  calls.  You may pass in nil for the error if you don't care to receive it.
 ///
-- (MOLCodesignChecker *)codesignChecker;
-
-///
-///  If there was an error while calling codesignChecker you can read it from this property.
-///
-@property(nonatomic,readonly) NSError *codesignCheckerError;
+- (MOLCodesignChecker *)codesignCheckerWithError:(NSError **)error;
 
 @end

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -74,6 +74,12 @@
 - (NSString *)SHA256;
 
 ///
+///  Computes SHA1 and SHA256, caching the results.  This is slightly faster than computing each
+//   hash separately if you need them both.
+///
+- (void)precomputeSecureHashes;
+
+///
 ///  @return The architectures included in this binary (e.g. x86_64, ppc).
 ///
 - (NSArray *)architectures;

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -57,6 +57,7 @@
 @property NSString *cachedSHA256;
 @property NSString *cachedSHA1;
 @property MOLCodesignChecker *cachedCodesignChecker;
+@property(nonatomic, readonly) NSError *codesignCheckerError;
 @end
 
 @implementation SNTFileInfo
@@ -712,17 +713,15 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 
 ///
 ///  Cache and return a MOLCodeSignChecker for the given file.  If there was an error creating the
-///  code sign checker, the error may be obtained from the read-only codesignCheckerError property.
+///  code sign checker it will be returned in the passed-in error parameter.
 ///
-- (MOLCodesignChecker *)codesignChecker {
-  @synchronized (self) {
-    if (!self.cachedCodesignChecker) {
-      NSError *error;
-      self.cachedCodesignChecker = [[MOLCodesignChecker alloc]
-          initWithBinaryPath:self.path error:&error];
-      _codesignCheckerError = error;
-    }
+- (MOLCodesignChecker *)codesignCheckerWithError:(NSError **)error {
+  if (!self.cachedCodesignChecker) {
+    NSError *e;
+    self.cachedCodesignChecker = [[MOLCodesignChecker alloc] initWithBinaryPath:self.path error:&e];
+    _codesignCheckerError = e;
   }
+  if (error) *error = _codesignCheckerError;
   return self.cachedCodesignChecker;
 }
 

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -55,7 +55,7 @@
 @property NSDictionary *quarantineDict;
 @property NSDictionary *cachedHeaders;
 @property MOLCodesignChecker *cachedCodesignChecker;
-@property(nonatomic, readonly) NSError *codesignCheckerError;
+@property(nonatomic) NSError *codesignCheckerError;
 @end
 
 @implementation SNTFileInfo
@@ -703,9 +703,9 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
   if (!self.cachedCodesignChecker) {
     NSError *e;
     self.cachedCodesignChecker = [[MOLCodesignChecker alloc] initWithBinaryPath:self.path error:&e];
-    _codesignCheckerError = e;
+    self.codesignCheckerError = e;
   }
-  if (error) *error = _codesignCheckerError;
+  if (error) *error = self.codesignCheckerError;
   return self.cachedCodesignChecker;
 }
 

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -54,8 +54,6 @@
 @property NSDictionary *infoDict;
 @property NSDictionary *quarantineDict;
 @property NSDictionary *cachedHeaders;
-@property NSString *cachedSHA256;
-@property NSString *cachedSHA1;
 @property MOLCodesignChecker *cachedCodesignChecker;
 @property(nonatomic, readonly) NSError *codesignCheckerError;
 @end
@@ -209,29 +207,15 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 }
 
 - (NSString *)SHA1 {
-  if (!self.cachedSHA1) {
-    NSString *sha1;
-    [self hashSHA1:&sha1 SHA256:NULL];
-    self.cachedSHA1 = sha1;
-  }
-  return self.cachedSHA1;
+  NSString *sha1;
+  [self hashSHA1:&sha1 SHA256:NULL];
+  return sha1;
 }
 
 - (NSString *)SHA256 {
-  if (!self.cachedSHA256) {
-    NSString *sha256;
-    [self hashSHA1:NULL SHA256:&sha256];
-    self.cachedSHA256 = sha256;
-  }
-  return self.cachedSHA256;
-}
-
-- (void)precomputeSecureHashes {
-  if (self.cachedSHA256 && self.cachedSHA1) return;
-  NSString *sha1, *sha256;
-  [self hashSHA1:&sha1 SHA256:&sha256];
-  self.cachedSHA1 = sha1;
-  self.cachedSHA256 = sha256;
+  NSString *sha256;
+  [self hashSHA1:NULL SHA256:&sha256];
+  return sha256;
 }
 
 #pragma mark File Type Info

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -53,6 +53,8 @@
 @property NSDictionary *infoDict;
 @property NSDictionary *quarantineDict;
 @property NSDictionary *cachedHeaders;
+@property NSString *cachedSHA256;
+@property NSString *cachedSHA1;
 @end
 
 @implementation SNTFileInfo
@@ -204,15 +206,29 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 }
 
 - (NSString *)SHA1 {
-  NSString *sha1;
-  [self hashSHA1:&sha1 SHA256:NULL];
-  return sha1;
+  if (!self.cachedSHA1) {
+    NSString *sha1;
+    [self hashSHA1:&sha1 SHA256:NULL];
+    self.cachedSHA1 = sha1;
+  }
+  return self.cachedSHA1;
 }
 
 - (NSString *)SHA256 {
-  NSString *sha256;
-  [self hashSHA1:NULL SHA256:&sha256];
-  return sha256;
+  if (!self.cachedSHA256) {
+    NSString *sha256;
+    [self hashSHA1:NULL SHA256:&sha256];
+    self.cachedSHA256 = sha256;
+  }
+  return self.cachedSHA256;
+}
+
+- (void)precomputeSecureHashes {
+  if (self.cachedSHA256 && self.cachedSHA1) return;
+  NSString *sha1, *sha256;
+  [self hashSHA1:&sha1 SHA256:&sha256];
+  self.cachedSHA1 = sha1;
+  self.cachedSHA256 = sha256;
 }
 
 #pragma mark File Type Info

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -15,6 +15,7 @@
 #import "SNTFileInfo.h"
 
 #import <CommonCrypto/CommonDigest.h>
+#import <MOLCodesignChecker/MOLCodesignChecker.h>
 
 #include <mach-o/loader.h>
 #include <mach-o/swap.h>
@@ -55,6 +56,7 @@
 @property NSDictionary *cachedHeaders;
 @property NSString *cachedSHA256;
 @property NSString *cachedSHA1;
+@property MOLCodesignChecker *cachedCodesignChecker;
 @end
 
 @implementation SNTFileInfo
@@ -706,6 +708,22 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
   } else {
     return path;
   }
+}
+
+///
+///  Cache and return a MOLCodeSignChecker for the given file.  If there was an error creating the
+///  code sign checker, the error may be obtained from the read-only codesignCheckerError property.
+///
+- (MOLCodesignChecker *)codesignChecker {
+  @synchronized (self) {
+    if (!self.cachedCodesignChecker) {
+      NSError *error;
+      self.cachedCodesignChecker = [[MOLCodesignChecker alloc]
+          initWithBinaryPath:self.path error:&error];
+      _codesignCheckerError = error;
+    }
+  }
+  return self.cachedCodesignChecker;
 }
 
 @end

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -700,7 +700,7 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 ///  code sign checker it will be returned in the passed-in error parameter.
 ///
 - (MOLCodesignChecker *)codesignCheckerWithError:(NSError **)error {
-  if (!self.cachedCodesignChecker) {
+  if (!self.cachedCodesignChecker && !self.codesignCheckerError) {
     NSError *e;
     self.cachedCodesignChecker = [[MOLCodesignChecker alloc] initWithBinaryPath:self.path error:&e];
     self.codesignCheckerError = e;

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -267,6 +267,17 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
   return (magic && memcmp("koly", magic, 4) == 0);
 }
 
+- (NSString *)humanReadableFileType {
+  if ([self isExecutable]) return @"Executable";
+  if ([self isDylib]) return @"Dynamic Library";
+  if ([self isBundle]) return @"Bundle/Plugin";
+  if ([self isKext]) return @"Kernel Extension";
+  if ([self isScript]) return @"Script";
+  if ([self isXARArchive]) return @"XAR Archive";
+  if ([self isDMG]) return @"Disk Image";
+  return @"Unknown";
+}
+
 #pragma mark Page Zero
 
 - (BOOL)isMissingPageZero {

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -278,6 +278,7 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 }
 
 - (BOOL)isDMG {
+  if (self.fileSize < 512) return NO;
   NSUInteger last512 = self.fileSize - 512;
   const char *magic = (const char *)[[self safeSubdataWithRange:NSMakeRange(last512, 4)] bytes];
   return (magic && memcmp("koly", magic, 4) == 0);

--- a/Source/santabs/SNTBundleService.m
+++ b/Source/santabs/SNTBundleService.m
@@ -239,7 +239,7 @@
       se.fileBundleVersion = event.fileBundleVersion;
       se.fileBundleVersionString = event.fileBundleVersionString;
 
-      MOLCodesignChecker *cs = [fi codesignCheckerWithError:nil];
+      MOLCodesignChecker *cs = [fi codesignCheckerWithError:NULL];
       se.signingChain = cs.certificates;
 
       dispatch_sync(dispatch_get_main_queue(), ^{

--- a/Source/santabs/SNTBundleService.m
+++ b/Source/santabs/SNTBundleService.m
@@ -239,7 +239,7 @@
       se.fileBundleVersion = event.fileBundleVersion;
       se.fileBundleVersionString = event.fileBundleVersionString;
 
-      MOLCodesignChecker *cs = [fi codesignChecker];
+      MOLCodesignChecker *cs = [fi codesignCheckerWithError:nil];
       se.signingChain = cs.certificates;
 
       dispatch_sync(dispatch_get_main_queue(), ^{

--- a/Source/santabs/SNTBundleService.m
+++ b/Source/santabs/SNTBundleService.m
@@ -239,7 +239,7 @@
       se.fileBundleVersion = event.fileBundleVersion;
       se.fileBundleVersionString = event.fileBundleVersionString;
 
-      MOLCodesignChecker *cs = [[MOLCodesignChecker alloc] initWithBinaryPath:se.filePath];
+      MOLCodesignChecker *cs = [fi codesignChecker];
       se.signingChain = cs.certificates;
 
       dispatch_sync(dispatch_get_main_queue(), ^{

--- a/Source/santactl/Commands/SNTCommandBundleInfo.m
+++ b/Source/santactl/Commands/SNTCommandBundleInfo.m
@@ -21,7 +21,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandBundleInfo : SNTCommand
+@interface SNTCommandBundleInfo : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandBundleInfo
@@ -60,11 +60,10 @@ REGISTER_COMMAND_NAME(@"bundleinfo")
   SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
   se.fileBundlePath = fi.bundlePath;
 
-  [[self.daemonConn remoteObjectProxy] hashBundleBinariesForEvent:se
-                                                       reply:^(NSString *hash,
-                                                               NSArray<SNTStoredEvent *> *events,
-                                                               NSNumber *time) {
-
+  [[self.daemonConn remoteObjectProxy]
+      hashBundleBinariesForEvent:se
+                           reply:^(NSString *hash, NSArray<SNTStoredEvent *> *events,
+                                   NSNumber *time) {
     printf("Hashing time: %llu ms\n", time.unsignedLongLongValue);
     printf("%lu events found\n", events.count);
     printf("BundleHash: %s\n", hash.UTF8String);

--- a/Source/santactl/Commands/SNTCommandBundleInfo.m
+++ b/Source/santactl/Commands/SNTCommandBundleInfo.m
@@ -12,6 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
 
 #import "SNTFileInfo.h"
@@ -20,7 +21,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandBundleInfo : NSObject<SNTCommand>
+@interface SNTCommandBundleInfo : SNTCommand
 @end
 
 @implementation SNTCommandBundleInfo
@@ -45,7 +46,7 @@ REGISTER_COMMAND_NAME(@"bundleinfo")
   return @"Searches a bundle for binaries";
 }
 
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)runWithArguments:(NSArray *)arguments {
   NSError *error;
   SNTFileInfo *fi = [[SNTFileInfo alloc] initWithPath:arguments.firstObject error:&error];
   if (!fi) {
@@ -59,7 +60,7 @@ REGISTER_COMMAND_NAME(@"bundleinfo")
   SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
   se.fileBundlePath = fi.bundlePath;
 
-  [[daemonConn remoteObjectProxy] hashBundleBinariesForEvent:se
+  [[self.daemonConn remoteObjectProxy] hashBundleBinariesForEvent:se
                                                        reply:^(NSString *hash,
                                                                NSArray<SNTStoredEvent *> *events,
                                                                NSNumber *time) {

--- a/Source/santactl/Commands/SNTCommandCheckCache.m
+++ b/Source/santactl/Commands/SNTCommandCheckCache.m
@@ -23,7 +23,7 @@
 
 #include <sys/stat.h>
 
-@interface SNTCommandCheckCache : SNTCommand
+@interface SNTCommandCheckCache : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandCheckCache
@@ -51,7 +51,8 @@ REGISTER_COMMAND_NAME(@"checkcache")
 
 - (void)runWithArguments:(NSArray *)arguments {
   uint64_t vnodeID = [self vnodeIDForFile:arguments.firstObject];
-  [[self.daemonConn remoteObjectProxy] checkCacheForVnodeID:vnodeID withReply:^(santa_action_t action) {
+  [[self.daemonConn remoteObjectProxy] checkCacheForVnodeID:vnodeID
+                                                  withReply:^(santa_action_t action) {
     if (action == ACTION_RESPOND_ALLOW) {
       LOGI(@"File exists in [whitelist] kernel cache");
       exit(0);

--- a/Source/santactl/Commands/SNTCommandCheckCache.m
+++ b/Source/santactl/Commands/SNTCommandCheckCache.m
@@ -14,6 +14,7 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
 
 #import "SNTLogging.h"
@@ -22,7 +23,7 @@
 
 #include <sys/stat.h>
 
-@interface SNTCommandCheckCache : NSObject<SNTCommand>
+@interface SNTCommandCheckCache : SNTCommand
 @end
 
 @implementation SNTCommandCheckCache
@@ -48,9 +49,9 @@ REGISTER_COMMAND_NAME(@"checkcache")
           @"Returns 0 if successful, 1 otherwise");
 }
 
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)runWithArguments:(NSArray *)arguments {
   uint64_t vnodeID = [self vnodeIDForFile:arguments.firstObject];
-  [[daemonConn remoteObjectProxy] checkCacheForVnodeID:vnodeID withReply:^(santa_action_t action) {
+  [[self.daemonConn remoteObjectProxy] checkCacheForVnodeID:vnodeID withReply:^(santa_action_t action) {
     if (action == ACTION_RESPOND_ALLOW) {
       LOGI(@"File exists in [whitelist] kernel cache");
       exit(0);
@@ -64,7 +65,7 @@ REGISTER_COMMAND_NAME(@"checkcache")
   }];
 }
 
-+ (uint64_t)vnodeIDForFile:(NSString *)path {
+- (uint64_t)vnodeIDForFile:(NSString *)path {
   struct stat fstat = {};
   stat(path.fileSystemRepresentation, &fstat);
   return (((uint64_t)fstat.st_dev << 32) | fstat.st_ino);

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -13,7 +13,6 @@
 ///    limitations under the License.
 
 @import Foundation;
-@import AppKit;
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"
@@ -177,26 +176,26 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 - (instancetype)initWithDaemonConnection:(SNTXPCConnection *)daemonConn {
   self = [super initWithDaemonConnection:daemonConn];
-  if (!self) return nil;
-  _dateFormatter = [[NSDateFormatter alloc] init];
-  _dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
+  if (self) {
+    _dateFormatter = [[NSDateFormatter alloc] init];
+    _dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
 
-  _propertyMap = @{ kPath : self.path,
-                    kSHA256 : self.sha256,
-                    kSHA1 : self.sha1,
-                    kBundleName : self.bundleName,
-                    kBundleVersion : self.bundleVersion,
-                    kBundleVersionStr : self.bundleVersionStr,
-                    kDownloadReferrerURL : self.downloadReferrerURL,
-                    kDownloadURL : self.downloadURL,
-                    kDownloadTimestamp : self.downloadTimestamp,
-                    kDownloadAgent : self.downloadAgent,
-                    kType : self.type,
-                    kPageZero : self.pageZero,
-                    kCodeSigned : self.codeSigned,
-                    kRule : self.rule,
-                    kSigningChain : self.signingChain };
-
+    _propertyMap = @{ kPath : self.path,
+                      kSHA256 : self.sha256,
+                      kSHA1 : self.sha1,
+                      kBundleName : self.bundleName,
+                      kBundleVersion : self.bundleVersion,
+                      kBundleVersionStr : self.bundleVersionStr,
+                      kDownloadReferrerURL : self.downloadReferrerURL,
+                      kDownloadURL : self.downloadURL,
+                      kDownloadTimestamp : self.downloadTimestamp,
+                      kDownloadAgent : self.downloadAgent,
+                      kType : self.type,
+                      kPageZero : self.pageZero,
+                      kCodeSigned : self.codeSigned,
+                      kRule : self.rule,
+                      kSigningChain : self.signingChain };
+  }
   return self;
 }
 
@@ -486,7 +485,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     fprintf(stderr, "File does not exist: %s\n", [path UTF8String]);
     return;
   }
-  if (isDir) isBundle = [[NSWorkspace sharedWorkspace] isFilePackageAtPath:path];
+
+  if (isDir) isBundle = ([NSBundle bundleWithPath:path] != nil);
 
   if (isDir && self.recursive) {
     NSDirectoryEnumerator<NSString *> * dirEnum = [fm enumeratorAtPath:path];

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -497,7 +497,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     return;
   }
 
-  if (isDir) isBundle = ([NSBundle bundleWithPath:path] != nil);
+  if (isDir) {
+    NSBundle *bundle = [NSBundle bundleWithPath:path];
+    isBundle = bundle && [bundle bundleIdentifier];
+  }
 
   NSOperationQueue *operationQueue = [[NSOperationQueue alloc] init];
   operationQueue.qualityOfService = NSQualityOfServiceUserInitiated;
@@ -505,8 +508,6 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   if (isDir && self.recursive) {
     NSDirectoryEnumerator<NSString *> * dirEnum = [fm enumeratorAtPath:path];
     for (NSString *file in dirEnum) {
-      // Need autorelease pool inside the loop because fileinfo objects use up lots of memory when
-      // they examine the file's mach header, so we should release them as soon as possible.
       @autoreleasepool {
         NSString *filepath = [path stringByAppendingPathComponent:file];
         BOOL exists = [fm fileExistsAtPath:filepath isDirectory:&isDir];

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -338,9 +338,9 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
     [[cmd.daemonConn remoteObjectProxy] decisionForFilePath:fileInfo.path
-                                                  fileSHA256:fileInfo.SHA256
-                                           certificateSHA256:csc.leafCertificate.SHA256
-                                                       reply:^(SNTEventState s) {
+                                                 fileSHA256:fileInfo.SHA256
+                                          certificateSHA256:csc.leafCertificate.SHA256
+                                                      reply:^(SNTEventState s) {
       state = s;
       dispatch_semaphore_signal(sema);
     }];

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -337,7 +337,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     __block SNTEventState state;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    [[self.daemonConn remoteObjectProxy] decisionForFilePath:fileInfo.path
+    [[cmd.daemonConn remoteObjectProxy] decisionForFilePath:fileInfo.path
                                                   fileSHA256:fileInfo.SHA256
                                            certificateSHA256:csc.leafCertificate.SHA256
                                                        reply:^(SNTEventState s) {
@@ -483,8 +483,9 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   operationQueue.qualityOfService = NSQualityOfServiceUserInitiated;
 
   if (isDir && self.recursive) {
-    NSDirectoryEnumerator<NSString *> * dirEnum = [fm enumeratorAtPath:path];
-    for (NSString *file in dirEnum) {
+    NSDirectoryEnumerator *dirEnum = [fm enumeratorAtPath:path];
+    NSString *file = [dirEnum nextObject];
+    while (file) {
       @autoreleasepool {
         NSString *filepath = [path stringByAppendingPathComponent:file];
         BOOL exists = [fm fileExistsAtPath:filepath isDirectory:&isDir];
@@ -493,6 +494,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
             [self printInfoForFile:filepath];
           }];
         }
+        file = [dirEnum nextObject];
       }
     }
   } else if (isDir && !isBundle) {

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -567,9 +567,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
                     ![self.outputKeyList.firstObject isEqual:kSigningChain]);
   NSMutableString *output = [NSMutableString string];
   if (self.jsonOutput) {
-    if (self.jsonPreviousEntry) [output appendString:@",\n"];
     [output appendString:[self jsonStringForDictionary:outputDict]];
-    self.jsonPreviousEntry = YES;
   } else {
     for (NSString *key in self.outputKeyList) {
       if (![outputDict objectForKey:key]) continue;
@@ -588,6 +586,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   }
 
   dispatch_group_async(group, self.printQueue, ^{
+    if (self.jsonOutput) {  // print commas between JSON entries
+      if (self.jsonPreviousEntry) printf(",\n");
+      self.jsonPreviousEntry = YES;
+    }
     printf("%s", output.UTF8String);
   });
 }

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -63,19 +63,6 @@ NSString *printKeyArray(NSArray *array) {
   return string;
 }
 
-// This should be a method defined in the fileInfo class.
-NSString *humanReadableFileType(SNTFileInfo *fileInfo) {
-  if ([fileInfo isScript]) return @"Script";
-  if ([fileInfo isExecutable]) return @"Executable";
-  if ([fileInfo isDylib]) return @"Dynamic Library";
-  if ([fileInfo isBundle]) return @"Bundle/Plugin";
-  if ([fileInfo isKext]) return @"Kernel Extension";
-  if ([fileInfo isXARArchive]) return @"XAR Archive";
-  if ([fileInfo isDMG]) return @"Disk Image";
-  return @"Unknown";
-}
-
-
 @interface SNTCommandFileInfo : SNTCommand
 
 // Properties set from commandline flags
@@ -264,10 +251,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   return ^id (SNTFileInfo *fileInfo) {
     NSArray *archs = [fileInfo architectures];
     if (archs.count == 0) {
-      return humanReadableFileType(fileInfo);
+      return [fileInfo humanReadableFileType];
     }
     return [NSString stringWithFormat:@"%@ (%@)",
-            humanReadableFileType(fileInfo), [archs componentsJoinedByString:@", "]];
+            [fileInfo humanReadableFileType], [archs componentsJoinedByString:@", "]];
   };
 }
 

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -491,7 +491,9 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   NSFileManager *fm = [NSFileManager defaultManager];
   BOOL isDir = NO, isBundle = NO;
   if (![fm fileExistsAtPath:path isDirectory:&isDir]) {
-    fprintf(stderr, "File does not exist: %s\n", [path UTF8String]);
+    dispatch_group_async(self.printGroup, self.printQueue, ^{
+      fprintf(stderr, "File does not exist: %s\n", [path UTF8String]);
+    });
     return;
   }
 
@@ -516,8 +518,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       }
     }
   } else if (isDir && !isBundle) {
-    fprintf(stderr, "%s is a directory.  Use the -r flag to search recursively.\n",
-            [path UTF8String]);
+    dispatch_group_async(self.printGroup, self.printQueue, ^{
+      fprintf(stderr, "%s is a directory.  Use the -r flag to search recursively.\n",
+          [path UTF8String]);
+    });
   } else {
     [operationQueue addOperationWithBlock:^{
       [self printInfoForFile:path];
@@ -532,7 +536,9 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 - (void)printInfoForFile:(NSString *)path {
   SNTFileInfo *fileInfo = [[SNTFileInfo alloc] initWithPath:path];
   if (!fileInfo) {
-    fprintf(stderr, "Invalid or empty file: %s\n", [path UTF8String]);
+    dispatch_group_async(self.printGroup, self.printQueue, ^{
+      fprintf(stderr, "Invalid or empty file: %s\n", [path UTF8String]);
+    });
     return;
   }
 

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -562,30 +562,30 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   // c) are we displaying a cert?
   BOOL singleKey = (self.outputKeyList.count == 1 &&
                     ![self.outputKeyList.firstObject isEqual:kSigningChain]);
-  NSMutableArray<NSString *> *output = [NSMutableArray arrayWithCapacity:8];
+  NSMutableString *output = [NSMutableString string];
   if (self.jsonOutput) {
-    if (self.jsonPreviousEntry) [output addObject:@",\n"];
-    [output addObject:[self jsonStringForDictionary:outputDict]];
+    if (self.jsonPreviousEntry) [output appendString:@",\n"];
+    [output appendString:[self jsonStringForDictionary:outputDict]];
     self.jsonPreviousEntry = YES;
   } else {
     for (NSString *key in self.outputKeyList) {
       if (![outputDict objectForKey:key]) continue;
       if ([key isEqual:kSigningChain]) {
-        [output addObject:[self stringForSigningChain:outputDict[key]]];
+        [output appendString:[self stringForSigningChain:outputDict[key]]];
       } else {
         if (singleKey) {
-          [output addObject:[NSString stringWithFormat:@"%@\n", outputDict[key]]];
+          [output appendFormat:@"%@\n", outputDict[key]];
         } else {
-          [output addObject:[NSString stringWithFormat:@"%-*s: %@\n",
-              (int)self.maxKeyWidth, key.UTF8String, outputDict[key]]];
+          [output appendFormat:@"%-*s: %@\n",
+              (int)self.maxKeyWidth, key.UTF8String, outputDict[key]];
         }
       }
     }
-    if (!singleKey) [output addObject:@"\n"];
+    if (!singleKey) [output appendString:@"\n"];
   }
 
   dispatch_group_async(group, self.printQueue, ^{
-    for (NSString *string in output) printf("%s", string.UTF8String);
+    printf("%s", output.UTF8String);
   });
 }
 

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -437,7 +437,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     [self recurseAtPath:fullPath];
   }
 
-  if (self.jsonOutput) printf("\n]\n"); // print closing bracket of JSON output array
+  if (self.jsonOutput) printf("\n]\n");  // print closing bracket of JSON output array
 
   exit(0);
 }
@@ -451,13 +451,13 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 - (NSString *)getDirectoryTTYColor {
   NSString *lscolors = [[NSProcessInfo processInfo] environment][@"LSCOLORS"];
   if (!lscolors || lscolors.length < 2) {
-    return @"\033[1;35m"; // bold magenta
+    return @"\033[1;35m";  // bold magenta
   }
   char fg = [lscolors characterAtIndex:0];
   char bg = [lscolors characterAtIndex:1];
   char validChars[] = "abcdefghxABCDEFGHX";
   if (!strchr(validChars, fg) || !strchr(validChars, bg)) {
-    return @"\033[1;35m"; // bold magenta
+    return @"\033[1;35m";  // bold magenta
   }
   NSMutableString *code = @"\033[".mutableCopy;
   if (isupper(fg)) {
@@ -523,7 +523,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     if (self.jsonPreviousEntry) printf(",\n");
     printf("%s", [self jsonStringForFileInfo:fileInfo withKeys:self.outputKeyList].UTF8String);
     self.jsonPreviousEntry = YES;
-  } else { // print directly (so we don't have to build a big nsstring?)
+  } else {  // print directly (so we don't have to build a big nsstring?)
     for (NSString *key in self.outputKeyList) {
       if ([key isEqual:kSigningChain]) {
         NSArray *signingChain = self.propertyMap[key](self, fileInfo);
@@ -565,7 +565,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     if ([arg caseInsensitiveCompare:@"--json"] == NSOrderedSame) {
       self.jsonOutput = YES;
     } else if ([arg caseInsensitiveCompare:@"--cert-index"] == NSOrderedSame) {
-      i += 1; // advance to next argument and grab index
+      i += 1;  // advance to next argument and grab index
       if (i >= nargs || [arguments[i] hasPrefix:@"--"]) {
         [self printErrorUsageAndExit:@"\n--cert-index requires an argument"];
       }
@@ -576,7 +576,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       }
       self.certIndex = @(index);
     } else if ([arg caseInsensitiveCompare:@"--key"] == NSOrderedSame) {
-      i += 1; // advance to next argument and grab the key
+      i += 1;  // advance to next argument and grab the key
       if (i >= nargs || [arguments[i] hasPrefix:@"--"]) {
         [self printErrorUsageAndExit:@"\n--key requires an argument"];
       }

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -338,36 +338,6 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 # pragma mark -
 
-
-- (NSString *)getDirectoryTTYColor {
-  NSString *lscolors = [[NSProcessInfo processInfo] environment][@"LSCOLORS"];
-  if (!lscolors || lscolors.length < 2) {
-    return @"\033[1;35m";
-  }
-  char fg = [lscolors characterAtIndex:0];
-  char bg = [lscolors characterAtIndex:1];
-  char validChars[] = "abcdefghxABCDEFGHX";
-  if (!strchr(validChars, fg) || !strchr(validChars, bg)) {
-    return @"\033[1;35m";
-  }
-  NSMutableString *code = @"\033[".mutableCopy;
-  if (isupper(fg)) {
-    [code appendString:@"1;"];
-    fg = tolower(fg);
-  }
-  if (fg == 'x') {
-    [code appendFormat:@"0"];
-  } else {
-    [code appendFormat:@"%d", fg - 'a' + 30];
-  }
-  if (isupper(bg)) bg = tolower(bg);
-  if (bg != 'x') {
-    [code appendFormat:@";%d", fg - 'a' + 40];
-  }
-  [code appendString:@"m"];
-  return code.copy;
-}
-
 // Entry point for the command.
 - (void)runWithArguments:(NSArray *)arguments {
   if (!arguments.count) [self printErrorUsageAndExit:@"No arguments"];
@@ -404,6 +374,36 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 // Returns YES if we should output colored text.
 - (BOOL)prettyOutput {
   return isatty(STDOUT_FILENO) && !self.jsonOutput;
+}
+
+// Look at environment variable to try to discover user's directory color preference.
+- (NSString *)getDirectoryTTYColor {
+  NSString *lscolors = [[NSProcessInfo processInfo] environment][@"LSCOLORS"];
+  if (!lscolors || lscolors.length < 2) {
+    return @"\033[1;35m"; // bold magenta
+  }
+  char fg = [lscolors characterAtIndex:0];
+  char bg = [lscolors characterAtIndex:1];
+  char validChars[] = "abcdefghxABCDEFGHX";
+  if (!strchr(validChars, fg) || !strchr(validChars, bg)) {
+    return @"\033[1;35m"; // bold magenta
+  }
+  NSMutableString *code = @"\033[".mutableCopy;
+  if (isupper(fg)) {
+    [code appendString:@"1;"];
+    fg = tolower(fg);
+  }
+  if (fg == 'x') {
+    [code appendFormat:@"0"];
+  } else {
+    [code appendFormat:@"%d", fg - 'a' + 30];
+  }
+  if (isupper(bg)) bg = tolower(bg);
+  if (bg != 'x') {
+    [code appendFormat:@";%d", fg - 'a' + 40];
+  }
+  [code appendString:@"m"];
+  return code.copy;
 }
 
 // Print out file info for the object at the given path or, if path is a directory and the

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -452,7 +452,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 }
 
 - (void)processFile:(NSString *)path {
-  SNTFileInfo *fileInfo = [[SNTFileInfo alloc] initWithResolvedPath:path error:nil];
+  SNTFileInfo *fileInfo = [[SNTFileInfo alloc] initWithPath:path];
   if (!fileInfo) {
     printf("couldn't get fileinfo for path: %s\n", [path UTF8String]);
     return;

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -14,6 +14,7 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
 
 #import <MOLCertificate/MOLCertificate.h>
@@ -55,316 +56,26 @@ static NSString *const kSHA1 = @"SHA-1";
 // global json output flag
 static BOOL json = NO;
 
-BOOL PrettyOutput() {
-  static int tty = 0;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    tty = isatty(STDOUT_FILENO);
-  });
-  return (tty && !json);
-}
-
 #pragma mark SNTCommandFileInfo
 
-@interface SNTCommandFileInfo : NSObject<SNTCommand>
-
-@property(nonatomic) SNTXPCConnection *daemonConn;
-@property(nonatomic) SNTFileInfo *fileInfo;
-@property(nonatomic) MOLCodesignChecker *csc;
-
-// file path used for object initialization
-@property(readonly, nonatomic) NSString *filePath;
-
-// Block type to be used with propertyMap values
-typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *);
-
-// on read generated properties
-@property(readonly, copy, nonatomic) SNTAttributeBlock path;
-@property(readonly, copy, nonatomic) SNTAttributeBlock sha256;
-@property(readonly, copy, nonatomic) SNTAttributeBlock sha1;
-@property(readonly, copy, nonatomic) SNTAttributeBlock bundleName;
-@property(readonly, copy, nonatomic) SNTAttributeBlock bundleVersion;
-@property(readonly, copy, nonatomic) SNTAttributeBlock bundleShortVersionString;
-@property(readonly, copy, nonatomic) SNTAttributeBlock downloadReferrerURL;
-@property(readonly, copy, nonatomic) SNTAttributeBlock downloadURL;
-@property(readonly, copy, nonatomic) SNTAttributeBlock downloadTimestamp;
-@property(readonly, copy, nonatomic) SNTAttributeBlock downloadAgent;
-@property(readonly, copy, nonatomic) SNTAttributeBlock type;
-@property(readonly, copy, nonatomic) SNTAttributeBlock pageZero;
-@property(readonly, copy, nonatomic) SNTAttributeBlock codeSigned;
-@property(readonly, copy, nonatomic) SNTAttributeBlock rule;
-@property(readonly, copy, nonatomic) SNTAttributeBlock signingChain;
-
-// Mapping between property string keys and SNTAttributeBlocks
-@property(nonatomic) NSMutableDictionary<NSString *, SNTAttributeBlock> *propertyMap;
-
-// Common Date Formatter
-@property(nonatomic) NSDateFormatter *dateFormatter;
-
-// Block Helpers
-- (NSString *)humanReadableFileType:(SNTFileInfo *)fi;
-
+@interface SNTCommandFileInfo : SNTCommand
+@property(nonatomic) BOOL prettyOutput;
+@property NSArray *fileInfoKeys;
+@property NSArray *signingChainKeys;
 @end
+
+
+NSString *printKeyArray(NSArray *array) {
+  __block NSMutableString *string = [[NSMutableString alloc] init];
+  [array enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    [string appendString:[NSString stringWithFormat:@"                       \"%@\"\n", obj]];
+  }];
+  return string;
+}
 
 @implementation SNTCommandFileInfo
 
 REGISTER_COMMAND_NAME(@"fileinfo")
-
-- (instancetype)initWithFilePath:(NSString *)filePath
-                daemonConnection:(SNTXPCConnection *)daemonConn {
-  self = [super init];
-  if (self) {
-    _filePath = filePath;
-    _daemonConn = daemonConn;
-    _dateFormatter = [[NSDateFormatter alloc] init];
-    _dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
-    _propertyMap = @{ kPath : self.path,
-                      kSHA256 : self.sha256,
-                      kSHA1 : self.sha1,
-                      kBundleName : self.bundleName,
-                      kBundleVersion : self.bundleVersion,
-                      kBundleVersionStr : self.bundleVersionStr,
-                      kDownloadReferrerURL : self.downloadReferrerURL,
-                      kDownloadURL : self.downloadURL,
-                      kDownloadTimestamp : self.downloadTimestamp,
-                      kDownloadAgent : self.downloadAgent,
-                      kType : self.type,
-                      kPageZero : self.pageZero,
-                      kCodeSigned : self.codeSigned,
-                      kRule : self.rule,
-                      kSigningChain : self.signingChain }.mutableCopy;
-  }
-  return self;
-}
-
-#pragma mark property getters
-
-- (SNTFileInfo *)fileInfo {
-  if (!_fileInfo) {
-    _fileInfo = [[SNTFileInfo alloc] initWithPath:self.filePath];
-    if (!_fileInfo) {
-      fprintf(stderr, "\rInvalid or empty file: %s\n", self.filePath.UTF8String);
-    }
-  }
-  return _fileInfo;
-}
-
-- (SNTAttributeBlock)path {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.path;
-  };
-}
-
-- (SNTAttributeBlock)sha256 {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.SHA256;
-  };
-}
-
-- (SNTAttributeBlock)sha1 {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.SHA1;
-  };
-}
-
-- (SNTAttributeBlock)bundleName {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.bundleName;
-  };
-}
-
-- (SNTAttributeBlock)bundleVersion {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.bundleVersion;
-  };
-}
-
-- (SNTAttributeBlock)bundleVersionStr {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.bundleShortVersionString;
-  };
-}
-
-- (SNTAttributeBlock)downloadReferrerURL {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.quarantineRefererURL;
-  };
-}
-
-- (SNTAttributeBlock)downloadURL {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.quarantineDataURL;
-  };
-}
-
-- (SNTAttributeBlock)downloadTimestamp {
-  return ^id (SNTCommandFileInfo *fi) {
-    return [fi.dateFormatter stringFromDate:fi.fileInfo.quarantineTimestamp];
-  };
-}
-
-- (SNTAttributeBlock)downloadAgent {
-  return ^id (SNTCommandFileInfo *fi) {
-    return fi.fileInfo.quarantineAgentBundleID;
-  };
-}
-
-- (SNTAttributeBlock)type {
-  return ^id (SNTCommandFileInfo *fi) {
-    NSArray *archs = [fi.fileInfo architectures];
-    if (archs.count == 0) {
-      return [fi humanReadableFileType:fi.fileInfo];
-    }
-    return [NSString stringWithFormat:@"%@ (%@)",
-               [fi humanReadableFileType:fi.fileInfo], [archs componentsJoinedByString:@", "]];
-  };
-}
-
-- (SNTAttributeBlock)pageZero {
-  return ^id (SNTCommandFileInfo *fi) {
-    if ([fi.fileInfo isMissingPageZero]) {
-      return @"__PAGEZERO segment missing/bad!";
-    }
-    return nil;
-  };
-}
-
-- (SNTAttributeBlock)codeSigned {
-  return ^id (SNTCommandFileInfo *fi) {
-    NSError *error;
-    fi.csc = [[MOLCodesignChecker alloc] initWithBinaryPath:fi.filePath error:&error];
-    if (error) {
-      switch (error.code) {
-        case errSecCSUnsigned:
-          return @"No";
-        case errSecCSSignatureFailed:
-        case errSecCSStaticCodeChanged:
-        case errSecCSSignatureNotVerifiable:
-        case errSecCSSignatureUnsupported:
-          return @"Yes, but code/signature changed/unverifiable";
-        case errSecCSResourceDirectoryFailed:
-        case errSecCSResourceNotSupported:
-        case errSecCSResourceRulesInvalid:
-        case errSecCSResourcesInvalid:
-        case errSecCSResourcesNotFound:
-        case errSecCSResourcesNotSealed:
-          return @"Yes, but resources invalid";
-        case errSecCSReqFailed:
-        case errSecCSReqInvalid:
-        case errSecCSReqUnsupported:
-          return @"Yes, but failed requirement validation";
-        case errSecCSInfoPlistFailed:
-          return @"Yes, but can't validate as Info.plist is missing";
-        default: {
-          return [NSString stringWithFormat:@"Yes, but failed to validate (%ld)", error.code];
-        }
-      }
-    } else if (fi.csc.signatureFlags & kSecCodeSignatureAdhoc) {
-      return @"Yes, but ad-hoc";
-    } else {
-      return @"Yes";
-    }
-  };
-}
-
-- (SNTAttributeBlock)rule {
-  return ^id (SNTCommandFileInfo *fi) {
-    __block SNTEventState s;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      [fi.daemonConn resume];
-    });
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    if (!fi.csc) {
-      NSError *error;
-      fi.csc = [[MOLCodesignChecker alloc] initWithBinaryPath:fi.path(fi) error:&error];
-    }
-    [[fi.daemonConn remoteObjectProxy] decisionForFilePath:fi.path(fi)
-                                                fileSHA256:fi.propertyMap[kSHA256](fi)
-                                         certificateSHA256:fi.csc.leafCertificate.SHA256
-                                                     reply:^(SNTEventState state) {
-      if (state) s = state;
-      dispatch_semaphore_signal(sema);
-    }];
-    if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC))) {
-      return @"Cannot communicate with daemon";
-    } else {
-      NSMutableString *output =
-          (SNTEventStateAllow & s) ? @"Whitelisted".mutableCopy : @"Blacklisted".mutableCopy;
-      switch (s) {
-        case SNTEventStateAllowUnknown:
-        case SNTEventStateBlockUnknown:
-          [output appendString:@" (Unknown)"];
-          break;
-        case SNTEventStateAllowBinary:
-        case SNTEventStateBlockBinary:
-          [output appendString:@" (Binary)"];
-          break;
-        case SNTEventStateAllowCertificate:
-        case SNTEventStateBlockCertificate:
-          [output appendString:@" (Certificate)"];
-          break;
-        case SNTEventStateAllowScope:
-        case SNTEventStateBlockScope:
-          [output appendString:@" (Scope)"];
-          break;
-        default:
-          output = @"None".mutableCopy;
-          break;
-      }
-      if (PrettyOutput()) {
-        if ((SNTEventStateAllow & s)) {
-          [output insertString:@"\033[32m" atIndex:0];
-          [output appendString:@"\033[0m"];
-        } else if ((SNTEventStateBlock & s)) {
-          [output insertString:@"\033[31m" atIndex:0];
-          [output appendString:@"\033[0m"];
-        } else {
-          [output insertString:@"\033[33m" atIndex:0];
-          [output appendString:@"\033[0m"];
-        }
-      }
-      return output.copy;
-    }
-  };
-}
-
-- (SNTAttributeBlock)signingChain {
-  return ^id (SNTCommandFileInfo *fi) {
-    if (!fi.csc) {
-      NSError *error;
-      fi.csc = [[MOLCodesignChecker alloc] initWithBinaryPath:fi.filePath error:&error];
-    }
-    if (fi.csc.certificates.count) {
-      NSMutableArray *certs = [[NSMutableArray alloc] initWithCapacity:fi.csc.certificates.count];
-      [fi.csc.certificates enumerateObjectsUsingBlock:^(MOLCertificate *c, unsigned long idx,
-                                                        BOOL *stop) {
-        [certs addObject:@{ kSHA256 : c.SHA256 ?: @"null",
-                            kSHA1 : c.SHA1 ?: @"null",
-                            kCommonName : c.commonName ?: @"null",
-                            kOrganization : c.orgName ?: @"null",
-                            kOrganizationalUnit : c.orgUnit ?: @"null",
-                            kValidFrom : [fi.dateFormatter stringFromDate:c.validFrom] ?: @"null",
-                            kValidUntil : [fi.dateFormatter stringFromDate:c.validUntil]
-                                ?: @"null"
-                          }];
-      }];
-      return certs;
-    }
-    return nil;
-  };
-}
-
-- (NSString *)humanReadableFileType:(SNTFileInfo *)fi {
-  if ([fi isScript]) return @"Script";
-  if ([fi isExecutable]) return @"Executable";
-  if ([fi isDylib]) return @"Dynamic Library";
-  if ([fi isBundle]) return @"Bundle/Plugin";
-  if ([fi isKext]) return @"Kernel Extension";
-  if ([fi isXARArchive]) return @"XAR Archive";
-  if ([fi isDMG]) return @"Disk Image";
-  return @"Unknown";
-}
 
 #pragma mark SNTCommand protocol methods
 
@@ -382,125 +93,28 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 + (NSString *)longHelpText {
   return [NSString stringWithFormat:
-             @"The details provided will be the same ones Santa uses to make a decision\n"
-             @"about executables. This includes SHA-256, SHA-1, code signing information and\n"
-             @"the type of file."
-             @"\n"
-             @"Usage: santactl fileinfo [options] [file-paths]\n"
-             @"    --json: output in json format\n"
-             @"    --key: search and return this one piece of information\n"
-             @"           valid Keys:\n"
-             @"%@\n"
-             @"           valid keys when using --cert-index:\n"
-             @"%@\n"
-             @"    --cert-index: an integer corresponding to a certificate of the signing chain\n"
-             @"                  1 for the leaf certificate\n"
-             @"                  -1 for the root certificate\n"
-             @"                  2 and up for the intermediates / root\n"
-             @"\n"
-             @"Examples: santactl fileinfo --cert-index 1 --key SHA-256 --json /usr/bin/yes\n"
-             @"          santactl fileinfo --key SHA-256 --json /usr/bin/yes\n"
-             @"          santactl fileinfo /usr/bin/yes /bin/*\n",
-             [self printKeyArray:[self fileInfoKeys]],
-             [self printKeyArray:[self signingChainKeys]]];
+          @"The details provided will be the same ones Santa uses to make a decision\n"
+          @"about executables. This includes SHA-256, SHA-1, code signing information and\n"
+          @"the type of file."
+          @"\n"
+          @"Usage: santactl fileinfo [options] [file-paths]\n"
+          @"    --json: output in json format\n"
+          @"    --key: search and return this one piece of information\n"
+          @"           valid Keys:\n"
+          @"%@\n"
+          @"           valid keys when using --cert-index:\n"
+          @"%@\n"
+          @"    --cert-index: an integer corresponding to a certificate of the signing chain\n"
+          @"                  1 for the leaf certificate\n"
+          @"                  -1 for the root certificate\n"
+          @"                  2 and up for the intermediates / root\n"
+          @"\n"
+          @"Examples: santactl fileinfo --cert-index 1 --key SHA-256 --json /usr/bin/yes\n"
+          @"          santactl fileinfo --key SHA-256 --json /usr/bin/yes\n"
+          @"          santactl fileinfo /usr/bin/yes /bin/*\n",
+          printKeyArray([self fileInfoKeys]),
+          printKeyArray([self signingChainKeys])];
 }
-
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
-  if (!arguments.count) [self printErrorUsageAndExit:@"No arguments"];
-
-  NSString *key;
-  NSNumber *certIndex;
-  NSArray *filePaths;
-
-  [self parseArguments:arguments
-                forKey:&key
-             certIndex:&certIndex
-            jsonOutput:&json
-             filePaths:&filePaths];
-
-  // Only access outputHashes from the outputHashesQueue
-  __block NSMutableArray *outputHashes = [[NSMutableArray alloc] initWithCapacity:filePaths.count];
-  dispatch_group_t outputHashesGroup = dispatch_group_create();
-  dispatch_queue_t outputHashesQueue =
-      dispatch_queue_create("com.google.santa.outputhashes", DISPATCH_QUEUE_SERIAL);
-
-  __block NSOperationQueue *hashQueue = [[NSOperationQueue alloc] init];
-  hashQueue.maxConcurrentOperationCount = 15;
-
-  __block NSUInteger hashed = 0;
-
-  [filePaths enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-    NSBlockOperation *hashOperation = [NSBlockOperation blockOperationWithBlock:^{
-      if (PrettyOutput()) printf("\rCalculating %lu/%lu", ++hashed, filePaths.count);
-
-      SNTCommandFileInfo *fi = [[self alloc] initWithFilePath:obj daemonConnection:daemonConn];
-      if (!fi.fileInfo) return;
-
-      __block NSMutableDictionary *outputHash = [[NSMutableDictionary alloc] init];
-
-      if (key && !certIndex) {
-        SNTAttributeBlock block = fi.propertyMap[key];
-        outputHash[key] = block(fi);
-      } else if (certIndex) {
-        NSArray *signingChain = fi.signingChain(fi);
-        if (key) {
-          if ([certIndex isEqual:@(-1)]) {
-            outputHash[key] = signingChain.lastObject[key];
-          } else {
-            if (certIndex.unsignedIntegerValue - 1 < signingChain.count) {
-              outputHash[key] = signingChain[certIndex.unsignedIntegerValue - 1][key];
-            }
-          }
-        } else {
-          if ([certIndex isEqual:@(-1)]) {
-            outputHash[kSigningChain] = @[ signingChain.lastObject ?: @{} ];
-          } else {
-            NSMutableArray *indexedCert = [NSMutableArray arrayWithCapacity:signingChain.count];
-            [signingChain enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-              if (certIndex.unsignedIntegerValue - 1 == idx) {
-                [indexedCert addObject:obj];
-              } else {
-                [indexedCert addObject:[NSNull null]];
-              }
-            }];
-            if (indexedCert.count) outputHash[kSigningChain] = indexedCert;
-          }
-        }
-      } else {
-        NSString *sha1, *sha256;
-        [fi.fileInfo hashSHA1:&sha1 SHA256:&sha256];
-        fi.propertyMap[kSHA1] = ^id (SNTCommandFileInfo *fi) { return sha1; };
-        fi.propertyMap[kSHA256] = ^id (SNTCommandFileInfo *fi) { return sha256; };
-        [fi.propertyMap enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-          SNTAttributeBlock block = obj;
-          outputHash[key] = block(fi);
-        }];
-      }
-      if (outputHash.count) {
-        dispatch_group_async(outputHashesGroup, outputHashesQueue, ^{
-          [outputHashes addObject:outputHash];
-        });
-      }
-    }];
-    
-    hashOperation.qualityOfService = NSQualityOfServiceUserInitiated;
-    [hashQueue addOperation:hashOperation];
-  }];
-
-  // Wait for all the calculating threads to finish
-  [hashQueue waitUntilAllOperationsAreFinished];
-
-  // Clear the "Calculating ..." indicator if present
-  if (PrettyOutput()) printf("\33[2K\r");
-
-  // Wait for all the writes to the outputHashes to finish
-  dispatch_group_wait(outputHashesGroup, DISPATCH_TIME_FOREVER);
-
-  if (outputHashes.count) [self printOutputHashes:outputHashes];
-  exit(0);
-}
-
-#pragma mark FileInfo helper methods
 
 + (NSArray *)fileInfoKeys {
   return @[ kPath, kSHA256, kSHA1, kBundleName, kBundleVersion, kBundleVersionStr,
@@ -513,21 +127,113 @@ REGISTER_COMMAND_NAME(@"fileinfo")
             kValidUntil ];
 }
 
-+ (NSString *)printKeyArray:(NSArray *)array {
-  __block NSMutableString *string = [[NSMutableString alloc] init];
-  [array enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-    [string appendString:[NSString stringWithFormat:@"                       \"%@\"\n", obj]];
-  }];
-  return string;
+- (instancetype)initWithDaemonConnection:(SNTXPCConnection *)daemonConn {
+  self = [super initWithDaemonConnection:daemonConn];
+  if (!self) return nil;
+  _prettyOutput = isatty(STDOUT_FILENO) && !json;
+  return self;
 }
 
-+ (void)printErrorUsageAndExit:(NSString *)error {
-  printf("%s\n\n", [error UTF8String]);
-  printf("%s\n", [[self longHelpText] UTF8String]);
-  exit(1);
+- (void)runWithArguments:(NSArray *)arguments {
+  if (!arguments.count) [self printErrorUsageAndExit:@"No arguments"];
+
+  NSString *key;
+  NSNumber *certIndex;
+  NSArray *filePaths;
+
+  [self parseArguments:arguments
+                forKey:&key
+             certIndex:&certIndex
+            jsonOutput:&json
+             filePaths:&filePaths];
+
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSString *cwd = [fm currentDirectoryPath];
+  for (NSString *path in filePaths) {
+    NSString *fullPath = [path stringByStandardizingPath];
+    if ([path characterAtIndex:0] != '/') {
+      fullPath = [cwd stringByAppendingPathComponent:fullPath];
+    }
+    [self recurseAtPath:fullPath indent:0];
+  }
+  exit(0);
 }
 
-+ (void)parseArguments:(NSArray *)args
+- (void)recurseAtPath:(NSString *)path indent:(int)indent {
+  NSFileManager *fm = [NSFileManager defaultManager];
+  BOOL isDir = NO;
+  if (![fm fileExistsAtPath:path isDirectory:&isDir]) return;
+  if (isDir) {
+    NSDirectoryEnumerator<NSString *> * dirEnum = [fm enumeratorAtPath:path];
+    for (NSString *file in dirEnum) {
+      NSString *filepath = [path stringByAppendingPathComponent:file];
+      if ([fm fileExistsAtPath:filepath isDirectory:&isDir] && isDir) {
+        if (self.prettyOutput) printf("\033[93m");
+        printf("\n%s:\n", [filepath UTF8String]);
+        if (self.prettyOutput) printf("\033[0m");
+      } else {
+        [self processFile:filepath];
+      }
+    }
+  } else {
+    [self processFile:path];
+  }
+}
+
+- (NSString *)ruleForFileInfo:(SNTFileInfo *)fileInfo {
+  static dispatch_once_t token;
+  dispatch_once(&token, ^{ [self.daemonConn resume]; });
+  __block SNTEventState s;
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  [[self.daemonConn remoteObjectProxy] decisionForFilePath:fileInfo.path
+                                                fileSHA256:fileInfo.SHA256
+                                         certificateSHA256:nil
+                                                     reply:^(SNTEventState state) {
+                                                       s = state;
+                                                       dispatch_semaphore_signal(sema);
+                                                     }];
+  if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC))) {
+    return @"Cannot communicate with daemon";
+  } else {
+    NSMutableString *output =
+    (SNTEventStateAllow & s) ? @"Whitelisted".mutableCopy : @"Blacklisted".mutableCopy;
+    switch (s) {
+      case SNTEventStateAllowUnknown:
+      case SNTEventStateBlockUnknown:
+        [output appendString:@" (Unknown)"];
+        break;
+      case SNTEventStateAllowBinary:
+      case SNTEventStateBlockBinary:
+        [output appendString:@" (Binary)"];
+        break;
+      case SNTEventStateAllowCertificate:
+      case SNTEventStateBlockCertificate:
+        [output appendString:@" (Certificate)"];
+        break;
+      case SNTEventStateAllowScope:
+      case SNTEventStateBlockScope:
+        [output appendString:@" (Scope)"];
+        break;
+      default:
+        output = @"None".mutableCopy;
+        break;
+    }
+    return output.copy;
+  }
+}
+
+- (void)processFile:(NSString *)path {
+  SNTFileInfo *fileInfo = [[SNTFileInfo alloc] initWithResolvedPath:path error:nil];
+  printf("path:\t%s\n", [path UTF8String]);
+  printf("SHA256:\t%s\n", [fileInfo.SHA256 UTF8String]);
+  printf("fileSize:\t%lu\n", fileInfo.fileSize);
+  printf("executable:\t%s\n", fileInfo.isExecutable ? "YES" : "NO");
+  printf("rule:\t%s\n", [[self ruleForFileInfo:fileInfo] UTF8String]);
+}
+
+
+// We can convert all of this stuff to property vars now.
+- (void)parseArguments:(NSArray *)args
                 forKey:(NSString **)key
              certIndex:(NSNumber **)certIndex
             jsonOutput:(BOOL *)jsonOutput
@@ -552,10 +258,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       [paths addObject:args[idx]];
     }
   }];
-  if (*key && !*certIndex && ![self.fileInfoKeys containsObject:*key]) {
+  if (*key && !*certIndex && ![[[self class] fileInfoKeys] containsObject:*key]) {
     [self printErrorUsageAndExit:
         [NSString stringWithFormat:@"\n\"%@\" is an invalid key", *key]];
-  } else if (*key && *certIndex && ![self.signingChainKeys containsObject:*key]) {
+  } else if (*key && *certIndex && ![[[self class] signingChainKeys] containsObject:*key]) {
     [self printErrorUsageAndExit:
         [NSString stringWithFormat:@"\n\"%@\" is an invalid key when using --cert-index", *key]];
   } else if ([@(0) isEqual:*certIndex]) {
@@ -565,67 +271,5 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   *filePaths = paths.copy;
 }
 
-+ (void)printOutputHashes:(NSArray *)outputHashes {
-  if (json) {
-    id object = (outputHashes.count > 1) ? outputHashes : outputHashes.firstObject;
-    if (!object) return;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:object
-                                                       options:NSJSONWritingPrettyPrinted
-                                                         error:NULL];
-    printf("%s\n", [[NSString alloc] initWithData:jsonData
-                                         encoding:NSUTF8StringEncoding].UTF8String);
-    return;
-  }
-
-  [outputHashes enumerateObjectsUsingBlock:^(id outputHash, NSUInteger idx, BOOL *stop) {
-    if ([outputHash count] == 1) {
-      return [self printValueFromOutputHash:outputHash];
-    }
-    [self.fileInfoKeys enumerateObjectsUsingBlock:^(id key, NSUInteger idx, BOOL *stop) {
-      [self printValueForKey:key fromOutputHash:outputHash];
-    }];
-    printf("\n");
-  }];
-}
-
-+ (void)printValueForKey:(NSString *)key fromOutputHash:(NSDictionary *)outputHash {
-  id value = outputHash[key];
-  if (!value) return;
-  if ([key isEqualToString:kSigningChain]) {
-    return [self printSigningChain:value];
-  }
-  printf("%-21s: %s\n", [key UTF8String], [value UTF8String]);
-}
-
-+ (void)printValueFromOutputHash:(NSDictionary *)outputHash {
-  if ([[[outputHash allKeys] firstObject] isEqualToString:kSigningChain]) {
-    return [self printSigningChain:[[outputHash allValues] firstObject]];
-  }
-  printf("%s\n", [[[outputHash allValues] firstObject] UTF8String]);
-}
-
-+ (void)printSigningChain:(NSArray *)signingChain {
-  if (!signingChain) return;
-  printf("%s:\n", kSigningChain.UTF8String);
-  __block int i = 0;
-  [signingChain enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-    if ([obj isEqual:[NSNull null]]) return;
-    if (i++) printf("\n");
-    printf("    %2lu. %-20s: %s\n", idx + 1, kSHA256.UTF8String,
-        ((NSString *)obj[kSHA256]).UTF8String);
-    printf("        %-20s: %s\n", kSHA1.UTF8String,
-        ((NSString *)obj[kSHA1]).UTF8String);
-    printf("        %-20s: %s\n", kCommonName.UTF8String,
-        ((NSString *)obj[kCommonName]).UTF8String);
-    printf("        %-20s: %s\n", kOrganization.UTF8String,
-        ((NSString *)obj[kOrganization]).UTF8String);
-    printf("        %-20s: %s\n", kOrganizationalUnit.UTF8String,
-        ((NSString *)obj[kOrganizationalUnit]).UTF8String);
-    printf("        %-20s: %s\n", kValidFrom.UTF8String,
-        ((NSString *)obj[kValidFrom]).UTF8String);
-    printf("        %-20s: %s\n", kValidUntil.UTF8String,
-        ((NSString *)obj[kValidUntil]).UTF8String);
-  }];
-}
-
+                         
 @end

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -336,7 +336,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     dispatch_once(&token, ^{ [cmd.daemonConn resume]; });
     __block SNTEventState state;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:nil];
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
     [[self.daemonConn remoteObjectProxy] decisionForFilePath:fileInfo.path
                                                   fileSHA256:fileInfo.SHA256
                                            certificateSHA256:csc.leafCertificate.SHA256
@@ -390,7 +390,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 - (SNTAttributeBlock)signingChain {
   return ^id (SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
-    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:nil];
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
     if (!csc.certificates.count) return nil;
     NSMutableArray *certs = [[NSMutableArray alloc] initWithCapacity:csc.certificates.count];
     for (MOLCertificate *c in csc.certificates) {

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -556,6 +556,9 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     }
   }
 
+  // If there's nothing in the outputDict, then don't need to print anything.
+  if (!outputDict.count) return;
+
   // Then display the information in the dictionary.  How we display it depends on
   // a) do we want JSON output?
   // b) is there only one key?

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -218,14 +218,12 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 - (SNTAttributeBlock)sha256 {
   return ^id (SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
-    [fileInfo precomputeSecureHashes];
     return fileInfo.SHA256;
   };
 }
 
 - (SNTAttributeBlock)sha1 {
   return ^id (SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
-    [fileInfo precomputeSecureHashes];
     return fileInfo.SHA1;
   };
 }

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -294,8 +294,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 - (SNTAttributeBlock)codeSigned {
   return ^id (SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
-    MOLCodesignChecker *csc = [fileInfo codesignChecker];
-    NSError *error = [fileInfo codesignCheckerError];
+    NSError *error;
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:&error];
     if (error) {
       switch (error.code) {
         case errSecCSUnsigned:
@@ -338,7 +338,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     dispatch_once(&token, ^{ [cmd.daemonConn resume]; });
     __block SNTEventState state;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    MOLCodesignChecker *csc = [fileInfo codesignChecker];
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:nil];
     [[self.daemonConn remoteObjectProxy] decisionForFilePath:fileInfo.path
                                                   fileSHA256:fileInfo.SHA256
                                            certificateSHA256:csc.leafCertificate.SHA256
@@ -392,7 +392,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
 - (SNTAttributeBlock)signingChain {
   return ^id (SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
-    MOLCodesignChecker *csc = [fileInfo codesignChecker];
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:nil];
     if (!csc.certificates.count) return nil;
     NSMutableArray *certs = [[NSMutableArray alloc] initWithCapacity:csc.certificates.count];
     for (MOLCertificate *c in csc.certificates) {

--- a/Source/santactl/Commands/SNTCommandFlushCache.m
+++ b/Source/santactl/Commands/SNTCommandFlushCache.m
@@ -21,7 +21,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandFlushCache : SNTCommand
+@interface SNTCommandFlushCache : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandFlushCache

--- a/Source/santactl/Commands/SNTCommandFlushCache.m
+++ b/Source/santactl/Commands/SNTCommandFlushCache.m
@@ -14,13 +14,14 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
 
 #import "SNTLogging.h"
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandFlushCache : NSObject<SNTCommand>
+@interface SNTCommandFlushCache : SNTCommand
 @end
 
 @implementation SNTCommandFlushCache
@@ -46,8 +47,8 @@ REGISTER_COMMAND_NAME(@"flushcache")
           @"Returns 0 if successful, 1 otherwise");
 }
 
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
-  [[daemonConn remoteObjectProxy] flushCache:^(BOOL success) {
+- (void)runWithArguments:(NSArray *)arguments {
+  [[self.daemonConn remoteObjectProxy] flushCache:^(BOOL success) {
     if (success) {
       LOGI(@"Cache flush requested");
       exit(0);

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -134,7 +134,7 @@ REGISTER_COMMAND_NAME(@"rule")
     if (newRule.type == SNTRuleTypeBinary) {
       newRule.shasum = fi.SHA256;
     } else if (newRule.type == SNTRuleTypeCertificate) {
-      MOLCodesignChecker *cs = [fi codesignCheckerWithError:nil];
+      MOLCodesignChecker *cs = [fi codesignCheckerWithError:NULL];
       newRule.shasum = cs.leafCertificate.SHA256;
     }
   }

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -134,7 +134,7 @@ REGISTER_COMMAND_NAME(@"rule")
     if (newRule.type == SNTRuleTypeBinary) {
       newRule.shasum = fi.SHA256;
     } else if (newRule.type == SNTRuleTypeCertificate) {
-      MOLCodesignChecker *cs = [fi codesignChecker];
+      MOLCodesignChecker *cs = [fi codesignCheckerWithError:nil];
       newRule.shasum = cs.leafCertificate.SHA256;
     }
   }

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -134,7 +134,7 @@ REGISTER_COMMAND_NAME(@"rule")
     if (newRule.type == SNTRuleTypeBinary) {
       newRule.shasum = fi.SHA256;
     } else if (newRule.type == SNTRuleTypeCertificate) {
-      MOLCodesignChecker *cs = [[MOLCodesignChecker alloc] initWithBinaryPath:fi.path];
+      MOLCodesignChecker *cs = [fi codesignChecker];
       newRule.shasum = cs.leafCertificate.SHA256;
     }
   }

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -14,21 +14,20 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
-
-#include "SNTLogging.h"
 
 #import "MOLCertificate.h"
 #import "MOLCodesignChecker.h"
 #import "SNTConfigurator.h"
 #import "SNTDropRootPrivs.h"
 #import "SNTFileInfo.h"
+#include "SNTLogging.h"
 #import "SNTRule.h"
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandRule : NSObject<SNTCommand>
-@property SNTXPCConnection *daemonConn;
+@interface SNTCommandRule : SNTCommand
 @end
 
 @implementation SNTCommandRule
@@ -68,13 +67,7 @@ REGISTER_COMMAND_NAME(@"rule")
           @"    --message {message}: custom message\n");
 }
 
-+ (void)printErrorUsageAndExit:(NSString *)error {
-  printf("%s\n\n", [error UTF8String]);
-  printf("%s\n", [[self longHelpText] UTF8String]);
-  exit(1);
-}
-
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)runWithArguments:(NSArray *)arguments {
   SNTConfigurator *config = [SNTConfigurator configurator];
   if ([config syncBaseURL] && ![arguments containsObject:@"--check"]) {
     printf("SyncBaseURL is set, rules are managed centrally.\n");
@@ -129,7 +122,7 @@ REGISTER_COMMAND_NAME(@"rule")
 
   if (check) {
     if (!newRule.shasum) return [self printErrorUsageAndExit:@"--check requires --sha256"];
-    return [self printStateOfRule:newRule daemonConnection:daemonConn];
+    return [self printStateOfRule:newRule daemonConnection:self.daemonConn];
   }
 
   if (path) {
@@ -152,7 +145,7 @@ REGISTER_COMMAND_NAME(@"rule")
     [self printErrorUsageAndExit:@"Either SHA-256 or path to file must be specified"];
   }
 
-  [[daemonConn remoteObjectProxy] databaseRuleAddRules:@[newRule]
+  [[self.daemonConn remoteObjectProxy] databaseRuleAddRules:@[newRule]
                                             cleanSlate:NO
                                                  reply:^(NSError *error) {
     if (error) {
@@ -170,7 +163,7 @@ REGISTER_COMMAND_NAME(@"rule")
   }];
 }
 
-+ (void)printStateOfRule:(SNTRule *)rule daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)printStateOfRule:(SNTRule *)rule daemonConnection:(SNTXPCConnection *)daemonConn {
   NSString *fileSHA256 = (rule.type == SNTRuleTypeBinary) ? rule.shasum : nil;
   NSString *certificateSHA256 = (rule.type == SNTRuleTypeCertificate) ? rule.shasum : nil;
   dispatch_group_t group = dispatch_group_create();

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -27,7 +27,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandRule : SNTCommand
+@interface SNTCommandRule : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandRule
@@ -146,8 +146,8 @@ REGISTER_COMMAND_NAME(@"rule")
   }
 
   [[self.daemonConn remoteObjectProxy] databaseRuleAddRules:@[newRule]
-                                            cleanSlate:NO
-                                                 reply:^(NSError *error) {
+                                                 cleanSlate:NO
+                                                      reply:^(NSError *error) {
     if (error) {
       printf("Failed to modify rules: %s", [error.localizedDescription UTF8String]);
       LOGD(@"Failure reason: %@", error.localizedFailureReason);

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -14,13 +14,14 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
 
 #import "SNTConfigurator.h"
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandStatus : NSObject<SNTCommand>
+@interface SNTCommandStatus : SNTCommand
 @end
 
 @implementation SNTCommandStatus
@@ -44,7 +45,7 @@ REGISTER_COMMAND_NAME(@"status")
           @"  Use --json to output in JSON format");
 }
 
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)runWithArguments:(NSArray *)arguments {
   dispatch_group_t group = dispatch_group_create();
 
   // Daemon status
@@ -52,7 +53,7 @@ REGISTER_COMMAND_NAME(@"status")
   __block uint64_t cpuEvents, ramEvents;
   __block double cpuPeak, ramPeak;
   dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] clientMode:^(SNTClientMode cm) {
+  [[self.daemonConn remoteObjectProxy] clientMode:^(SNTClientMode cm) {
     switch (cm) {
       case SNTClientModeMonitor:
         clientMode = @"Monitor";
@@ -67,7 +68,7 @@ REGISTER_COMMAND_NAME(@"status")
     dispatch_group_leave(group);
   }];
   dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] watchdogInfo:^(uint64_t wd_cpuEvents, uint64_t wd_ramEvents,
+  [[self.daemonConn remoteObjectProxy] watchdogInfo:^(uint64_t wd_cpuEvents, uint64_t wd_ramEvents,
                                                  double wd_cpuPeak, double wd_ramPeak) {
     cpuEvents = wd_cpuEvents;
     cpuPeak = wd_cpuPeak;
@@ -81,7 +82,7 @@ REGISTER_COMMAND_NAME(@"status")
   // Kext status
   __block int64_t cacheCount = -1;
   dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] cacheCount:^(int64_t count) {
+  [[self.daemonConn remoteObjectProxy] cacheCount:^(int64_t count) {
     cacheCount = count;
     dispatch_group_leave(group);
   }];
@@ -89,13 +90,13 @@ REGISTER_COMMAND_NAME(@"status")
   // Database counts
   __block int64_t eventCount = -1, binaryRuleCount = -1, certRuleCount = -1;
   dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] databaseRuleCounts:^(int64_t binary, int64_t certificate) {
+  [[self.daemonConn remoteObjectProxy] databaseRuleCounts:^(int64_t binary, int64_t certificate) {
     binaryRuleCount = binary;
     certRuleCount = certificate;
     dispatch_group_leave(group);
   }];
   dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] databaseEventCount:^(int64_t count) {
+  [[self.daemonConn remoteObjectProxy] databaseEventCount:^(int64_t count) {
     eventCount = count;
     dispatch_group_leave(group);
   }];
@@ -114,7 +115,7 @@ REGISTER_COMMAND_NAME(@"status")
   __block BOOL pushNotifications = NO;
   if ([[SNTConfigurator configurator] syncBaseURL]) {
     dispatch_group_enter(group);
-    [[daemonConn remoteObjectProxy] pushNotifications:^(BOOL response) {
+    [[self.daemonConn remoteObjectProxy] pushNotifications:^(BOOL response) {
       pushNotifications = response;
       dispatch_group_leave(group);
     }];
@@ -123,7 +124,7 @@ REGISTER_COMMAND_NAME(@"status")
   __block BOOL bundlesEnabled = NO;
   if ([[SNTConfigurator configurator] syncBaseURL]) {
     dispatch_group_enter(group);
-    [[daemonConn remoteObjectProxy] bundlesEnabled:^(BOOL response) {
+    [[self.daemonConn remoteObjectProxy] bundlesEnabled:^(BOOL response) {
       bundlesEnabled = response;
       dispatch_group_leave(group);
     }];

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -21,7 +21,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandStatus : SNTCommand
+@interface SNTCommandStatus : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandStatus
@@ -69,7 +69,7 @@ REGISTER_COMMAND_NAME(@"status")
   }];
   dispatch_group_enter(group);
   [[self.daemonConn remoteObjectProxy] watchdogInfo:^(uint64_t wd_cpuEvents, uint64_t wd_ramEvents,
-                                                 double wd_cpuPeak, double wd_ramPeak) {
+                                                      double wd_cpuPeak, double wd_ramPeak) {
     cpuEvents = wd_cpuEvents;
     cpuPeak = wd_cpuPeak;
     ramEvents = wd_ramEvents;

--- a/Source/santactl/Commands/SNTCommandVersion.m
+++ b/Source/santactl/Commands/SNTCommandVersion.m
@@ -23,7 +23,7 @@
 #import "SNTKernelCommon.h"
 #import "SNTXPCConnection.h"
 
-@interface SNTCommandVersion : SNTCommand
+@interface SNTCommandVersion : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandVersion

--- a/Source/santactl/Commands/SNTCommandVersion.m
+++ b/Source/santactl/Commands/SNTCommandVersion.m
@@ -13,17 +13,17 @@
 ///    limitations under the License.
 
 @import Foundation;
-
-#import "SNTCommandController.h"
-
 @import IOKit.kext;
+
+#import "SNTCommand.h"
+#import "SNTCommandController.h"
 
 #import "SNTCommonEnums.h"
 #import "SNTFileInfo.h"
 #import "SNTKernelCommon.h"
 #import "SNTXPCConnection.h"
 
-@interface SNTCommandVersion : NSObject<SNTCommand>
+@interface SNTCommandVersion : SNTCommand
 @end
 
 @implementation SNTCommandVersion
@@ -47,7 +47,7 @@ REGISTER_COMMAND_NAME(@"version")
           @"  Use --json to output in JSON format.");
 }
 
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)runWithArguments:(NSArray *)arguments {
   if ([arguments containsObject:@"--json"]) {
     NSDictionary *versions = @{
       @"santa-driver" : [self santaKextVersion],
@@ -70,7 +70,7 @@ REGISTER_COMMAND_NAME(@"version")
   exit(0);
 }
 
-+ (NSString *)santaKextVersion {
+- (NSString *)santaKextVersion {
   NSDictionary *loadedKexts = CFBridgingRelease(
       KextManagerCopyLoadedKextInfo((__bridge CFArrayRef) @[ @(USERCLIENT_ID) ],
                                     (__bridge CFArrayRef) @[ @"CFBundleVersion" ]));
@@ -87,18 +87,18 @@ REGISTER_COMMAND_NAME(@"version")
   return @"not found";
 }
 
-+ (NSString *)santadVersion {
+- (NSString *)santadVersion {
   SNTFileInfo *daemonInfo = [[SNTFileInfo alloc] initWithPath:@(kSantaDPath)];
   return daemonInfo.bundleVersion;
 }
 
-+ (NSString *)santaAppVersion {
+- (NSString *)santaAppVersion {
   SNTFileInfo *guiInfo =
       [[SNTFileInfo alloc] initWithPath:@"/Applications/Santa.app/Contents/MacOS/Santa"];
   return guiInfo.bundleVersion;
 }
 
-+ (NSString *)santactlVersion {
+- (NSString *)santactlVersion {
   return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
 }
 

--- a/Source/santactl/Commands/sync/SNTCommandSync.m
+++ b/Source/santactl/Commands/sync/SNTCommandSync.m
@@ -24,7 +24,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandSync : SNTCommand
+@interface SNTCommandSync : SNTCommand<SNTCommandProtocol>
 @property SNTXPCConnection *listener;
 @property SNTCommandSyncManager *syncManager;
 @end

--- a/Source/santactl/Commands/sync/SNTCommandSync.m
+++ b/Source/santactl/Commands/sync/SNTCommandSync.m
@@ -14,6 +14,7 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
 #import "SNTCommandController.h"
 
 #import "SNTCommandSyncManager.h"
@@ -23,7 +24,7 @@
 #import "SNTXPCConnection.h"
 #import "SNTXPCControlInterface.h"
 
-@interface SNTCommandSync : NSObject<SNTCommand>
+@interface SNTCommandSync : SNTCommand
 @property SNTXPCConnection *listener;
 @property SNTCommandSyncManager *syncManager;
 @end
@@ -54,7 +55,7 @@ REGISTER_COMMAND_NAME(@"sync")
           @"           clean sync from the server.");
 }
 
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+- (void)runWithArguments:(NSArray *)arguments {
   // Ensure we have no privileges
   if (!DropRootPrivileges()) {
     LOGE(@"Failed to drop root privileges. Exiting.");
@@ -66,10 +67,9 @@ REGISTER_COMMAND_NAME(@"sync")
     exit(1);
   }
 
-  SNTCommandSync *s = [[self alloc] init];
-  [daemonConn resume];
+  [self.daemonConn resume];
   BOOL daemon = [arguments containsObject:@"--daemon"];
-  s.syncManager = [[SNTCommandSyncManager alloc] initWithDaemonConnection:daemonConn
+  self.syncManager = [[SNTCommandSyncManager alloc] initWithDaemonConnection:self.daemonConn
                                                                  isDaemon:daemon];
 
   // Dropping root privileges to the 'nobody' user causes the default NSURLCache to throw
@@ -78,8 +78,8 @@ REGISTER_COMMAND_NAME(@"sync")
                                                               diskCapacity:0
                                                                   diskPath:nil]];
 
-  if (!s.syncManager.daemon) return [s.syncManager fullSync];
-  [s syncdWithDaemonConnection:daemonConn];
+  if (!self.syncManager.daemon) return [self.syncManager fullSync];
+  [self syncdWithDaemonConnection:self.daemonConn];
 }
 
 #pragma mark daemon methods

--- a/Source/santactl/Commands/sync/SNTCommandSync.m
+++ b/Source/santactl/Commands/sync/SNTCommandSync.m
@@ -70,7 +70,7 @@ REGISTER_COMMAND_NAME(@"sync")
   [self.daemonConn resume];
   BOOL daemon = [arguments containsObject:@"--daemon"];
   self.syncManager = [[SNTCommandSyncManager alloc] initWithDaemonConnection:self.daemonConn
-                                                                 isDaemon:daemon];
+                                                                    isDaemon:daemon];
 
   // Dropping root privileges to the 'nobody' user causes the default NSURLCache to throw
   // sandbox errors, which are benign but annoying. This line disables the cache entirely.

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -195,11 +195,11 @@ static void reachabilityHandler(
     self.FCMClient = nil;
     [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:kDefaultFullSyncInterval];
   };
-  
+
   self.FCMClient.loggingBlock = ^(NSString *log) {
     LOGD(@"%@", log);
   };
-  
+
   [self.FCMClient connect];
 }
 
@@ -464,7 +464,7 @@ static void reachabilityHandler(
   } else if ([config syncClientAuthCertificateIssuer]) {
     authURLSession.clientCertIssuerCn = [config syncClientAuthCertificateIssuer];
   }
-  
+
   syncState.session = [authURLSession session];
   syncState.daemonConn = self.daemonConn;
   syncState.daemon = self.daemon;

--- a/Source/santactl/SNTCommand.h
+++ b/Source/santactl/SNTCommand.h
@@ -1,0 +1,64 @@
+/// Copyright 2017 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+@import Foundation;
+
+@class SNTXPCConnection;
+
+@protocol SNTCommandProtocol <NSObject>
+
+///
+///  @return YES if command requires root.
+///
++ (BOOL)requiresRoot;
+
+///
+///  @return YES if command requires connection to santad.
+///
++ (BOOL)requiresDaemonConn;
+
+///
+///  A small summary of the command, to be printed with the list of available commands
+///
++ (NSString *)shortHelpText;
+
+///
+///  A longer description of the command when the user runs <tt>santactl help x</tt>
+///
++ (NSString *)longHelpText;
+
+///
+///  Called when the user is running the command
+///  @param arguments an array of arguments passed in
+///  @param daemonConn connection to santad. Will be nil if connection failed or
+///      if @c requiresDaemonConn is @c NO
+///
+///  @note This method (or one of the methods it calls) is responsible for calling exit().
+///
++ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn;
+
+@end
+
+@interface SNTCommand : NSObject<SNTCommandProtocol>
+
+@property SNTXPCConnection *daemonConn;
+
+///  Designated initializer
+- (instancetype)initWithDaemonConnection:(SNTXPCConnection *)daemonConn;
+
+- (void)runWithArguments:(NSArray *)arguments;
+
+- (void)printErrorUsageAndExit:(NSString *)error;
+@end
+

--- a/Source/santactl/SNTCommand.h
+++ b/Source/santactl/SNTCommand.h
@@ -16,7 +16,7 @@
 
 @class SNTXPCConnection;
 
-@protocol SNTCommandProtocol <NSObject>
+@protocol SNTCommandProtocol
 
 ///
 ///  @return YES if command requires root.
@@ -38,6 +38,10 @@
 ///
 + (NSString *)longHelpText;
 
+@end
+
+@protocol SNTCommandRunProtocol
+
 ///
 ///  Called when the user is running the command
 ///  @param arguments an array of arguments passed in
@@ -50,9 +54,9 @@
 
 @end
 
-@interface SNTCommand : NSObject<SNTCommandProtocol>
+@interface SNTCommand : NSObject<SNTCommandRunProtocol>
 
-@property SNTXPCConnection *daemonConn;
+@property(nonatomic,readonly) SNTXPCConnection *daemonConn;
 
 ///  Designated initializer
 - (instancetype)initWithDaemonConnection:(SNTXPCConnection *)daemonConn;

--- a/Source/santactl/SNTCommand.m
+++ b/Source/santactl/SNTCommand.m
@@ -16,11 +16,6 @@
 
 @implementation SNTCommand
 
-+ (BOOL)requiresRoot { return NO; }
-+ (BOOL)requiresDaemonConn { return NO; }
-+ (NSString *)shortHelpText { return @""; }
-+ (NSString *)longHelpText { return @""; }
-
 + (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
   id cmd = [[self alloc] initWithDaemonConnection:daemonConn];
   [cmd runWithArguments:arguments];
@@ -28,8 +23,9 @@
 
 - (instancetype)initWithDaemonConnection:(SNTXPCConnection *)daemonConn {
   self = [super init];
-  if (!self) return nil;
-  _daemonConn = daemonConn;
+  if (self) {
+    _daemonConn = daemonConn;
+  }
   return self;
 }
 

--- a/Source/santactl/SNTCommand.m
+++ b/Source/santactl/SNTCommand.m
@@ -1,10 +1,16 @@
-//
-//  SNTCommand.m
-//  Santa
-//
-//  Created by Phillip Nguyen on 8/4/17.
-//
-//
+/// Copyright 2017 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
 
 #import "SNTCommand.h"
 
@@ -28,12 +34,13 @@
 }
 
 - (void)runWithArguments:(NSArray *)arguments {
-  // print error message
+  // This method must be overridden.
+  [self doesNotRecognizeSelector:_cmd];
 }
 
 - (void)printErrorUsageAndExit:(NSString *)error {
-  printf("%s\n\n", [error UTF8String]);
-  printf("%s\n", [[[self class] longHelpText] UTF8String]);
+  fprintf(stderr, "%s\n\n", [error UTF8String]);
+  fprintf(stderr, "%s\n", [[[self class] longHelpText] UTF8String]);
   exit(1);
 }
 

--- a/Source/santactl/SNTCommand.m
+++ b/Source/santactl/SNTCommand.m
@@ -1,0 +1,40 @@
+//
+//  SNTCommand.m
+//  Santa
+//
+//  Created by Phillip Nguyen on 8/4/17.
+//
+//
+
+#import "SNTCommand.h"
+
+@implementation SNTCommand
+
++ (BOOL)requiresRoot { return NO; }
++ (BOOL)requiresDaemonConn { return NO; }
++ (NSString *)shortHelpText { return @""; }
++ (NSString *)longHelpText { return @""; }
+
++ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn {
+  id cmd = [[self alloc] initWithDaemonConnection:daemonConn];
+  [cmd runWithArguments:arguments];
+}
+
+- (instancetype)initWithDaemonConnection:(SNTXPCConnection *)daemonConn {
+  self = [super init];
+  if (!self) return nil;
+  _daemonConn = daemonConn;
+  return self;
+}
+
+- (void)runWithArguments:(NSArray *)arguments {
+  // print error message
+}
+
+- (void)printErrorUsageAndExit:(NSString *)error {
+  printf("%s\n\n", [error UTF8String]);
+  printf("%s\n", [[[self class] longHelpText] UTF8String]);
+  exit(1);
+}
+
+@end

--- a/Source/santactl/SNTCommandController.h
+++ b/Source/santactl/SNTCommandController.h
@@ -14,43 +14,9 @@
 
 @import Foundation;
 
+#import "SNTCommand.h"
+
 @class SNTXPCConnection;
-
-///
-///  Protocol that each command must adhere to.
-///
-@protocol SNTCommand<NSObject>
-
-///
-///  @return YES if command requires root.
-///
-+ (BOOL)requiresRoot;
-
-///
-///  @return YES if command requires connection to santad.
-///
-+ (BOOL)requiresDaemonConn;
-
-///
-///  A small summary of the command, to be printed with the list of available commands
-///
-+ (NSString *)shortHelpText;
-
-///
-///  A longer description of the command when the user runs <tt>santactl help x</tt>
-///
-+ (NSString *)longHelpText;
-
-///
-///  Called when the user is running the command
-///  @param arguments an array of arguments passed in
-///  @param daemonConn connection to santad. Will be nil if connection failed or
-///      if @c requiresDaemonConn is @c NO
-///
-///  @note This method (or one of the methods it calls) is responsible for calling exit().
-///
-+ (void)runWithArguments:(NSArray *)arguments daemonConnection:(SNTXPCConnection *)daemonConn;
-@end
 
 ///
 ///  Responsible for maintaining the list of available commands by name, printing their help text
@@ -64,7 +30,7 @@
 ///  Register a new command with the specified name. Do not use this directly, use the
 ///  @c REGISTER_COMMAND_NAME macro instead.
 ///
-+ (void)registerCommand:(Class<SNTCommand>)command named:(NSString *)name;
++ (void)registerCommand:(Class<SNTCommandProtocol>)command named:(NSString *)name;
 
 ///
 ///  @return a usage string listing all of the available commands

--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -24,7 +24,8 @@
 /// Value is the Class
 static NSMutableDictionary *registeredCommands;
 
-+ (void)registerCommand:(Class<SNTCommandProtocol>)command named:(NSString *)name {
++ (void)registerCommand:(Class<SNTCommandProtocol,SNTCommandRunProtocol>)command
+                  named:(NSString *)name {
   if (!registeredCommands) {
     registeredCommands = [NSMutableDictionary dictionary];
   }
@@ -86,7 +87,7 @@ static NSMutableDictionary *registeredCommands;
 }
 
 + (void)runCommandWithName:(NSString *)commandName arguments:(NSArray *)arguments {
-  Class<SNTCommandProtocol> command = registeredCommands[commandName];
+  Class<SNTCommandProtocol,SNTCommandRunProtocol> command = registeredCommands[commandName];
 
   if ([command requiresRoot] && getuid() != 0) {
     printf("The command '%s' requires root privileges.\n", [commandName UTF8String]);

--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -24,7 +24,7 @@
 /// Value is the Class
 static NSMutableDictionary *registeredCommands;
 
-+ (void)registerCommand:(Class<SNTCommandProtocol,SNTCommandRunProtocol>)command
++ (void)registerCommand:(Class<SNTCommandProtocol, SNTCommandRunProtocol>)command
                   named:(NSString *)name {
   if (!registeredCommands) {
     registeredCommands = [NSMutableDictionary dictionary];
@@ -87,7 +87,7 @@ static NSMutableDictionary *registeredCommands;
 }
 
 + (void)runCommandWithName:(NSString *)commandName arguments:(NSArray *)arguments {
-  Class<SNTCommandProtocol,SNTCommandRunProtocol> command = registeredCommands[commandName];
+  Class<SNTCommandProtocol, SNTCommandRunProtocol> command = registeredCommands[commandName];
 
   if ([command requiresRoot] && getuid() != 0) {
     printf("The command '%s' requires root privileges.\n", [commandName UTF8String]);

--- a/Source/santactl/SNTCommandController.m
+++ b/Source/santactl/SNTCommandController.m
@@ -24,7 +24,7 @@
 /// Value is the Class
 static NSMutableDictionary *registeredCommands;
 
-+ (void)registerCommand:(Class<SNTCommand>)command named:(NSString *)name {
++ (void)registerCommand:(Class<SNTCommandProtocol>)command named:(NSString *)name {
   if (!registeredCommands) {
     registeredCommands = [NSMutableDictionary dictionary];
   }
@@ -43,9 +43,9 @@ static NSMutableDictionary *registeredCommands;
 
   for (NSString *cmdName in
        [[registeredCommands allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]) {
-    Class<SNTCommand> cmd = registeredCommands[cmdName];
+    Class<SNTCommandProtocol> command = registeredCommands[cmdName];
     [helpText appendFormat:@"\t%*s - %@\n", longestCommandName,
-                           [cmdName UTF8String], [cmd shortHelpText]];
+                           [cmdName UTF8String], [command shortHelpText]];
   }
 
   [helpText appendFormat:@"\nSee 'santactl help <command>' to read about a specific subcommand."];
@@ -53,7 +53,7 @@ static NSMutableDictionary *registeredCommands;
 }
 
 + (NSString *)helpForCommandWithName:(NSString *)commandName {
-  Class<SNTCommand> command = registeredCommands[commandName];
+  Class<SNTCommandProtocol> command = registeredCommands[commandName];
   if (command) {
     NSString *shortHelp = [command shortHelpText];
     NSString *longHelp = [command longHelpText];
@@ -86,7 +86,7 @@ static NSMutableDictionary *registeredCommands;
 }
 
 + (void)runCommandWithName:(NSString *)commandName arguments:(NSArray *)arguments {
-  Class<SNTCommand> command = registeredCommands[commandName];
+  Class<SNTCommandProtocol> command = registeredCommands[commandName];
 
   if ([command requiresRoot] && getuid() != 0) {
     printf("The command '%s' requires root privileges.\n", [commandName UTF8String]);

--- a/Tests/LogicTests/SNTCommandFileInfoTest.m
+++ b/Tests/LogicTests/SNTCommandFileInfoTest.m
@@ -39,6 +39,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 @interface SNTCommandFileInfoTest : XCTestCase
 
 @property SNTCommandFileInfo *cfi;
+@property SNTFileInfo *fileInfo;
 @property id cscMock;
 
 @end
@@ -49,12 +50,14 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   [super setUp];
 
   self.cfi = [[SNTCommandFileInfo alloc] initWithDaemonConnection:nil];
+  self.fileInfo = [[SNTFileInfo alloc] initWithResolvedPath:@"/usr/bin/yes" error:nil];
   self.cscMock = OCMClassMock([MOLCodesignChecker class]);
   OCMStub([self.cscMock alloc]).andReturn(self.cscMock);
 }
 
 - (void)tearDown {
   self.cfi = nil;
+  self.fileInfo = nil;
   [self.cscMock stopMocking];
   self.cscMock = nil;
 
@@ -121,7 +124,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSUnsigned userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), @"No");
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), @"No");
 }
 
 - (void)testCodeSignedSignatureFailed {
@@ -129,7 +132,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSSignatureFailed userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedStaticCodeChanged {
@@ -137,7 +140,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSStaticCodeChanged userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedSignatureNotVerifiable {
@@ -145,7 +148,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSSignatureNotVerifiable userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedSignatureUnsupported {
@@ -153,7 +156,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSSignatureUnsupported userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedResourceDirectoryFailed {
@@ -161,7 +164,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourceDirectoryFailed userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedResourceNotSupported {
@@ -169,7 +172,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourceNotSupported userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedResourceRulesInvalid {
@@ -177,7 +180,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourceRulesInvalid userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedResourcesInvalid {
@@ -185,7 +188,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourcesInvalid userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedResourcesNotFound {
@@ -193,7 +196,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotFound userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedResourcesNotSealed {
@@ -201,7 +204,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSResourcesNotSealed userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedReqFailed {
@@ -209,7 +212,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSReqFailed userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedReqInvalid {
@@ -217,7 +220,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSReqInvalid userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedReqUnsupported {
@@ -225,7 +228,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSReqUnsupported userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedInfoPlistFailed {
@@ -233,7 +236,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:errSecCSInfoPlistFailed userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 - (void)testCodeSignedDefault {
@@ -241,7 +244,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
   NSError *err = [NSError errorWithDomain:@"" code:999 userInfo:nil];
   OCMStub([self.cscMock initWithBinaryPath:OCMOCK_ANY
                                      error:[OCMArg setTo:err]]).andReturn(self.cscMock);
-  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, nil), expected);
+  XCTAssertEqualObjects(self.cfi.codeSigned(self.cfi, self.fileInfo), expected);
 }
 
 @end

--- a/Tests/LogicTests/SNTEventTableTest.m
+++ b/Tests/LogicTests/SNTEventTableTest.m
@@ -43,7 +43,7 @@
 
 - (SNTStoredEvent *)createTestEvent {
   SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:@"/usr/bin/false"];
-  MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:nil];
+  MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:NULL];
   SNTStoredEvent *event;
   event = [[SNTStoredEvent alloc] init];
   event.idx = @(arc4random());

--- a/Tests/LogicTests/SNTEventTableTest.m
+++ b/Tests/LogicTests/SNTEventTableTest.m
@@ -43,7 +43,7 @@
 
 - (SNTStoredEvent *)createTestEvent {
   SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:@"/usr/bin/false"];
-  MOLCodesignChecker *csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:@"/usr/bin/false"];
+  MOLCodesignChecker *csInfo = [binInfo codesignChecker];
   SNTStoredEvent *event;
   event = [[SNTStoredEvent alloc] init];
   event.idx = @(arc4random());

--- a/Tests/LogicTests/SNTEventTableTest.m
+++ b/Tests/LogicTests/SNTEventTableTest.m
@@ -43,7 +43,7 @@
 
 - (SNTStoredEvent *)createTestEvent {
   SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:@"/usr/bin/false"];
-  MOLCodesignChecker *csInfo = [binInfo codesignChecker];
+  MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:nil];
   SNTStoredEvent *event;
   event = [[SNTStoredEvent alloc] init];
   event.idx = @(arc4random());


### PR DESCRIPTION
Sorry this is so large.  This implements the recursive fileinfo command and adds the ability to specify multiple --key flags.  I haven't implemented filtering yet, because it seemed like it was already too much change at once.

I rewrote the SNTCommand* classes so that they would behave more consistently.  They all inherit from SNTCommand and now all instantiate themselves in the same way before running, which means they all run as instances instead of some commands being implemented entirely with class methods.