### PR TITLE
santa-driver: Add timestamp support for ACTION_REQUEST_BINARY

### DIFF
--- a/Source/common/SNTKernelCommon.h
+++ b/Source/common/SNTKernelCommon.h
@@ -82,6 +82,7 @@ typedef enum {
 // Message struct that is sent down the IODataQueue.
 typedef struct {
   santa_action_t action;
+  uint64_t timestamp;
   uint64_t vnode_id;
   uid_t uid;
   gid_t gid;

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -86,8 +86,8 @@ class SantaDecisionManager : public OSObject {
   kern_return_t StopListener();
 
   /// Adds a decision to the cache, with a timestamp. Parameter old_microsecs
-  /// is used to test and set the expected value of an ACTION_REQUEST_BINARY entry when attempting
-  /// to update it with a ACTION_RESPOND_ALLOW or ACTION_RESPOND_DENY entry.
+  /// is used to compare and swap the expected value of an ACTION_REQUEST_BINARY entry
+  /// when attempting to update it with a ACTION_RESPOND_ALLOW or ACTION_RESPOND_DENY entry.
   void AddToCache(uint64_t identifier,
                   const santa_action_t decision,
                   const uint64_t microsecs = GetCurrentUptime(),

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -85,10 +85,13 @@ class SantaDecisionManager : public OSObject {
   */
   kern_return_t StopListener();
 
-  /// Adds a decision to the cache, with a timestamp.
+  /// Adds a decision to the cache, with a timestamp. Parameter old_microsecs
+  /// is used to test and set the expected value of an ACTION_REQUEST_BINARY entry when attempting
+  /// to update it with a ACTION_RESPOND_ALLOW or ACTION_RESPOND_DENY entry.
   void AddToCache(uint64_t identifier,
                   const santa_action_t decision,
-                  const uint64_t microsecs = GetCurrentUptime());
+                  const uint64_t microsecs = GetCurrentUptime(),
+                  const uint64_t old_microsecs = 0);
 
   /**
     Fetches a response from the cache, first checking to see if the entry 
@@ -136,6 +139,16 @@ class SantaDecisionManager : public OSObject {
   */
   void FileOpCallback(kauth_action_t action, const vnode_t vp,
                       const char *path, const char *new_path);
+
+  /**
+   Returns the current system uptime in microseconds
+   */
+  static inline uint64_t GetCurrentUptime() {
+    clock_sec_t sec;
+    clock_usec_t usec;
+    clock_get_system_microtime(&sec, &usec);
+    return (uint64_t)((sec * 1000000) + usec);
+  }
 
  private:
   /**
@@ -255,16 +268,6 @@ class SantaDecisionManager : public OSObject {
     }
 
     return message;
-  }
-
-  /**
-    Returns the current system uptime in microseconds
-  */
-  static inline uint64_t GetCurrentUptime() {
-    clock_sec_t sec;
-    clock_usec_t usec;
-    clock_get_system_microtime(&sec, &usec);
-    return (uint64_t)((sec * 1000000) + usec);
   }
 
   SantaCache<uint64_t> *root_decision_cache_;

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -135,7 +135,9 @@ IOReturn SantaDriverClient::allow_binary(
 
   const uint64_t vnode_id = static_cast<const uint64_t>(arguments->scalarInput[0]);
   if (!vnode_id) return kIOReturnInvalid;
-  me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_ALLOW);
+  const uint64_t timestamp = static_cast<const uint64_t>(arguments->scalarInput[1]);
+  me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_ALLOW,
+                                  SantaDecisionManager::GetCurrentUptime(), timestamp);
 
   return kIOReturnSuccess;
 }
@@ -147,7 +149,9 @@ IOReturn SantaDriverClient::deny_binary(
 
   const uint64_t vnode_id = static_cast<const uint64_t>(arguments->scalarInput[0]);
   if (!vnode_id) return kIOReturnInvalid;
-  me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_DENY);
+  const uint64_t timestamp = static_cast<const uint64_t>(arguments->scalarInput[1]);
+  me->decisionManager->AddToCache(vnode_id, ACTION_RESPOND_DENY,
+                                  SantaDecisionManager::GetCurrentUptime(), timestamp);
 
   return kIOReturnSuccess;
 }
@@ -197,8 +201,8 @@ IOReturn SantaDriverClient::externalMethod(
   static IOExternalMethodDispatch sMethods[kSantaUserClientNMethods] = {
     // Function ptr, input scalar count, input struct size, output scalar count, output struct size
     { &SantaDriverClient::open, 0, 0, 0, 0 },
-    { &SantaDriverClient::allow_binary, 1, 0, 0, 0 },
-    { &SantaDriverClient::deny_binary, 1, 0, 0, 0 },
+    { &SantaDriverClient::allow_binary, 2, 0, 0, 0 },
+    { &SantaDriverClient::deny_binary, 2, 0, 0, 0 },
     { &SantaDriverClient::clear_cache, 1, 0, 0, 0 },
     { &SantaDriverClient::cache_count, 0, 0, 2, 0 },
     { &SantaDriverClient::check_cache, 1, 0, 1, 0 }

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -45,7 +45,9 @@
 ///
 ///  Sends a response to a query back to the kernel.
 ///
-- (kern_return_t)postToKernelAction:(santa_action_t)action forVnodeID:(uint64_t)vnodeId;
+- (kern_return_t)postToKernelAction:(santa_action_t)action
+                         forVnodeID:(uint64_t)vnodeId
+                          timestamp:(uint64_t)timestamp;
 
 ///
 ///  Get the number of binaries in the kernel's caches.

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -146,20 +146,23 @@ static const int MAX_DELAY = 15;
 
 #pragma mark Outgoing messages
 
-- (kern_return_t)postToKernelAction:(santa_action_t)action forVnodeID:(uint64_t)vnodeId {
+- (kern_return_t)postToKernelAction:(santa_action_t)action
+                         forVnodeID:(uint64_t)vnodeId
+                          timestamp:(uint64_t)timestamp {
+  uint64_t input[2] = {vnodeId, timestamp};
   switch (action) {
     case ACTION_RESPOND_ALLOW:
       return IOConnectCallScalarMethod(_connection,
                                        kSantaUserClientAllowBinary,
-                                       &vnodeId,
-                                       1,
+                                       input,
+                                       2,
                                        0,
                                        0);
     case ACTION_RESPOND_DENY:
       return IOConnectCallScalarMethod(_connection,
                                        kSantaUserClientDenyBinary,
-                                       &vnodeId,
-                                       1,
+                                       input,
+                                       2,
                                        0,
                                        0);
     default:

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -85,20 +85,26 @@
   // Get info about the file. If we can't get this info, allow execution and log an error.
   if (unlikely(message.path == NULL)) {
     LOGE(@"Path for vnode_id is NULL: %llu", message.vnode_id);
-    [_driverManager postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:message.vnode_id];
+    [_driverManager postToKernelAction:ACTION_RESPOND_ALLOW
+                            forVnodeID:message.vnode_id
+                             timestamp:message.timestamp];
     return;
   }
   NSError *fileInfoError;
   SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:@(message.path) error:&fileInfoError];
   if (unlikely(!binInfo)) {
     LOGE(@"Failed to read file %@: %@", @(message.path), fileInfoError.localizedDescription);
-    [_driverManager postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:message.vnode_id];
+    [_driverManager postToKernelAction:ACTION_RESPOND_ALLOW
+                            forVnodeID:message.vnode_id
+                             timestamp:message.timestamp];
     return;
   }
 
   // PrinterProxy workaround, see description above the method for more details.
   if ([self printerProxyWorkaround:binInfo]) {
-    [_driverManager postToKernelAction:ACTION_RESPOND_DENY forVnodeID:message.vnode_id];
+    [_driverManager postToKernelAction:ACTION_RESPOND_DENY
+                            forVnodeID:message.vnode_id
+                             timestamp:message.timestamp];
     return;
   }
 
@@ -124,7 +130,7 @@
   if (action == ACTION_RESPOND_ALLOW) [_eventLog saveDecisionDetails:cd];
 
   // Send the decision to the kernel.
-  [_driverManager postToKernelAction:action forVnodeID:cd.vnodeId];
+  [_driverManager postToKernelAction:action forVnodeID:cd.vnodeId timestamp:message.timestamp];
 
   // Log to database if necessary.
   if (cd.decision != SNTEventStateAllowBinary &&

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -94,11 +94,14 @@
 
 /// Call in-kernel function: |kSantaUserClientAllowBinary| or |kSantaUserClientDenyBinary|
 /// passing the |vnodeID|.
-- (void)postToKernelAction:(santa_action_t)action forVnodeID:(uint64_t)vnodeid {
+- (void)postToKernelAction:(santa_action_t)action
+                forVnodeID:(uint64_t)vnodeid
+                 timestamp:(uint64_t)timestamp {
+  uint64_t input[2] = {vnodeid, timestamp};
   if (action == ACTION_RESPOND_ALLOW) {
-    IOConnectCallScalarMethod(self.connection, kSantaUserClientAllowBinary, &vnodeid, 1, 0, 0);
+    IOConnectCallScalarMethod(self.connection, kSantaUserClientAllowBinary, input, 2, 0, 0);
   } else if (action == ACTION_RESPOND_DENY) {
-    IOConnectCallScalarMethod(self.connection, kSantaUserClientDenyBinary, &vnodeid, 1, 0, 0);
+    IOConnectCallScalarMethod(self.connection, kSantaUserClientDenyBinary, input, 2, 0, 0);
   }
 }
 
@@ -227,20 +230,32 @@
         if (vdata.action != ACTION_REQUEST_BINARY) continue;
 
         if ([[self sha256ForPath:@(vdata.path)] isEqual:edSHA]) {
-          [self postToKernelAction:ACTION_RESPOND_DENY forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_DENY
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
         } else if (strncmp("/bin/mv", vdata.path, strlen("/bin/mv")) == 0) {
-          [self postToKernelAction:ACTION_RESPOND_DENY forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_DENY
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
         } else if (strncmp("/bin/ls", vdata.path, strlen("/bin/ls")) == 0) {
-          [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_ALLOW
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
           self.timesSeenLs++;
         } else if (strncmp("/bin/cp", vdata.path, strlen("/bin/cp")) == 0) {
-          [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_ALLOW
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
           self.timesSeenCp++;
         } else if (strncmp("/bin/cat", vdata.path, strlen("/bin/cat")) == 0) {
-          [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_ALLOW
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
           self.timesSeenCat++;
         } else if (strncmp("/bin/ln", vdata.path, strlen("/bin/ln")) == 0) {
-          [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_ALLOW
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
 
           TSTART("Sends valid pid/ppid");
           if (vdata.pid < 1 || vdata.ppid < 1) {
@@ -269,7 +284,9 @@
           }
 
           // Allow everything not related to our testing.
-          [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:vdata.vnode_id];
+          [self postToKernelAction:ACTION_RESPOND_ALLOW
+                        forVnodeID:vdata.vnode_id
+                         timestamp:vdata.timestamp];
         }
       } else {
         TFAILINFO("Error receiving data: %d", kr);


### PR DESCRIPTION
https://github.com/google/santa/commit/133814cd733dce84d30a71aad336b3739d7953bc introduced a hanging issue when making decisions are larger executables. This stems from prematurely evicting ACTION_REQUEST_BINARY entries from the kernel cache, causing the decision queue to fill up with re-requests.

To be able to evict stale ACTION_REQUEST_BINARY requests we need to:
  *  store a timestamp at request time
  *  Send the timestamp along with the request to user-space and receive the timestamp along with the decision back in the kernel-space
  *  Use the timestamp along with ACTION_REQUEST_BINARY as the expected CAS value before updating the decision.