### PR TITLE
santactl: Added -h and --help as synonyms for help

### DIFF
--- a/Source/santactl/main.m
+++ b/Source/santactl/main.m
@@ -53,7 +53,9 @@ int main(int argc, const char *argv[]) {
     }
     [arguments removeObjectAtIndex:0];
 
-    if ([commandName isEqualToString:@"help"]) {
+    if ([commandName isEqualToString:@"help"] ||
+        [commandName isEqualToString:@"-h"] ||
+        [commandName isEqualToString:@"--help"]) {
       if ([arguments count]) {
         // User wants help for specific command
         commandName = [arguments firstObject];


### PR DESCRIPTION
Fixes #216 .  As implemented -h and --help must be the first argument to do anything which I think is sort of reasonable as there is an extremely remote possibility that have a file named "--help" that you wanted to run fileinfo on.