### PR TITLE
santa-driver: Fix possible race condition in SDM::AddToCache

### DIFF
--- a/Tests/LogicTests/SantaCacheTest.mm
+++ b/Tests/LogicTests/SantaCacheTest.mm
@@ -150,4 +150,27 @@
   delete sut;
 }
 
+- (void)testCompareAndSwap {
+  auto sut = new SantaCache<uint64_t>(100, 2);
+
+  sut->set(1, 42);
+  sut->set(1, 666, 1);
+  sut->set(1, 666, 0);
+  XCTAssertEqual(sut->get(1), 42);
+
+  sut->set(1, 0);
+  XCTAssertEqual(sut->get(1), 0);
+
+  sut->set(1, 42, 1);
+  XCTAssertEqual(sut->get(1), 0);
+
+  sut->set(1, 42, 0);
+  XCTAssertEqual(sut->get(1), 42);
+
+  sut->set(1, 0, 666);
+  XCTAssertEqual(sut->get(1), 42);
+  sut->set(1, 0, 42);
+  XCTAssertEqual(sut->get(1), 0);
+}
+
 @end


### PR DESCRIPTION
SantaDecisionManager::AddToCache() rejects allow/deny entries being added to the
cache unless there's already an entry for that vnode with the REQUEST_BINARY
status, so that if a write to the file happens and the entry is removed while a
decision is being made, it's rejected.

However, as it's currently implemented there's a small window where the entry is
actually added to the cache. To fix that, this PR adds a way to use the
cache->set() method as a compare-and-swap.

While here, I also fixed the cache performance test in KernelTests so that it
measures walltime instead of CPU time.

Also fixed some line length violations.