### PR TITLE
sync-state: Mitigate com.apple.ManagedClient flapping

### DIFF
--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -318,11 +318,17 @@ void diskDisappearedCallback(DADiskRef disk, void *context) {
 - (void)syncBaseURLDidChange:(NSURL *)syncBaseURL {
   if (syncBaseURL) {
     LOGI(@"Starting santactl with new SyncBaseURL: %@", syncBaseURL);
+    [NSObject cancelPreviousPerformRequestsWithTarget:[SNTConfigurator configurator]
+                                             selector:@selector(clearSyncState)
+                                               object:nil];
     [self startSyncd];
   } else {
     LOGI(@"SyncBaseURL removed, killing santactl pid: %i", self.syncdPID);
     [self stopSyncd];
-    [[SNTConfigurator configurator] clearSyncState];
+    // Keep the syncState active for 5 seconds in case com.apple.ManagedClient is flapping.
+    [[SNTConfigurator configurator] performSelector:@selector(clearSyncState)
+                                         withObject:nil
+                                         afterDelay:5];
   }
 }
 

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -325,10 +325,10 @@ void diskDisappearedCallback(DADiskRef disk, void *context) {
   } else {
     LOGI(@"SyncBaseURL removed, killing santactl pid: %i", self.syncdPID);
     [self stopSyncd];
-    // Keep the syncState active for 5 seconds in case com.apple.ManagedClient is flapping.
+    // Keep the syncState active for 10 min in case com.apple.ManagedClient is flapping.
     [[SNTConfigurator configurator] performSelector:@selector(clearSyncState)
                                          withObject:nil
-                                         afterDelay:5];
+                                         afterDelay:600];
   }
 }
 


### PR DESCRIPTION
* If the SyncBaseURL disappears, keep the syncState active for 5 seconds before clearing.