### PR TITLE
Minor refactor to merge similar methods into one:

### DIFF
--- a/Source/common/SNTXPCSyncdInterface.h
+++ b/Source/common/SNTXPCSyncdInterface.h
@@ -20,9 +20,8 @@
 
 /// Protocol implemented by santactl and utilized by santad
 @protocol SNTSyncdXPC
-- (void)postEventToSyncServer:(SNTStoredEvent *)event;
+- (void)postEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle;
 - (void)postBundleEventToSyncServer:(SNTStoredEvent *)event reply:(void (^)(BOOL))reply;
-- (void)postBundleEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events;
 - (void)isFCMListening:(void (^)(BOOL))reply;
 @end
 

--- a/Source/common/SNTXPCSyncdInterface.m
+++ b/Source/common/SNTXPCSyncdInterface.m
@@ -22,7 +22,7 @@
   NSXPCInterface *r = [NSXPCInterface interfaceWithProtocol:@protocol(SNTSyncdXPC)];
 
   [r setClasses:[NSSet setWithObjects:[NSArray class], [SNTStoredEvent class], nil]
-        forSelector:@selector(postBundleEventsToSyncServer:)
+        forSelector:@selector(postEventsToSyncServer:isFromBundle:)
       argumentIndex:0
             ofReply:NO];
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -122,6 +122,17 @@ static void reachabilityHandler(
 
 #pragma mark SNTSyncdXPC protocol methods
 
+- (void)postEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle {
+  SNTCommandSyncState *syncState = [self createSyncState];
+  if (isFromBundle) syncState.eventBatchSize = self.eventBatchSize;
+  SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc] initWithState:syncState];
+  if (events && [p uploadEvents:events]) {
+    LOGD(@"Events upload complete");
+  } else {
+    LOGE(@"Events upload failed");
+  }
+}
+
 - (void)postBundleEventToSyncServer:(SNTStoredEvent *)event reply:(void (^)(BOOL))reply {
   SNTCommandSyncState *syncState = [self createSyncState];
   SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc] initWithState:syncState];
@@ -136,27 +147,6 @@ static void reachabilityHandler(
   } else {
     reply(NO);
     LOGE(@"Bundle event upload failed");
-  }
-}
-
-- (void)postBundleEventsToSyncServer:(NSArray<SNTStoredEvent *> *)events {
-  SNTCommandSyncState *syncState = [self createSyncState];
-  syncState.eventBatchSize = self.eventBatchSize;
-  SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc] initWithState:syncState];
-  if (events && [p uploadEvents:events]) {
-    LOGD(@"Bundle events upload complete");
-  } else {
-    LOGE(@"Bundle events upload failed");
-  }
-}
-
-- (void)postEventToSyncServer:(SNTStoredEvent *)event {
-  SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc]
-                                     initWithState:[self createSyncState]];
-  if (event && [p uploadEvents:@[event]]) {
-    LOGD(@"Event upload complete");
-  } else {
-    LOGE(@"Event upload failed");
   }
 }
 

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -288,7 +288,7 @@ double watchdogRAMPeak = 0;
     STRONGIFY(self);
     if (needRelatedEvents) {
       [eventTable addStoredEvents:events];
-      [self.syncdQueue addBundleEvents:events];
+      [self.syncdQueue addEvents:events isFromBundle:YES];
     }
   }];
 }

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -178,7 +178,7 @@
       [_eventLog logDeniedExecution:cd withMessage:message];
 
       if ([[SNTConfigurator configurator] bundlesEnabled] && binInfo.bundle) {
-        // If the binary is apart of a bundle, find and hash all the related binaries in the bundle.
+        // If the binary is part of a bundle, find and hash all the related binaries in the bundle.
         // Let the GUI know hashing is needed. Once the hashing is complete the GUI will send a
         // message to santad to perform the upload logic for bundles.
         // See syncBundleEvent:relatedEvents: for more info.
@@ -187,7 +187,7 @@
         // So the server has something to show the user straight away, initiate an event
         // upload for the blocked binary rather than waiting for the next sync.
         dispatch_async(_eventQueue, ^{
-          [_syncdQueue addEvent:se];
+          [_syncdQueue addEvents:@[se] isFromBundle:NO];
         });
       }
 

--- a/Source/santad/SNTSyncdQueue.h
+++ b/Source/santad/SNTSyncdQueue.h
@@ -23,8 +23,7 @@
 @property(copy) void (^invalidationHandler)();
 @property(copy) void (^acceptedHandler)();
 
-- (void)addEvent:(SNTStoredEvent *)event;
-- (void)addBundleEvents:(NSArray<SNTStoredEvent *> *)events;
+- (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle;
 - (void)addBundleEvent:(SNTStoredEvent *)event reply:(void (^)(BOOL))reply;
 - (void)startSyncingEvents;
 - (void)stopSyncingEvents;

--- a/Source/santad/SNTSyncdQueue.m
+++ b/Source/santad/SNTSyncdQueue.m
@@ -39,7 +39,7 @@
 }
 
 - (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle {
-  if (!events || events.count == 0) return;
+  if (!events || !events.count) return;
   SNTStoredEvent *first = events.firstObject;
   NSString *hash = isFromBundle ? first.fileBundleHash : first.fileSHA256;
   if (![self backoffForPrimaryHash:hash]) return;

--- a/Source/santad/SNTSyncdQueue.m
+++ b/Source/santad/SNTSyncdQueue.m
@@ -39,7 +39,7 @@
 }
 
 - (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle {
-  if (!events || !events.count) return;
+  if (!events.count) return;
   SNTStoredEvent *first = events.firstObject;
   NSString *hash = isFromBundle ? first.fileBundleHash : first.fileSHA256;
   if (![self backoffForPrimaryHash:hash]) return;

--- a/Source/santad/SNTSyncdQueue.m
+++ b/Source/santad/SNTSyncdQueue.m
@@ -38,30 +38,27 @@
   return self;
 }
 
-- (void)addBundleEvents:(NSArray<SNTStoredEvent *> *)events {
-  if (![self backoffForBundleHash:events.firstObject.fileBundleHash]) return;
+- (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle {
+  if (!events || events.count == 0) return;
+  SNTStoredEvent *first = events.firstObject;
+  NSString *hash = isFromBundle ? first.fileBundleHash : first.fileSHA256;
+  if (![self backoffForPrimaryHash:hash]) return;
   [self dispatchBlockOnSyncdQueue:^{
-    [self.syncdConnection.remoteObjectProxy postBundleEventsToSyncServer:events];
+    [self.syncdConnection.remoteObjectProxy postEventsToSyncServer:events
+                                                      isFromBundle:isFromBundle];
   }];
 }
 
 - (void)addBundleEvent:(SNTStoredEvent *)event reply:(void (^)(BOOL))reply {
-  if (![self backoffForBundleHash:event.fileBundleHash]) return;
+  if (![self backoffForPrimaryHash:event.fileBundleHash]) return;
   [self dispatchBlockOnSyncdQueue:^{
     [self.syncdConnection.remoteObjectProxy postBundleEventToSyncServer:event
                                                                   reply:^(BOOL needRelatedEvents) {
       // Remove the backoff entry for the inital block event. The same event will be included in the
-      // related events synced using addBundleEvents:.
+      // related events synced using addEvents:isFromBundle:.
       if (needRelatedEvents) [self.uploadBackoff removeObjectForKey:event.fileBundleHash];
       reply(needRelatedEvents);
     }];
-  }];
-}
-
-- (void)addEvent:(SNTStoredEvent *)event {
-  if (![self backoffForEvent:event]) return;
-  [self dispatchBlockOnSyncdQueue:^{
-    [self.syncdConnection.remoteObjectProxy postEventToSyncServer:event];
   }];
 }
 
@@ -87,23 +84,13 @@
   });
 }
 
-// The event upload is skipped if an event upload has been initiated for it in the
-// last 10 minutes.
-- (BOOL)backoffForEvent:(SNTStoredEvent *)event {
-  NSDate *backoff = [self.uploadBackoff objectForKey:event.fileSHA256];
+// The event upload is skipped if an event has been initiated for it in the last 10 minutes.
+// The passed-in hash is fileBundleHash for a bundle event, or fileSHA256 for a normal event.
+- (BOOL)backoffForPrimaryHash:(NSString *)hash {
+  NSDate *backoff = [self.uploadBackoff objectForKey:hash];
   NSDate *now = [NSDate date];
   if (([now timeIntervalSince1970] - [backoff timeIntervalSince1970]) < 600) return NO;
-  [self.uploadBackoff setObject:now forKey:event.fileSHA256];
-  return YES;
-}
-
-// The bundle event upload is skipped if a bundle event has been initiated for it in the
-// last 10 minutes.
-- (BOOL)backoffForBundleHash:(NSString *)bundleHash {
-  NSDate *backoff = [self.uploadBackoff objectForKey:bundleHash];
-  NSDate *now = [NSDate date];
-  if (([now timeIntervalSince1970] - [backoff timeIntervalSince1970]) < 600) return NO;
-  [self.uploadBackoff setObject:now forKey:bundleHash];
+  [self.uploadBackoff setObject:now forKey:hash];
   return YES;
 }
 


### PR DESCRIPTION
* SNTSyncdQueue addBundleEvents: and addEvent: became addEvents:isFromBundle:
* SNTSyncdQueue backoffForBundleHash: and backoffForEvent: became backoffForPrimaryHash:
* SNTCommandSyncManager postBundleEventsToSyncServer: and postEventToSyncServer: became postEventsToSyncServer:isFromBundle: