### PR TITLE
Split kernel cache for root/non-root volume.

### DIFF
--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -555,8 +555,7 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
     NSData *d = [self.fileHandle readDataOfLength:range.length];
     if (d.length != range.length) return nil;
     return d;
-  }
-  @catch (NSException *e) {
+  } @catch (NSException *e) {
     return nil;
   }
 }

--- a/Source/common/SNTLogging.h
+++ b/Source/common/SNTLogging.h
@@ -24,13 +24,13 @@
 #include <IOKit/IOLib.h>
 
 #ifdef DEBUG
-#define LOGD(...) IOLog("D santa-driver: " __VA_ARGS__); IOLog("\n")
+#define LOGD(format, ...) IOLog("D santa-driver: " format "\n", ##__VA_ARGS__);
 #else  // DEBUG
-#define LOGD(...)
+#define LOGD(format, ...)
 #endif  // DEBUG
-#define LOGI(...) IOLog("I santa-driver: " __VA_ARGS__); IOLog("\n")
-#define LOGW(...) IOLog("W santa-driver: " __VA_ARGS__); IOLog("\n")
-#define LOGE(...) IOLog("E santa-driver: " __VA_ARGS__); IOLog("\n")
+#define LOGI(format, ...) IOLog("I santa-driver: " format "\n", ##__VA_ARGS__);
+#define LOGW(format, ...) IOLog("W santa-driver: " format "\n", ##__VA_ARGS__);
+#define LOGE(format, ...) IOLog("E santa-driver: " format "\n", ##__VA_ARGS__);
 
 #else  // KERNEL
 

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -33,7 +33,7 @@
 ///
 ///  Kernel ops
 ///
-- (void)cacheCount:(void (^)(int64_t))reply;
+- (void)cacheCounts:(void (^)(uint64_t rootCache, uint64_t nonRootCache))reply;
 - (void)flushCache:(void (^)(BOOL))reply;
 - (void)checkCacheForVnodeID:(uint64_t)vnodeID withReply:(void (^)(santa_action_t))reply;
 

--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -237,8 +237,12 @@ void SantaDecisionManager::RemoveFromCache(uint64_t identifier) {
   wakeup((void *)identifier);
 }
 
-uint64_t SantaDecisionManager::CacheCount() const {
-  return root_decision_cache_->count() + non_root_decision_cache_->count();
+uint64_t SantaDecisionManager::RootCacheCount() const {
+  return root_decision_cache_->count();
+}
+
+uint64_t SantaDecisionManager::NonRootCacheCount() const {
+  return non_root_decision_cache_->count();
 }
 
 void SantaDecisionManager::ClearCache(bool non_root_only) {

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -99,8 +99,8 @@ class SantaDecisionManager : public OSObject {
   uint64_t RootCacheCount() const;
   uint64_t NonRootCacheCount() const;
 
-  /// Clears the cache.
-  void ClearCache(bool non_root_only = true);
+  /// Clears the cache(s). If non_root_only is true, only the non-root cache is cleared.
+  void ClearCache(bool non_root_only = false);
 
   /// Increments the count of active callbacks pending.
   void IncrementListenerInvocations();

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -130,7 +130,7 @@ class SantaDecisionManager : public OSObject {
   void FileOpCallback(kauth_action_t action, const vnode_t vp,
                       const char *path, const char *new_path);
 
- protected:
+ private:
   /**
     While waiting for a response from the daemon, this is the maximum number of
     milliseconds to sleep for before checking the cache for a response.
@@ -244,7 +244,6 @@ class SantaDecisionManager : public OSObject {
     return (uint64_t)((sec * 1000000) + usec);
   }
 
- private:
   SantaCache<uint64_t> *root_decision_cache_;
   SantaCache<uint64_t> *non_root_decision_cache_;
   SantaCache<uint64_t> *vnode_pid_map_;
@@ -259,7 +258,7 @@ class SantaDecisionManager : public OSObject {
 
   // This is the file system ID of the root filesystem,
   // used to determine which cache to use for requests
-  uint32_t root_vsid_;
+  uint32_t root_fsid_;
 
   lck_grp_t *sdm_lock_grp_;
   lck_grp_attr_t *sdm_lock_grp_attr_;

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -96,7 +96,8 @@ class SantaDecisionManager : public OSObject {
   void RemoveFromCache(uint64_t identifier);
 
   /// Returns the number of entries in the cache.
-  uint64_t CacheCount() const;
+  uint64_t RootCacheCount() const;
+  uint64_t NonRootCacheCount() const;
 
   /// Clears the cache.
   void ClearCache(bool non_root_only = true);

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -99,7 +99,7 @@ class SantaDecisionManager : public OSObject {
   uint64_t CacheCount() const;
 
   /// Clears the cache.
-  void ClearCache();
+  void ClearCache(bool non_root_only = true);
 
   /// Increments the count of active callbacks pending.
   void IncrementListenerInvocations();
@@ -244,8 +244,21 @@ class SantaDecisionManager : public OSObject {
   }
 
  private:
-  SantaCache<uint64_t> *decision_cache_;
+  SantaCache<uint64_t> *root_decision_cache_;
+  SantaCache<uint64_t> *non_root_decision_cache_;
   SantaCache<uint64_t> *vnode_pid_map_;
+
+  /**
+    Return the correct cache for a given identifier.
+
+    @param identifier The identifier
+    @return SantaCache* The cache to use
+  */
+  SantaCache<uint64_t>* CacheForIdentifier(const uint64_t identifier);
+
+  // This is the file system ID of the root filesystem,
+  // used to determine which cache to use for requests
+  uint32_t root_vsid_;
 
   lck_grp_t *sdm_lock_grp_;
   lck_grp_attr_t *sdm_lock_grp_attr_;

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -166,7 +166,8 @@ IOReturn SantaDriverClient::cache_count(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  arguments->scalarOutput[0] = me->decisionManager->CacheCount();
+  arguments->scalarOutput[0] = me->decisionManager->RootCacheCount();
+  arguments->scalarOutput[1] = me->decisionManager->NonRootCacheCount();
   return kIOReturnSuccess;
 }
 
@@ -197,7 +198,7 @@ IOReturn SantaDriverClient::externalMethod(
     { &SantaDriverClient::allow_binary, 1, 0, 0, 0 },
     { &SantaDriverClient::deny_binary, 1, 0, 0, 0 },
     { &SantaDriverClient::clear_cache, 1, 0, 0, 0 },
-    { &SantaDriverClient::cache_count, 0, 0, 1, 0 },
+    { &SantaDriverClient::cache_count, 0, 0, 2, 0 },
     { &SantaDriverClient::check_cache, 1, 0, 1, 0 }
   };
 

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -133,7 +133,7 @@ IOReturn SantaDriverClient::allow_binary(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  const uint64_t vnode_id = static_cast<const uint64_t>(*arguments->scalarInput);
+  const uint64_t vnode_id = static_cast<const uint64_t>(arguments->scalarInput[0]);
   me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_ALLOW);
 
   return kIOReturnSuccess;
@@ -144,7 +144,7 @@ IOReturn SantaDriverClient::deny_binary(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  const uint64_t vnode_id = static_cast<const uint64_t>(*arguments->scalarInput);
+  const uint64_t vnode_id = static_cast<const uint64_t>(arguments->scalarInput[0]);
   me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_DENY);
 
   return kIOReturnSuccess;
@@ -155,7 +155,8 @@ IOReturn SantaDriverClient::clear_cache(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  me->decisionManager->ClearCache();
+  const bool non_root_only = static_cast<const bool>(arguments->scalarInput[0]);
+  me->decisionManager->ClearCache(non_root_only);
 
   return kIOReturnSuccess;
 }
@@ -174,7 +175,7 @@ IOReturn SantaDriverClient::check_cache(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  uint64_t input = *arguments->scalarInput;
+  const uint64_t input = static_cast<const uint64_t>(arguments->scalarInput[0]);
   arguments->scalarOutput[0] = me->decisionManager->GetFromCache(input);
 
   return kIOReturnSuccess;
@@ -195,7 +196,7 @@ IOReturn SantaDriverClient::externalMethod(
     { &SantaDriverClient::open, 0, 0, 0, 0 },
     { &SantaDriverClient::allow_binary, 1, 0, 0, 0 },
     { &SantaDriverClient::deny_binary, 1, 0, 0, 0 },
-    { &SantaDriverClient::clear_cache, 0, 0, 0, 0 },
+    { &SantaDriverClient::clear_cache, 1, 0, 0, 0 },
     { &SantaDriverClient::cache_count, 0, 0, 1, 0 },
     { &SantaDriverClient::check_cache, 1, 0, 1, 0 }
   };

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -134,6 +134,7 @@ IOReturn SantaDriverClient::allow_binary(
   if (!me) return kIOReturnBadArgument;
 
   const uint64_t vnode_id = static_cast<const uint64_t>(arguments->scalarInput[0]);
+  if (!vnode_id) return kIOReturnInvalid;
   me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_ALLOW);
 
   return kIOReturnSuccess;
@@ -145,6 +146,7 @@ IOReturn SantaDriverClient::deny_binary(
   if (!me) return kIOReturnBadArgument;
 
   const uint64_t vnode_id = static_cast<const uint64_t>(arguments->scalarInput[0]);
+  if (!vnode_id) return kIOReturnInvalid;
   me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_DENY);
 
   return kIOReturnSuccess;

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -79,10 +79,11 @@ REGISTER_COMMAND_NAME(@"status")
   BOOL fileLogging = ([[SNTConfigurator configurator] fileChangesRegex] != nil);
 
   // Kext status
-  __block int64_t cacheCount = -1;
+  __block uint64_t rootCacheCount = -1, nonRootCacheCount = -1;
   dispatch_group_enter(group);
-  [[daemonConn remoteObjectProxy] cacheCount:^(int64_t count) {
-    cacheCount = count;
+  [[daemonConn remoteObjectProxy] cacheCounts:^(uint64_t rootCache, uint64_t nonRootCache) {
+    rootCacheCount = rootCache;
+    nonRootCacheCount = nonRootCache;
     dispatch_group_leave(group);
   }];
 
@@ -145,7 +146,8 @@ REGISTER_COMMAND_NAME(@"status")
         @"watchdog_ram_peak" : @(ramPeak),
       },
       @"kernel" : @{
-        @"cache_count" : @(cacheCount),
+        @"root_cache_count" : @(rootCacheCount),
+        @"non_root_cache_count": @(nonRootCacheCount),
       },
       @"database" : @{
         @"binary_rules" : @(binaryRuleCount),
@@ -173,7 +175,8 @@ REGISTER_COMMAND_NAME(@"status")
     printf("  %-25s | %lld  (Peak: %.2f%%)\n", "Watchdog CPU Events", cpuEvents, cpuPeak);
     printf("  %-25s | %lld  (Peak: %.2fMB)\n", "Watchdog RAM Events", ramEvents, ramPeak);
     printf(">>> Kernel Info\n");
-    printf("  %-25s | %lld\n", "Kernel cache count", cacheCount);
+    printf("  %-25s | %lld\n", "Root cache count", rootCacheCount);
+    printf("  %-25s | %lld\n", "Non-root cache count", nonRootCacheCount);
     printf(">>> Database Info\n");
     printf("  %-25s | %lld\n", "Binary Rules", binaryRuleCount);
     printf("  %-25s | %lld\n", "Certificate Rules", certRuleCount);

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -56,9 +56,9 @@ double watchdogRAMPeak = 0;
 
 #pragma mark Kernel ops
 
-- (void)cacheCount:(void (^)(int64_t))reply {
-  int64_t count = [self.driverManager cacheCount];
-  reply(count);
+- (void)cacheCounts:(void (^)(uint64_t, uint64_t))reply {
+  NSArray<NSNumber *> *counts = [self.driverManager cacheCounts];
+  reply([counts[0] unsignedLongLongValue], [counts[1] unsignedLongLongValue]);
 }
 
 - (void)flushCache:(void (^)(BOOL))reply {

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -62,7 +62,7 @@ double watchdogRAMPeak = 0;
 }
 
 - (void)flushCache:(void (^)(BOOL))reply {
-  reply([self.driverManager flushCache]);
+  reply([self.driverManager flushCacheNonRootOnly:NO]);
 }
 
 - (void)checkCacheForVnodeID:(uint64_t)vnodeID withReply:(void (^)(santa_action_t))reply {
@@ -86,7 +86,7 @@ double watchdogRAMPeak = 0;
   NSPredicate *p = [NSPredicate predicateWithFormat:@"SELF.state != %d", SNTRuleStateWhitelist];
   if ([rules filteredArrayUsingPredicate:p].count || cleanSlate) {
     LOGI(@"Received non-whitelist rule, flushing cache");
-    [self.driverManager flushCache];
+    [self.driverManager flushCacheNonRootOnly:NO];
   }
 
   reply(error);
@@ -170,7 +170,7 @@ double watchdogRAMPeak = 0;
                                                                         error:NULL];
   [[SNTConfigurator configurator] setWhitelistPathRegex:re];
   LOGI(@"Received new whitelist regex, flushing cache");
-  [self.driverManager flushCache];
+  [self.driverManager flushCacheNonRootOnly:NO];
   reply();
 }
 
@@ -180,7 +180,7 @@ double watchdogRAMPeak = 0;
                                                                         error:NULL];
   [[SNTConfigurator configurator] setBlacklistPathRegex:re];
   LOGI(@"Received new blacklist regex, flushing cache");
-  [self.driverManager flushCache];  
+  [self.driverManager flushCacheNonRootOnly:NO];
   reply();
 }
 

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -55,11 +55,11 @@
 ///
 ///  Flush the kernel's binary cache.
 ///
-- (BOOL)flushCache;
+- (BOOL)flushCacheNonRootOnly:(BOOL)nonRootOnly;
 
 ///
 ///  Check the kernel cache for a VnodeID
 ///
--(santa_action_t)checkCache:(uint64_t)vnodeID;
+- (santa_action_t)checkCache:(uint64_t)vnodeID;
 
 @end

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -48,9 +48,9 @@
 - (kern_return_t)postToKernelAction:(santa_action_t)action forVnodeID:(uint64_t)vnodeId;
 
 ///
-///  Get the number of binaries in the kernel's cache.
+///  Get the number of binaries in the kernel's caches.
 ///
-- (uint64_t)cacheCount;
+- (NSArray<NSNumber *> *)cacheCounts;
 
 ///
 ///  Flush the kernel's binary cache.

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -180,9 +180,14 @@ static const int MAX_DELAY = 15;
   return cache_count;
 }
 
-- (BOOL)flushCache {
+- (BOOL)flushCacheNonRootOnly:(BOOL)nonRootOnly {
+  const uint64_t nonRoot = nonRootOnly;
   return IOConnectCallScalarMethod(_connection,
-                                   kSantaUserClientClearCache, 0, 0, 0, 0) == KERN_SUCCESS;
+                                   kSantaUserClientClearCache,
+                                   &nonRoot,
+                                   1,
+                                   0,
+                                   0) == KERN_SUCCESS;
 }
 
 - (santa_action_t)checkCache:(uint64_t)vnodeID {

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -167,17 +167,18 @@ static const int MAX_DELAY = 15;
   }
 }
 
-- (uint64_t)cacheCount {
-  uint32_t input_count = 1;
-  uint64_t cache_count = 0;
+- (NSArray<NSNumber *> *)cacheCounts {
+  uint32_t input_count = 2;
+  uint64_t cache_counts[2] = {0, 0};
 
   IOConnectCallScalarMethod(_connection,
                             kSantaUserClientCacheCount,
                             0,
                             0,
-                            &cache_count,
+                            cache_counts,
                             &input_count);
-  return cache_count;
+
+  return @[ @(cache_counts[0]), @(cache_counts[1]) ];
 }
 
 - (BOOL)flushCacheNonRootOnly:(BOOL)nonRootOnly {

--- a/Source/santad/SNTEventLog.m
+++ b/Source/santad/SNTEventLog.m
@@ -216,8 +216,6 @@
 }
 
 - (void)logDiskAppeared:(NSDictionary *)diskProperties {
-  if (![diskProperties[@"DAVolumeMountable"] boolValue]) return;
-
   NSString *dmgPath = @"";
   NSString *serial = @"";
   if ([diskProperties[@"DADeviceModel"] isEqual:@"Disk Image"]) {
@@ -252,8 +250,6 @@
 }
 
 - (void)logDiskDisappeared:(NSDictionary *)diskProperties {
-  if (![diskProperties[@"DAVolumeMountable"] boolValue]) return;
-
   LOGI(@"action=DISKDISAPPEAR|mount=%@|volume=%@|bsdname=%@",
        [diskProperties[@"DAVolumePath"] path] ?: @"",
        diskProperties[@"DAVolumeName"] ?: @"",

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -104,7 +104,8 @@
 
 /// Call in-kernel function: |kSantaUserClientClearCache|
 - (void)flushCache {
-  IOConnectCallScalarMethod(self.connection, kSantaUserClientClearCache, 0, 0, 0, 0);
+  uint64_t nonRootOnly = 0;
+  IOConnectCallScalarMethod(self.connection, kSantaUserClientClearCache, &nonRootOnly, 1, 0, 0);
 }
 
 #pragma mark - Connection Tests


### PR DESCRIPTION
Split the kernel cache into 2 separate caches, one for the root volume and one for secondary volumes. When an unmount happens, clear the non-root cache to ensure no overlap with filesystem IDs. Show the count for both caches in the santactl/status command.

Reduce the total cache size from **10k** entries to **5k (root) + 500 (non-root)**.

Also attempt to make logging slightly less bad in the kernel, using a gcc/clang varargs extension to avoid needing to call IOLog twice per output line.