### PR TITLE
 config: use KVO

### DIFF
--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -149,7 +149,6 @@
 		0DEA5F7D1CF64EB600704398 /* SNTCommandSyncRuleDownload.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0A1EC2191998C900B8450F /* SNTCommandSyncRuleDownload.m */; };
 		0DEFB7C01ACB28B000B92AAE /* SNTCommandSyncConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7BF1ACB28B000B92AAE /* SNTCommandSyncConstants.m */; };
 		0DEFB7C41ACDD80100B92AAE /* SNTFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C31ACDD80100B92AAE /* SNTFileWatcher.m */; };
-		0DEFB7C51ACDD80100B92AAE /* SNTFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C31ACDD80100B92AAE /* SNTFileWatcher.m */; };
 		0DEFB7C61ACDE5F600B92AAE /* SNTFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C31ACDD80100B92AAE /* SNTFileWatcher.m */; };
 		0DEFB7C81ACF0BFE00B92AAE /* SNTFileWatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C71ACF0BFE00B92AAE /* SNTFileWatcherTest.m */; };
 		0DF395641AB76A7900CBC520 /* NSData+Zlib.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DF395631AB76A7900CBC520 /* NSData+Zlib.m */; };
@@ -173,6 +172,7 @@
 		C776A1071DEE160500A56616 /* SNTCommandSyncManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C776A1061DEE160500A56616 /* SNTCommandSyncManager.m */; };
 		C78227631E1C3C7D006EB2D6 /* santabs.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = C78227541E1C3C58006EB2D6 /* santabs.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C7943FE92028B855008D4F76 /* SNTFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C31ACDD80100B92AAE /* SNTFileWatcher.m */; };
+		C7943FEA2028C4F7008D4F76 /* SNTFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C31ACDD80100B92AAE /* SNTFileWatcher.m */; };
 		C795ED901D80A5BE007CFF42 /* SNTPolicyProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C795ED8F1D80A5BE007CFF42 /* SNTPolicyProcessor.m */; };
 		C795ED911D80B66B007CFF42 /* SNTPolicyProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C795ED8F1D80A5BE007CFF42 /* SNTPolicyProcessor.m */; };
 		C79A23581E23F7E80037AFA8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C79A23561E23F7E80037AFA8 /* main.m */; };
@@ -1535,6 +1535,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C7943FEA2028C4F7008D4F76 /* SNTFileWatcher.m in Sources */,
 				0DCA552718C95928002A7DAE /* SNTXPCConnection.m in Sources */,
 				0D385DF1180DE51600418BC6 /* SNTAppDelegate.m in Sources */,
 				0D88680A1AC48A1200B86659 /* SNTSystemInfo.m in Sources */,
@@ -1549,7 +1550,6 @@
 				0D1B477019A53419008CADD3 /* SNTAboutWindowController.m in Sources */,
 				0D668E8118D1121700E29A8B /* SNTMessageWindow.m in Sources */,
 				0DA73CA11934F8100056D7C4 /* SNTLogging.m in Sources */,
-				0DEFB7C51ACDD80100B92AAE /* SNTFileWatcher.m in Sources */,
 				C7479F051E53704E0054C1CF /* SNTXPCBundleServiceInterface.m in Sources */,
 				0D20710E1A7C4A86008B0A9A /* SNTStoredEvent.m in Sources */,
 				0DE2CE561CA05561002B649A /* SNTAccessibleTextField.m in Sources */,

--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		C76614EC1D142D3C00D150C1 /* SNTCommandCheckCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C76614EB1D142D3C00D150C1 /* SNTCommandCheckCache.m */; };
 		C776A1071DEE160500A56616 /* SNTCommandSyncManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C776A1061DEE160500A56616 /* SNTCommandSyncManager.m */; };
 		C78227631E1C3C7D006EB2D6 /* santabs.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = C78227541E1C3C58006EB2D6 /* santabs.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C7943FE92028B855008D4F76 /* SNTFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DEFB7C31ACDD80100B92AAE /* SNTFileWatcher.m */; };
 		C795ED901D80A5BE007CFF42 /* SNTPolicyProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C795ED8F1D80A5BE007CFF42 /* SNTPolicyProcessor.m */; };
 		C795ED911D80B66B007CFF42 /* SNTPolicyProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C795ED8F1D80A5BE007CFF42 /* SNTPolicyProcessor.m */; };
 		C79A23581E23F7E80037AFA8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C79A23561E23F7E80037AFA8 /* main.m */; };
@@ -1515,6 +1516,7 @@
 				C76614EC1D142D3C00D150C1 /* SNTCommandCheckCache.m in Sources */,
 				0D416401191974F1006A356A /* SNTCommandSyncState.m in Sources */,
 				0DC5D871192160180078A5C0 /* SNTCommandSyncLogUpload.m in Sources */,
+				C7943FE92028B855008D4F76 /* SNTFileWatcher.m in Sources */,
 				0DB77FDA1CD14092004DF060 /* SNTBlockMessage.m in Sources */,
 				0D35BDA218FD71CE00921A21 /* main.m in Sources */,
 				0DCD6043190ACCB8006B445C /* SNTFileInfo.m in Sources */,

--- a/Source/SantaGUI/SNTAppDelegate.m
+++ b/Source/SantaGUI/SNTAppDelegate.m
@@ -36,12 +36,6 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   [self setupMenu];
-
-  self.configFileWatcher = [[SNTFileWatcher alloc] initWithFilePath:kMobileConfigFilePath
-                                                            handler:^(unsigned long data) {
-    if (!(data & DISPATCH_VNODE_ATTRIB)) [[SNTConfigurator configurator] reloadConfigData];
-  }];
-
   self.notificationManager = [[SNTNotificationManager alloc] init];
 
   NSNotificationCenter *workspaceNotifications = [[NSWorkspace sharedWorkspace] notificationCenter];

--- a/Source/SantaGUI/SNTAppDelegate.m
+++ b/Source/SantaGUI/SNTAppDelegate.m
@@ -16,7 +16,6 @@
 
 #import "SNTAboutWindowController.h"
 #import "SNTConfigurator.h"
-#import "SNTFileWatcher.h"
 #import "SNTNotificationManager.h"
 #import "SNTStrengthify.h"
 #import "SNTXPCConnection.h"
@@ -24,7 +23,6 @@
 
 @interface SNTAppDelegate ()
 @property SNTAboutWindowController *aboutWindowController;
-@property SNTFileWatcher *configFileWatcher;
 @property SNTNotificationManager *notificationManager;
 @property SNTXPCConnection *daemonListener;
 @property SNTXPCConnection *bundleListener;

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -16,14 +16,24 @@
 
 #import "SNTCommonEnums.h"
 
-extern NSString *const kSyncStateFilePath;
-extern NSString *const kMobileConfigFilePath;
+///
+///  A protocol to notify the implementor when the client mode or sync server changes.
+///
+@protocol SNTConfiguratorReceiver
+@required
+- (void)clientModeDidChange:(SNTClientMode)newClientMode;
+- (void)syncBaseURLDidChange:(NSURL *)newSyncBaseURL;
+@end
 
 ///
 ///  Singleton that provides an interface for managing configuration values on disk
 ///  @note This class is designed as a singleton but that is not strictly enforced.
 ///
 @interface SNTConfigurator : NSObject
+
+#pragma mark - SNTConfiguratorReceiver delegate
+
+@property id delegate;
 
 #pragma mark - Daemon Settings
 
@@ -39,7 +49,7 @@ extern NSString *const kMobileConfigFilePath;
 ///  pointless as a path only ever has a single line.
 ///  If the regex doesn't begin with ^ to match from the beginning of the line, it will be added.
 ///
-@property(nonatomic) NSRegularExpression *fileChangesRegex;
+@property(readonly, nonatomic) NSRegularExpression *fileChangesRegex;
 
 ///
 ///  The regex of whitelisted paths. Regexes are specified in ICU format.
@@ -200,16 +210,5 @@ extern NSString *const kMobileConfigFilePath;
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;
-
-///
-///  Re-read config data from configuration sources. Returns YES if the reload completed
-///  successfully, NO if a reload is currently in progress.
-///
-- (BOOL)reloadConfigData;
-
-///
-///  Notify the receiver that the sync state file has changed.
-///
-- (void)syncStateFileChanged:(unsigned long)data;
 
 @end

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -202,9 +202,10 @@ extern NSString *const kMobileConfigFilePath;
 + (instancetype)configurator;
 
 ///
-///  Re-read config data from disk.
+///  Re-read config data from configuration sources. Returns YES if the reload completed
+///  successfully, NO if a reload is currently in progress.
 ///
-- (void)reloadConfigData;
+- (BOOL)reloadConfigData;
 
 ///
 ///  Notify the receiver that the sync state file has changed.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -17,30 +17,51 @@
 #import "SNTCommonEnums.h"
 
 ///
-///  A protocol to notify the implementer when the client mode or sync server changes.
-///
-@protocol SNTConfiguratorReceiver
-@required
-- (void)clientModeDidChange:(SNTClientMode)newClientMode;
-- (void)syncBaseURLDidChange:(NSURL *)newSyncBaseURL;
-@end
-
-///
 ///  Singleton that provides an interface for managing configuration values on disk
 ///  @note This class is designed as a singleton but that is not strictly enforced.
+///  @note All properties are KVO compliant.
 ///
 @interface SNTConfigurator : NSObject
-
-#pragma mark - SNTConfiguratorReceiver delegate
-
-@property id delegate;
 
 #pragma mark - Daemon Settings
 
 ///
 ///  The operating mode.
 ///
-@property(nonatomic) SNTClientMode clientMode;
+@property(readonly, nonatomic) SNTClientMode clientMode;
+
+///
+///  Set the operating mode as received from a sync server.
+///
+- (void)setSyncServerClientMode:(SNTClientMode)newMode;
+
+///
+///  The regex of whitelisted paths. Regexes are specified in ICU format.
+///
+///  The regex flags IXSM can be used, though the s (dotall) and m (multiline) flags are
+///  pointless as a path only ever has a single line.
+///  If the regex doesn't begin with ^ to match from the beginning of the line, it will be added.
+///
+@property(readonly, nonatomic) NSRegularExpression *whitelistPathRegex;
+
+///
+///  Set the regex of whitelisted paths as received from a sync server.
+///
+- (void)setSyncServerWhitelistPathRegex:(NSRegularExpression *)re;
+
+///
+///  The regex of blacklisted paths. Regexes are specified in ICU format.
+///
+///  The regex flags IXSM can be used, though the s (dotall) and m (multiline) flags are
+///  pointless as a path only ever has a single line.
+///  If the regex doesn't begin with ^ to match from the beginning of the line, it will be added.
+///
+@property(readonly, nonatomic) NSRegularExpression *blacklistPathRegex;
+
+///
+///  Set the regex of blacklisted paths as received from a sync server.
+///
+- (void)setSyncServerBlacklistPathRegex:(NSRegularExpression *)re;
 
 ///
 ///  The regex of paths to log file changes for. Regexes are specified in ICU format.
@@ -50,24 +71,6 @@
 ///  If the regex doesn't begin with ^ to match from the beginning of the line, it will be added.
 ///
 @property(readonly, nonatomic) NSRegularExpression *fileChangesRegex;
-
-///
-///  The regex of whitelisted paths. Regexes are specified in ICU format.
-///
-///  The regex flags IXSM can be used, though the s (dotall) and m (multiline) flags are
-///  pointless as a path only ever has a single line.
-///  If the regex doesn't begin with ^ to match from the beginning of the line, it will be added.
-///
-@property(nonatomic) NSRegularExpression *whitelistPathRegex;
-
-///
-///  The regex of blacklisted paths. Regexes are specified in ICU format.
-///
-///  The regex flags IXSM can be used, though the s (dotall) and m (multiline) flags are
-///  pointless as a path only ever has a single line.
-///  If the regex doesn't begin with ^ to match from the beginning of the line, it will be added.
-///
-@property(nonatomic) NSRegularExpression *blacklistPathRegex;
 
 ///
 ///  Enable __PAGEZERO protection, defaults to YES
@@ -210,5 +213,10 @@
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;
+
+///
+///  Clear the sync server configuration from the effective configuration.
+///
+- (void)clearSyncState;
 
 @end

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -17,7 +17,7 @@
 #import "SNTCommonEnums.h"
 
 ///
-///  A protocol to notify the implementor when the client mode or sync server changes.
+///  A protocol to notify the implementer when the client mode or sync server changes.
 ///
 @protocol SNTConfiguratorReceiver
 @required

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -380,7 +380,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (BOOL)reloadConfigData {
   if (!OSAtomicCompareAndSwap32Barrier(0, 1, &_reloading)) return NO;
-  sleep(5);
+  sleep(5); // Allow the on-disk changes to appear in NSUserDefaults
   [self reloadConfigDataHelper];
   OSAtomicCompareAndSwap32Barrier(1, 0, &_reloading);
   return YES;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -392,7 +392,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
     machineId = [plist[plistKey] isKindOfClass:[NSString class]] ? plist[plistKey] : nil;
   }
 
-  return [machineId length] ? machineId : [SNTSystemInfo hardwareUUID];
+  return machineId.length ? machineId : [SNTSystemInfo hardwareUUID];
 }
 
 #pragma mark Private
@@ -419,12 +419,12 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   NSMutableDictionary *syncState =
       [NSMutableDictionary dictionaryWithContentsOfFile:kSyncStateFilePath];
   for (NSString *key in syncState.allKeys) {
-    if (![syncState[key] isKindOfClass:self.syncServerKeyTypes[key]]) {
-      syncState[key] = nil;
-      continue;
-    } else if (self.syncServerKeyTypes[key] == [NSRegularExpression class]) {
+    if (self.syncServerKeyTypes[key] == [NSRegularExpression class]) {
       NSString *pattern = [syncState[key] isKindOfClass:[NSString class]] ? syncState[key] : nil;
       syncState[key] = [self expressionForPattern:pattern];
+    } else if (![syncState[key] isKindOfClass:self.syncServerKeyTypes[key]]) {
+      syncState[key] = nil;
+      continue;
     }
   }
   static dispatch_once_t onceToken;

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -75,8 +75,11 @@
 - (void)setClientMode:(SNTClientMode)mode reply:(void (^)())reply;
 - (void)xsrfToken:(void (^)(NSString *))reply;
 - (void)setXsrfToken:(NSString *)token reply:(void (^)())reply;
-- (void)setSyncLastSuccess:(NSDate *)date reply:(void (^)())reply;
+- (void)fullSyncLastSuccess:(void (^)(NSDate *))reply;
+- (void)setFullSyncLastSuccess:(NSDate *)date reply:(void (^)())reply;
+- (void)ruleSyncLastSuccess:(void (^)(NSDate *))reply;
 - (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)())reply;
+- (void)syncCleanRequired:(void (^)(BOOL))reply;
 - (void)setSyncCleanRequired:(BOOL)cleanReqd reply:(void (^)())reply;
 - (void)setWhitelistPathRegex:(NSString *)pattern reply:(void (^)())reply;
 - (void)setBlacklistPathRegex:(NSString *)pattern reply:(void (^)())reply;

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -103,15 +103,26 @@ REGISTER_COMMAND_NAME(@"status")
   }];
 
   // Sync status
-  NSString *syncURLStr = [[[SNTConfigurator configurator] syncBaseURL] absoluteString];
-  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-  dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
-  NSDate *lastSyncSuccess = [[SNTConfigurator configurator] fullSyncLastSuccess];
-  NSString *lastSyncSuccessStr = [dateFormatter stringFromDate:lastSyncSuccess] ?: @"Never";
-  NSDate *lastRuleSyncSuccess = [[SNTConfigurator configurator] ruleSyncLastSuccess];
-  NSString *lastRuleSyncSuccessStr =
-      [dateFormatter stringFromDate:lastRuleSyncSuccess] ?: lastSyncSuccessStr;
-  BOOL syncCleanReqd = [[SNTConfigurator configurator] syncCleanRequired];
+  __block NSDate *fullSyncLastSuccess;
+  dispatch_group_enter(group);
+  [[self.daemonConn remoteObjectProxy] fullSyncLastSuccess:^(NSDate *date) {
+    fullSyncLastSuccess = date;
+    dispatch_group_leave(group);
+  }];
+
+  __block NSDate *ruleSyncLastSuccess;
+  dispatch_group_enter(group);
+  [[self.daemonConn remoteObjectProxy] ruleSyncLastSuccess:^(NSDate *date) {
+    ruleSyncLastSuccess = date;
+    dispatch_group_leave(group);
+  }];
+
+  __block BOOL syncCleanReqd = NO;
+  dispatch_group_enter(group);
+  [[self.daemonConn remoteObjectProxy] syncCleanRequired:^(BOOL clean) {
+    syncCleanReqd = clean;
+    dispatch_group_leave(group);
+  }];
 
   __block BOOL pushNotifications = NO;
   if ([[SNTConfigurator configurator] syncBaseURL]) {
@@ -136,6 +147,15 @@ REGISTER_COMMAND_NAME(@"status")
     fprintf(stderr, "Failed to retrieve some stats from daemon\n\n");
   }
 
+  // Format dates
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z";
+  NSString *fullSyncLastSuccessStr = [dateFormatter stringFromDate:fullSyncLastSuccess] ?: @"Never";
+  NSString *ruleSyncLastSuccessStr =
+      [dateFormatter stringFromDate:ruleSyncLastSuccess] ?: fullSyncLastSuccessStr;
+
+  NSString *syncURLStr = [[[SNTConfigurator configurator] syncBaseURL] absoluteString];
+
   if ([arguments containsObject:@"--json"]) {
     NSDictionary *stats = @{
       @"daemon" : @{
@@ -158,8 +178,8 @@ REGISTER_COMMAND_NAME(@"status")
       @"sync" : @{
         @"server" : syncURLStr ?: @"null",
         @"clean_required" : @(syncCleanReqd),
-        @"last_successful_full" : lastSyncSuccessStr ?: @"null",
-        @"last_successful_rule" : lastRuleSyncSuccessStr ?: @"null",
+        @"last_successful_full" : fullSyncLastSuccessStr ?: @"null",
+        @"last_successful_rule" : ruleSyncLastSuccessStr ?: @"null",
         @"push_notifications" : pushNotifications ? @"Connected" : @"Disconnected",
         @"bundle_scanning" : @(bundlesEnabled)
       },
@@ -187,8 +207,8 @@ REGISTER_COMMAND_NAME(@"status")
       printf(">>> Sync Info\n");
       printf("  %-25s | %s\n", "Sync Server", [syncURLStr UTF8String]);
       printf("  %-25s | %s\n", "Clean Sync Required", (syncCleanReqd ? "Yes" : "No"));
-      printf("  %-25s | %s\n", "Last Successful Full Sync", [lastSyncSuccessStr UTF8String]);
-      printf("  %-25s | %s\n", "Last Successful Rule Sync", [lastRuleSyncSuccessStr UTF8String]);
+      printf("  %-25s | %s\n", "Last Successful Full Sync", [fullSyncLastSuccessStr UTF8String]);
+      printf("  %-25s | %s\n", "Last Successful Rule Sync", [ruleSyncLastSuccessStr UTF8String]);
       printf("  %-25s | %s\n", "Push Notifications",
              (pushNotifications ? "Connected" : "Disconnected"));
       printf("  %-25s | %s\n", "Bundle Scanning", (bundlesEnabled ? "Yes" : "No"));

--- a/Source/santactl/Commands/sync/SNTCommandSyncPostflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPostflight.m
@@ -63,7 +63,7 @@
 
   // Update last sync success
   dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] setSyncLastSuccess:[NSDate date] reply:replyBlock];
+  [[self.daemonConn remoteObjectProxy] setFullSyncLastSuccess:[NSDate date] reply:replyBlock];
 
   // Wait for dispatch group
   dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -60,11 +60,17 @@
     dispatch_group_leave(group);
   }];
 
+  __block BOOL syncClean = NO;
+  dispatch_group_enter(group);
+  [[self.daemonConn remoteObjectProxy] syncCleanRequired:^(BOOL clean) {
+    syncClean = clean;
+    dispatch_group_leave(group);
+  }];
+
   dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
 
   // If user requested it or we've never had a successful sync, try from a clean slate.
-  if ([[[NSProcessInfo processInfo] arguments] containsObject:@"--clean"] ||
-      [[SNTConfigurator configurator] syncCleanRequired]) {
+  if ([[[NSProcessInfo processInfo] arguments] containsObject:@"--clean"] || syncClean) {
     LOGD(@"Clean sync requested by user");
     requestDict[kRequestCleanSync] = @YES;
   }

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -98,9 +98,9 @@
     __block NSURL *origSyncURL = [[SNTConfigurator configurator] syncBaseURL];
     _configFileWatcher = [[SNTFileWatcher alloc] initWithFilePath:kMobileConfigFilePath
                                                           handler:^(unsigned long data) {
-
-      LOGD(@"Mobileconfig changed, reloading.");
-      [[SNTConfigurator configurator] reloadConfigData];
+      if (data & DISPATCH_VNODE_ATTRIB) return;
+      if (![[SNTConfigurator configurator] reloadConfigData]) return;
+      LOGI(@"Mobileconfig changed, reloading.");
 
       // Flush cache if client just went into lockdown.
       SNTClientMode newMode = [[SNTConfigurator configurator] clientMode];

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -78,7 +78,7 @@
       [self startSyncd];
     };
 
-    // Listen for clientMode and syncBaseURL changes
+    // Listen for actionable config changes.
     NSKeyValueObservingOptions bits = (NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld);
     [[SNTConfigurator configurator] addObserver:self
                                      forKeyPath:@"clientMode"
@@ -270,7 +270,6 @@ void diskDisappearedCallback(DADiskRef disk, void *context) {
                       ofObject:(id)object
                         change:(NSDictionary<NSString *,id> *)change
                        context:(void *)context {
-  LOGD(@"%@ --> %@", keyPath, change);
   if ([keyPath isEqualToString:@"clientMode"]) {
     SNTClientMode new =
         [change[@"new"] isKindOfClass:[NSNumber class]] ? [change[@"new"] longLongValue] : 0;
@@ -290,7 +289,7 @@ void diskDisappearedCallback(DADiskRef disk, void *context) {
         [change[@"old"] isKindOfClass:[NSRegularExpression class]] ? change[@"old"] : nil;
     if (!new && !old) return;
     if (![new.pattern isEqualToString:old.pattern]) {
-      LOGI(@"Received new [white|black]list regex, flushing cache");
+      LOGI(@"Changed [white|black]list regex, flushing cache");
       [self.driverManager flushCacheNonRootOnly:NO];
     }
   }

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -297,7 +297,6 @@ void diskDisappearedCallback(DADiskRef disk, void *context) {
 }
 
 - (void)clientModeDidChange:(SNTClientMode)clientMode {
-  LOGI(@"clientModeDidChange: %li", clientMode);
   if (clientMode == SNTClientModeLockdown) {
     LOGI(@"Changed client mode, flushing cache.");
     [self.driverManager flushCacheNonRootOnly:NO];

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -159,14 +159,26 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
-- (void)setSyncLastSuccess:(NSDate *)date reply:(void (^)())reply {
+- (void)fullSyncLastSuccess:(void (^)(NSDate *))reply {
+  reply([[SNTConfigurator configurator] fullSyncLastSuccess]);
+}
+
+- (void)setFullSyncLastSuccess:(NSDate *)date reply:(void (^)())reply {
   [[SNTConfigurator configurator] setFullSyncLastSuccess:date];
   reply();
+}
+
+- (void)ruleSyncLastSuccess:(void (^)(NSDate *))reply {
+  reply([[SNTConfigurator configurator] ruleSyncLastSuccess]);
 }
 
 - (void)setRuleSyncLastSuccess:(NSDate *)date reply:(void (^)())reply {
   [[SNTConfigurator configurator] setRuleSyncLastSuccess:date];
   reply();
+}
+
+- (void)syncCleanRequired:(void (^)(BOOL))reply {
+  reply([[SNTConfigurator configurator] syncCleanRequired]);
 }
 
 - (void)setSyncCleanRequired:(BOOL)cleanReqd reply:(void (^)())reply {

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -149,7 +149,7 @@ double watchdogRAMPeak = 0;
   if ([[SNTConfigurator configurator] clientMode] != mode) {
     // Flush cache if client just went into lockdown.
     if (mode == SNTClientModeLockdown) {
-      LOGI(@"Changed client mode, flushing cache.");
+      LOGI(@"Sync server changed client mode, flushing cache.");
       [self.driverManager flushCacheNonRootOnly:NO];
     }
     [[SNTConfigurator configurator] setClientMode:mode];

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -146,15 +146,7 @@ double watchdogRAMPeak = 0;
 }
 
 - (void)setClientMode:(SNTClientMode)mode reply:(void (^)())reply {
-  if ([[SNTConfigurator configurator] clientMode] != mode) {
-    // Flush cache if client just went into lockdown.
-    if (mode == SNTClientModeLockdown) {
-      LOGI(@"Sync server changed client mode, flushing cache.");
-      [self.driverManager flushCacheNonRootOnly:NO];
-    }
-    [[SNTConfigurator configurator] setClientMode:mode];
-    [[self.notQueue.notifierConnection remoteObjectProxy] postClientModeNotification:mode];
-  }
+  [[SNTConfigurator configurator] setSyncServerClientMode:mode];
   reply();
 }
 
@@ -186,9 +178,7 @@ double watchdogRAMPeak = 0;
   NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern
                                                                       options:0
                                                                         error:NULL];
-  [[SNTConfigurator configurator] setWhitelistPathRegex:re];
-  LOGI(@"Received new whitelist regex, flushing cache");
-  [self.driverManager flushCacheNonRootOnly:NO];
+  [[SNTConfigurator configurator] setSyncServerWhitelistPathRegex:re];
   reply();
 }
 
@@ -196,9 +186,7 @@ double watchdogRAMPeak = 0;
   NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern
                                                                       options:0
                                                                         error:NULL];
-  [[SNTConfigurator configurator] setBlacklistPathRegex:re];
-  LOGI(@"Received new blacklist regex, flushing cache");
-  [self.driverManager flushCacheNonRootOnly:NO];
+  [[SNTConfigurator configurator] setSyncServerBlacklistPathRegex:re];
   reply();
 }
 


### PR DESCRIPTION
Whenever there is a system wide mobileconfig change, all on-disk representations are deleted and re-created...twice (Thanks Apple). This flapping causes Santa to reload its config many times over a short period of time. In some cases this can result in an incorrect running config.

*  Build and merge the new config in temporary variables.
*  Let the caller of `reloadConfigData` know if a reload is taking place.
*  Update callers to not do unnecessary work.