### PR TITLE
santad / santactl: validate all architectures within universal binaries

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - MOLAuthenticatingURLSession (2.4):
     - MOLCertificate (~> 1.8)
   - MOLCertificate (1.8)
-  - MOLCodesignChecker (1.9):
+  - MOLCodesignChecker (1.10):
     - MOLCertificate (~> 1.8)
   - MOLFCMClient (1.7):
     - MOLAuthenticatingURLSession (~> 2.4)
@@ -23,7 +23,7 @@ SPEC CHECKSUMS:
   FMDB: 6198a90e7b6900cfc046e6bc0ef6ebb7be9236aa
   MOLAuthenticatingURLSession: c238aa1c9a7b1077eb39a6f40204bfe76a7d204e
   MOLCertificate: c999513316d511c69f290fbf313dfe8dca4ad592
-  MOLCodesignChecker: 303c01755646a0045c97f9f0b0fe5945ead42130
+  MOLCodesignChecker: b0d5db9d2f9bd94e0fd093891a5d40e5ad77cbc0
   MOLFCMClient: ee45348909351f232e2759c580329072ae7e02d4
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
 

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -213,6 +213,11 @@
 - (NSUInteger)fileSize;
 
 ///
+///  @return The underlying file handle.
+///
+@property(readonly) NSFileHandle *fileHandle;
+
+///
 ///  @return Returns an instance of MOLCodeSignChecker initialized with the file's binary path.
 ///  Both the MOLCodesignChecker and any resulting NSError are cached and returned on subsequent
 ///  calls.  You may pass in NULL for the error if you don't care to receive it.

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -17,6 +17,7 @@
 #import <CommonCrypto/CommonDigest.h>
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 
+#include <mach-o/arch.h>
 #include <mach-o/loader.h>
 #include <mach-o/swap.h>
 #include <pwd.h>
@@ -287,7 +288,8 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 - (BOOL)isMissingPageZero {
   // This method only checks i386 arch because the kernel enforces this for other archs
   // See bsd/kern/mach_loader.c, search for enforce_hard_pagezero.
-  MachHeaderWithOffset *x86Header = self.machHeaders[[self nameForCPUType:CPU_TYPE_X86]];
+  MachHeaderWithOffset *x86Header = self.machHeaders[[self nameForCPUType:CPU_TYPE_X86
+                                                               cpuSubType:CPU_SUBTYPE_I386_ALL]];
   if (!x86Header) return NO;
 
   struct mach_header *mh = (struct mach_header *)[x86Header.data bytes];
@@ -443,7 +445,7 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
   if (machHeader) {
     struct mach_header *mh = (struct mach_header *)[machHeader bytes];
     MachHeaderWithOffset *mhwo = [[MachHeaderWithOffset alloc] initWithData:machHeader offset:0];
-    machHeaders[[self nameForCPUType:mh->cputype]] = mhwo;
+    machHeaders[[self nameForCPUType:mh->cputype cpuSubType:mh->cpusubtype]] = mhwo;
   } else {
     NSRange range = NSMakeRange(0, sizeof(struct fat_header));
     NSData *fatHeader = [self safeSubdataWithRange:range];
@@ -459,11 +461,12 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
           int offset = OSSwapBigToHostInt32(fat_arch[i].offset);
           int size = OSSwapBigToHostInt32(fat_arch[i].size);
           int cputype = OSSwapBigToHostInt(fat_arch[i].cputype);
+          int cpusubtype = OSSwapBigToHostInt(fat_arch[i].cpusubtype);
 
           range = NSMakeRange(offset, size);
           NSData *machHeader = [self parseSingleMachHeader:[self safeSubdataWithRange:range]];
           if (machHeader) {
-            NSString *key = [self nameForCPUType:cputype];
+            NSString *key = [self nameForCPUType:cputype cpuSubType:cpusubtype];
             MachHeaderWithOffset *mhwo = [[MachHeaderWithOffset alloc] initWithData:machHeader
                                                                              offset:offset];
             machHeaders[key] = mhwo;
@@ -647,20 +650,15 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 ///
 ///  Return a human-readable string for a cpu_type_t.
 ///
-- (NSString *)nameForCPUType:(cpu_type_t)cpuType {
-  switch (cpuType) {
-    case CPU_TYPE_X86:
-      return @"i386";
-    case CPU_TYPE_X86_64:
-      return @"x86-64";
-    case CPU_TYPE_POWERPC:
-      return @"ppc";
-    case CPU_TYPE_POWERPC64:
-      return @"ppc64";
-    default:
-      return @"unknown";
+- (NSString *)nameForCPUType:(cpu_type_t)cpuType cpuSubType:(cpu_subtype_t)cpuSubType {
+  const NXArchInfo *archInfo = NXGetArchInfoFromCpuType(cpuType, cpuSubType);
+  NSString *arch;
+  if (archInfo && archInfo->name) {
+    arch = @(archInfo->name);
+  } else {
+    arch = [NSString stringWithFormat:@"%i:%i", cpuType, cpuSubType];
   }
-  return nil;
+  return arch;
 }
 
 ///

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -42,6 +42,7 @@ static NSString *const kPageZero = @"Page Zero";
 static NSString *const kCodeSigned = @"Code-signed";
 static NSString *const kRule = @"Rule";
 static NSString *const kSigningChain = @"Signing Chain";
+static NSString *const kUniversalSigningChain = @"Universal Signing Chain";
 
 // signing chain keys
 static NSString *const kCommonName = @"Common Name";
@@ -115,6 +116,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 @property(readonly, copy, nonatomic) SNTAttributeBlock codeSigned;
 @property(readonly, copy, nonatomic) SNTAttributeBlock rule;
 @property(readonly, copy, nonatomic) SNTAttributeBlock signingChain;
+@property(readonly, copy, nonatomic) SNTAttributeBlock universalSigningChain;
 
 // Mapping between property string keys and SNTAttributeBlocks
 @property(nonatomic) NSDictionary<NSString *, SNTAttributeBlock> *propertyMap;
@@ -182,7 +184,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 + (NSArray<NSString *> *)fileInfoKeys {
   return @[ kPath, kSHA256, kSHA1, kBundleName, kBundleVersion, kBundleVersionStr,
             kDownloadReferrerURL, kDownloadURL, kDownloadTimestamp, kDownloadAgent,
-            kType, kPageZero, kCodeSigned, kRule, kSigningChain ];
+            kType, kPageZero, kCodeSigned, kRule, kSigningChain, kUniversalSigningChain ];
 }
 
 + (NSArray<NSString *> *)signingChainKeys {
@@ -210,7 +212,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
                       kPageZero : self.pageZero,
                       kCodeSigned : self.codeSigned,
                       kRule : self.rule,
-                      kSigningChain : self.signingChain };
+                      kSigningChain : self.signingChain,
+                      kUniversalSigningChain : self.universalSigningChain };
 
     _printQueue = dispatch_queue_create("com.google.santactl.print_queue", DISPATCH_QUEUE_SERIAL);
   }
@@ -325,6 +328,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
           return @"Yes, but failed requirement validation";
         case errSecCSInfoPlistFailed:
           return @"Yes, but can't validate as Info.plist is missing";
+        case errSecCSSignatureInvalid:
+          if ([error.domain isEqualToString:@"com.google.molcodesignchecker"]) {
+            return @"Yes, but signing is not consistent for all architectures";
+          }
         default: {
           return [NSString stringWithFormat:@"Yes, but failed to validate (%ld)", error.code];
         }
@@ -415,6 +422,46 @@ REGISTER_COMMAND_NAME(@"fileinfo")
       }];
     }
     return certs;
+  };
+}
+
+- (SNTAttributeBlock)universalSigningChain {
+  return ^id (SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
+    MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
+    if (csc.certificates.count) return nil;
+    if (!csc.universalSigningInformation) return nil;
+    NSMutableArray *universal = [NSMutableArray array];
+    for (NSDictionary *arch in csc.universalSigningInformation) {
+      [universal addObject:@{ @"arch" : arch.allKeys.firstObject }];
+      int flags = [arch.allValues.firstObject[(__bridge id)kSecCodeInfoFlags] intValue];
+      if (flags & kSecCodeSignatureAdhoc) {
+        [universal addObject:@{ @"ad-hoc" : @YES }];
+        continue;
+      }
+      NSArray *certs = arch.allValues.firstObject[(__bridge id)kSecCodeInfoCertificates];
+      NSArray *chain = [MOLCertificate certificatesFromArray:certs];
+      if (!chain.count) {
+        [universal addObject:@{ @"unsigned" : @YES }];
+        continue;
+      }
+      for (MOLCertificate *c in chain) {
+        [universal addObject:@{
+          kSHA256 : c.SHA256 ?: @"null",
+          kSHA1 : c.SHA1 ?: @"null",
+          kCommonName : c.commonName ?: @"null",
+          kOrganization : c.orgName ?: @"null",
+          kOrganizationalUnit : c.orgUnit ?: @"null",
+          kValidFrom : [cmd.dateFormatter stringFromDate:c.validFrom] ?: @"null",
+          kValidUntil : [cmd.dateFormatter stringFromDate:c.validUntil] ?: @"null"
+        }];
+      }
+    }
+    NSMutableSet *set = [NSMutableSet set];
+    for (NSDictionary *cert in universal) {
+      if (cert[@"arch"]) continue;
+      [set addObject:cert];
+    }
+    return (set.count > 1) ? universal : nil;
   };
 }
 
@@ -591,8 +638,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   } else {
     for (NSString *key in self.outputKeyList) {
       if (![outputDict objectForKey:key]) continue;
-      if ([key isEqual:kSigningChain]) {
-        [output appendString:[self stringForSigningChain:outputDict[key]]];
+      if ([key isEqual:kSigningChain] || [key isEqual:kUniversalSigningChain]) {
+        [output appendString:[self stringForSigningChain:outputDict[key] key:key]];
       } else {
         if (singleKey) {
           [output appendFormat:@"%@\n", outputDict[key]];
@@ -729,14 +776,25 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
-- (NSString *)stringForSigningChain:(NSArray *)signingChain {
+- (NSString *)stringForSigningChain:(NSArray *)signingChain key:(NSString *)key {
   if (!signingChain) return @"";
   NSMutableString *result = [NSMutableString string];
-  [result appendFormat:@"%@:\n", kSigningChain];
+  [result appendFormat:@"%@:\n", key];
   int i = 1;
   NSArray<NSString *> *certKeys = [[self class] signingChainKeys];
   for (NSDictionary *cert in signingChain) {
     if ([cert isEqual:[NSNull null]]) continue;
+    if (cert[@"arch"]) {
+      [result appendFormat:@"  %2@\n", [@"Architecture: " stringByAppendingString:cert[@"arch"]]];
+      i = 1;
+      continue;
+    } else if (cert[@"ad-hoc"]) {
+      [result appendFormat:@"    %2d. %-20@\n", i, @"ad-hoc"];
+      continue;
+    } else if (cert[@"unsigned"]) {
+      [result appendFormat:@"    %2d. %-20@\n", i, @"unsigned"];
+      continue;
+    }
     if (i > 1) [result appendFormat:@"\n"];
     [result appendString:[self stringForCertificate:cert withKeys:certKeys index:i]];
     i += 1;
@@ -750,10 +808,10 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   BOOL firstKey = YES;
   for (NSString *key in keys) {
     if (firstKey) {
-      [result appendFormat:@"    %2d. %-20s: %@\n", index, key.UTF8String, cert[key]];
+      [result appendFormat:@"   %2d. %-20s: %@\n", index, key.UTF8String, cert[key]];
       firstKey = NO;
     } else {
-      [result appendFormat:@"        %-20s: %@\n", key.UTF8String, cert[key]];
+      [result appendFormat:@"       %-20s: %@\n", key.UTF8String, cert[key]];
     }
   }
   return result.copy;

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -117,9 +117,11 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
 
   // Get codesigning info about the file.
   NSError *csError;
-  MOLCodesignChecker *csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:binInfo.path
-                                                                        error:&csError];
-  // Ignore codesigning if there are any errors with the signature. 
+  MOLCodesignChecker *csInfo =
+      [[MOLCodesignChecker alloc] initWithBinaryPath:binInfo.path
+                                      fileDescriptor:binInfo.fileHandle.fileDescriptor
+                                               error:&csError];
+  // Ignore codesigning if there are any errors with the signature.
   if (csError) csInfo = nil;
 
   // Actually make the decision.

--- a/Tests/LogicTests/SNTExecutionControllerTest.m
+++ b/Tests/LogicTests/SNTExecutionControllerTest.m
@@ -47,7 +47,10 @@
 
   self.mockCodesignChecker = OCMClassMock([MOLCodesignChecker class]);
   OCMStub([self.mockCodesignChecker alloc]).andReturn(self.mockCodesignChecker);
-  OCMStub([self.mockCodesignChecker initWithBinaryPath:OCMOCK_ANY error:[OCMArg setTo:NULL]])
+
+  OCMStub([self.mockCodesignChecker initWithBinaryPath:OCMOCK_ANY
+                                        fileDescriptor:0
+                                                 error:[OCMArg setTo:NULL]])
       .andReturn(self.mockCodesignChecker);
 
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);


### PR DESCRIPTION
* Use MOLCodesignChecker v1.10
* Update `santactl fileinfo` to display universal signing information when appropriate  