### PR TITLE
SNTConfigurator: use mobileconfigs

### DIFF
--- a/Source/SantaGUI/SNTAppDelegate.m
+++ b/Source/SantaGUI/SNTAppDelegate.m
@@ -37,9 +37,9 @@
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   [self setupMenu];
 
-  self.configFileWatcher = [[SNTFileWatcher alloc] initWithFilePath:kDefaultConfigFilePath
+  self.configFileWatcher = [[SNTFileWatcher alloc] initWithFilePath:kMobileConfigFilePath
                                                             handler:^(unsigned long data) {
-    if (! (data & DISPATCH_VNODE_ATTRIB)) [[SNTConfigurator configurator] reloadConfigData];
+    if (!(data & DISPATCH_VNODE_ATTRIB)) [[SNTConfigurator configurator] reloadConfigData];
   }];
 
   self.notificationManager = [[SNTNotificationManager alloc] init];

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -16,6 +16,7 @@
 
 #import "SNTCommonEnums.h"
 
+extern NSString *const kSyncStateFilePath;
 extern NSString *const kMobileConfigFilePath;
 
 ///
@@ -204,5 +205,10 @@ extern NSString *const kMobileConfigFilePath;
 ///  Re-read config data from disk.
 ///
 - (void)reloadConfigData;
+
+///
+///  Notify the receiver that the sync state file has changed.
+///
+- (void)syncStateFileChanged:(unsigned long)data;
 
 @end

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -16,14 +16,13 @@
 
 #import "SNTCommonEnums.h"
 
+extern NSString *const kMobileConfigFilePath;
+
 ///
 ///  Singleton that provides an interface for managing configuration values on disk
 ///  @note This class is designed as a singleton but that is not strictly enforced.
 ///
 @interface SNTConfigurator : NSObject
-
-///  Default config file path
-extern NSString *const kDefaultConfigFilePath;
 
 #pragma mark - Daemon Settings
 
@@ -200,13 +199,6 @@ extern NSString *const kDefaultConfigFilePath;
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;
-
-///
-///  Designated initializer.
-///
-///  @param filePath The path to the file to use as a backing store.
-///
-- (instancetype)initWithFilePath:(NSString *)filePath;
 
 ///
 ///  Re-read config data from disk.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -359,7 +359,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
                                               error:&error];
   if (!readData) {
     LOGE(@"Could not read sync state file: %@, replacing.", [error localizedDescription]);
-    [self saveSyncStateToDisk];
     return;
   }
 
@@ -370,7 +369,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
                                                   error:&error];
   if (!syncState) {
     LOGE(@"Could not parse sync state file: %@, replacing.", [error localizedDescription]);
-    [self saveSyncStateToDisk];
     return;
   }
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -27,9 +27,6 @@
 
 /// A NSUserDefaults object set to use the com.google.santa suite.
 @property(readonly, nonatomic) NSUserDefaults *defaults;
-
-/// Array of keys that cannot be changed while santad is running if santad didn't make the change.
-@property(readonly) NSArray *protectedKeys;
 @end
 
 @implementation SNTConfigurator
@@ -100,7 +97,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return sharedConfigurator;
 }
 
-#pragma mark Protected Keys
+#pragma mark Keys
 
 - (NSArray *)syncServerKeys {
   static NSArray *keys;
@@ -430,7 +427,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
     }
   }
   if (config[kSyncBaseURLKey] || self.syncBaseURL) {
-    for (NSString *key in [self protectedKeys]) {
+    for (NSString *key in [self syncServerKeys]) {
       if ([key isEqualToString:kSyncBaseURLKey]) continue;
       [config removeObjectForKey:key];
     }

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -426,7 +426,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       config[key] = [self.defaults objectForKey:key];
     }
   }
-  if (config[kSyncBaseURLKey] || self.syncBaseURL) {
+  if (config[kSyncBaseURLKey]) {
     for (NSString *key in [self syncServerKeys]) {
       if ([key isEqualToString:kSyncBaseURLKey]) continue;
       [config removeObjectForKey:key];

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -92,40 +92,28 @@
 
     __block SNTClientMode origMode = [[SNTConfigurator configurator] clientMode];
     __block NSURL *origSyncURL = [[SNTConfigurator configurator] syncBaseURL];
-    _configFileWatcher = [[SNTFileWatcher alloc] initWithFilePath:kDefaultConfigFilePath
+    _configFileWatcher = [[SNTFileWatcher alloc] initWithFilePath:kMobileConfigFilePath
                                                           handler:^(unsigned long data) {
-      if (data & DISPATCH_VNODE_ATTRIB) {
-        const char *cPath = [kDefaultConfigFilePath fileSystemRepresentation];
-        struct stat fileStat;
-        stat(cPath, &fileStat);
-        int mask = S_IRWXU | S_IRWXG | S_IRWXO;
-        int desired = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-        if (fileStat.st_uid != 0 || fileStat.st_gid != 0 || (fileStat.st_mode & mask) != desired) {
-          LOGD(@"Config file permissions changed, fixing.");
-          chown(cPath, 0, 0);
-          chmod(cPath, desired);
-        }
-      } else {
-        LOGD(@"Config file changed, reloading.");
-        [[SNTConfigurator configurator] reloadConfigData];
 
-        // Flush cache if client just went into lockdown.
-        SNTClientMode newMode = [[SNTConfigurator configurator] clientMode];
-        if (origMode != newMode) {
-          origMode = newMode;
-          if (newMode == SNTClientModeLockdown) {
-            LOGI(@"Changed client mode, flushing cache.");
-            [self.driverManager flushCacheNonRootOnly:NO];
-          }
-        }
+      LOGD(@"Mobileconfig changed, reloading.");
+      [[SNTConfigurator configurator] reloadConfigData];
 
-        // Start santactl if the syncBaseURL changed from nil --> somthing
-        NSURL *syncURL = [[SNTConfigurator configurator] syncBaseURL];
-        if (!origSyncURL && syncURL) {
-          origSyncURL = syncURL;
-          LOGI(@"SyncBaseURL added, starting santactl.");
-          [self startSyncd];
+      // Flush cache if client just went into lockdown.
+      SNTClientMode newMode = [[SNTConfigurator configurator] clientMode];
+      if (origMode != newMode) {
+        origMode = newMode;
+        if (newMode == SNTClientModeLockdown) {
+          LOGI(@"Changed client mode, flushing cache.");
+          [self.driverManager flushCacheNonRootOnly:NO];
         }
+      }
+
+      // Start santactl if the syncBaseURL changed from nil --> somthing
+      NSURL *syncURL = [[SNTConfigurator configurator] syncBaseURL];
+      if (!origSyncURL && syncURL) {
+        origSyncURL = syncURL;
+        LOGI(@"SyncBaseURL added, starting santactl.");
+        [self startSyncd];
       }
     }];
 

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -42,6 +42,7 @@
 @property SNTEventLog *eventLog;
 @property SNTExecutionController *execController;
 @property SNTFileWatcher *configFileWatcher;
+@property SNTFileWatcher *syncStateWatcher;
 @property SNTXPCConnection *controlConnection;
 @end
 
@@ -115,6 +116,11 @@
         LOGI(@"SyncBaseURL added, starting santactl.");
         [self startSyncd];
       }
+    }];
+
+    _syncStateWatcher = [[SNTFileWatcher alloc] initWithFilePath:kSyncStateFilePath
+                                                         handler:^(unsigned long data) {
+      [[SNTConfigurator configurator] syncStateFileChanged:data];
     }];
 
     _eventLog = [[SNTEventLog alloc] init];

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -135,6 +135,11 @@ double watchdogRAMPeak = 0;
 
 - (void)setClientMode:(SNTClientMode)mode reply:(void (^)())reply {
   if ([[SNTConfigurator configurator] clientMode] != mode) {
+    // Flush cache if client just went into lockdown.
+    if (mode == SNTClientModeLockdown) {
+      LOGI(@"Changed client mode, flushing cache.");
+      [self.driverManager flushCacheNonRootOnly:NO];
+    }
     [[SNTConfigurator configurator] setClientMode:mode];
     [[self.notQueue.notifierConnection remoteObjectProxy] postClientModeNotification:mode];
   }


### PR DESCRIPTION
*  `/var/db/santa/config.plist` is now ignored and not used
*  `/var/db/santa/sync-state.plist` now holds state from the sync server
*  `com.google.santa` mobileconfig is now used for configuration
*  If a mobileconfig manages the `SyncBaseURL` the ` kClientModeKey` `kWhitelistRegexKey` `kBlacklistRegexKey` `kFileChangesRegexKey` keys will be ignored within the mobile config.

Fixes https://github.com/google/santa/issues/209

~~One note: The sync-state.plist could include values from a mobile config if the sync server is not setting them. This "effective" sync-state will only make a difference if the mobile config changed values while santad was not running and the sync server was not managing those values.~~