### PR TITLE
santa-driver: Prevent possible infinite loop if decision requests fai…

### DIFF
--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -279,16 +279,19 @@ santa_action_t SantaDecisionManager::GetFromCache(uint64_t identifier) {
   result = (santa_action_t)(cache_val >> 56);
   decision_time = (cache_val & ~(0xFF00000000000000));
 
-  if (RESPONSE_VALID(result)) {
+  // Ensure result hasn't passed its expiry.
+  if (result == ACTION_RESPOND_DENY || result == ACTION_REQUEST_BINARY) {
+    auto expiry_time = decision_time;
     if (result == ACTION_RESPOND_DENY) {
-      auto expiry_time = decision_time + (kMaxDenyCacheTimeMilliseconds * 1000);
-      if (expiry_time < GetCurrentUptime()) {
-        decision_cache->remove(identifier);
-        return ACTION_UNSET;
-      }
+      expiry_time += (kMaxDenyCacheTimeMilliseconds * 1000);
+    } else if (result == ACTION_REQUEST_BINARY) {
+      expiry_time += (kMaxRequestWaitTimeMilliseconds * 1000);
+    }
+    if (expiry_time < GetCurrentUptime()) {
+      decision_cache->remove(identifier);
+      return ACTION_UNSET;
     }
   }
-
   return result;
 }
 
@@ -404,14 +407,8 @@ bool SantaDecisionManager::PostToLogQueue(santa_message_t *message) {
     if (failed_log_queue_requests_++ == 0) {
       LOGW("Dropping log queue messages");
     }
-    // If enqueue failed, pop an item off the queue and try again.
-    uint32_t dataSize = 0;
-    log_dataqueue_->dequeue(0, &dataSize);
-    kr = log_dataqueue_->enqueue(message, sizeof(santa_message_t));
-  } else {
-    if (failed_log_queue_requests_ > 0) {
-      failed_log_queue_requests_--;
-    }
+  } else if (failed_log_queue_requests_ > 0) {
+    failed_log_queue_requests_--;
   }
   lck_mtx_unlock(log_dataqueue_lock_);
   return kr;

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -79,8 +79,9 @@ class SantaDecisionManager : public OSObject {
   kern_return_t StartListener();
 
   /**
-    Stops the kauth listeners. After stopping new callback requests, waits until all
-    current invocations have finished before clearing the cache and returning.
+    Stops the kauth listeners. After stopping new callback requests, waits 
+    until all current invocations have finished before clearing the cache and
+    returning.
   */
   kern_return_t StopListener();
 
@@ -89,7 +90,10 @@ class SantaDecisionManager : public OSObject {
                   const santa_action_t decision,
                   const uint64_t microsecs = GetCurrentUptime());
 
-  ///  Fetches a response from the cache, first checking to see if the entry has expired.
+  /**
+    Fetches a response from the cache, first checking to see if the entry 
+    has expired.
+  */
   santa_action_t GetFromCache(uint64_t identifier);
 
   /// Checks to see if a given identifier is in the cache and removes it.
@@ -99,7 +103,10 @@ class SantaDecisionManager : public OSObject {
   uint64_t RootCacheCount() const;
   uint64_t NonRootCacheCount() const;
 
-  /// Clears the cache(s). If non_root_only is true, only the non-root cache is cleared.
+  /**
+    Clears the cache(s). If non_root_only is true, only the non-root cache 
+    is cleared.
+  */
   void ClearCache(bool non_root_only = false);
 
   /// Increments the count of active callbacks pending.
@@ -137,8 +144,17 @@ class SantaDecisionManager : public OSObject {
   */
   static const uint32_t kRequestLoopSleepMilliseconds = 1000;
 
-  /// The maximum number of milliseconds a cached deny message should be considered valid.
+  /**
+    The maximum number of milliseconds a cached deny message should be
+    considered valid.
+  */
   static const uint64_t kMaxDenyCacheTimeMilliseconds = 500;
+
+  /** 
+    The maximum number of milliseconds a request can sit waiting for a response
+    before the pending request is evicted, forcing it to be retried.
+  */
+  static const uint64_t kMaxRequestWaitTimeMilliseconds = 5000;
 
   /// Maximum number of entries in the in-kernel cache.
   static const uint32_t kMaxCacheSize = 10000;
@@ -146,10 +162,16 @@ class SantaDecisionManager : public OSObject {
   /// Maximum number of PostToDecisionQueue failures to allow.
   static const uint32_t kMaxDecisionQueueFailures = 10;
 
-  /// The maximum number of messages can be kept in the decision data queue at any time.
+  /**
+    The maximum number of messages can be kept in the decision data queue at
+    any time.
+  */
   static const uint32_t kMaxDecisionQueueEvents = 512;
 
-  /// The maximum number of messages can be kept in the logging data queue at any time.
+  /**
+    The maximum number of messages can be kept in the logging data queue at
+    any time.
+  */
   static const uint32_t kMaxLogQueueEvents = 2048;
 
   /**
@@ -199,7 +221,8 @@ class SantaDecisionManager : public OSObject {
     @param vp The Vnode to get the ID for
     @return uint64_t The Vnode ID as a 64-bit unsigned int.
   */
-  static inline uint64_t GetVnodeIDForVnode(const vfs_context_t ctx, const vnode_t vp) {
+  static inline uint64_t GetVnodeIDForVnode(
+      const vfs_context_t ctx, const vnode_t vp) {
     struct vnode_attr vap;
     VATTR_INIT(&vap);
     VATTR_WANTED(&vap, va_fsid);

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -163,14 +163,14 @@ class SantaDecisionManager : public OSObject {
   static const uint32_t kMaxDecisionQueueFailures = 10;
 
   /**
-    The maximum number of messages can be kept in the decision data queue at
-    any time.
+    The maximum number of messages that can be kept in the decision data queue
+    at any time.
   */
   static const uint32_t kMaxDecisionQueueEvents = 512;
 
   /**
-    The maximum number of messages can be kept in the logging data queue at
-    any time.
+    The maximum number of messages that can be kept in the logging data queue
+    at any time.
   */
   static const uint32_t kMaxLogQueueEvents = 2048;
 


### PR DESCRIPTION
…l to be retrieved

When enqueue'ing on the decision data queue, if the queue is full the new message will overwrite the oldest. In this scenario it's possible for that overwritten request to get stuck in an infinite loop - as far as the driver is concerned there's a request pending that the driver should be picking up and responding to but the daemon has never actually received the request. The only way out of this loop is for the file being executed to be written to. This change adds an expiration to pending requests (of 5s) so that if this scenario were to happen the pending request would be removed, breaking out of the inner decision loop to the outer loop where the request is sent to the daemon.

This change also removes a pointless dequeue in the log queue, it was intended to try and help reduce the queue size to get logs flowing again but it doesn't really help.

Fixes #215 