### PR TITLE
Project: stop using @import for reasons.

### DIFF
--- a/Source/SantaGUI/SNTAboutWindowController.h
+++ b/Source/SantaGUI/SNTAboutWindowController.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 @interface SNTAboutWindowController : NSWindowController
 

--- a/Source/SantaGUI/SNTAccessibleTextField.h
+++ b/Source/SantaGUI/SNTAccessibleTextField.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 /**
    An NSTextField subclass that provides an accessiblity label equal to:

--- a/Source/SantaGUI/SNTAppDelegate.h
+++ b/Source/SantaGUI/SNTAppDelegate.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 ///
 /// Initiates and manages the connection to santad

--- a/Source/SantaGUI/SNTMessageWindow.h
+++ b/Source/SantaGUI/SNTMessageWindow.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 ///
 ///  An NSPanel that can become key/main and can fade in/out.

--- a/Source/SantaGUI/SNTMessageWindowController.h
+++ b/Source/SantaGUI/SNTMessageWindowController.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 @class SNTStoredEvent;
 

--- a/Source/SantaGUI/SNTMessageWindowController.m
+++ b/Source/SantaGUI/SNTMessageWindowController.m
@@ -14,7 +14,7 @@
 
 #import "SNTMessageWindowController.h"
 
-@import SecurityInterface.SFCertificatePanel;
+#import <SecurityInterface/SFCertificatePanel.h>
 
 #import <MOLCertificate/MOLCertificate.h>
 

--- a/Source/SantaGUI/SNTNotificationManager.h
+++ b/Source/SantaGUI/SNTNotificationManager.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 #import "SNTMessageWindowController.h"
 #import "SNTXPCNotifierInterface.h"

--- a/Source/SantaGUI/main.m
+++ b/Source/SantaGUI/main.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 #import "SNTAppDelegate.h"
 

--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -13,9 +13,9 @@
 ///    limitations under the License.
 
 #ifdef SANTAGUI
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 #else
-@import Foundation;
+#import <Foundation/Foundation.h>
 #endif
 
 @class SNTStoredEvent;

--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 ///
 ///  These enums are used in various places throughout the Santa client code.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/common/SNTDropRootPrivs.h
+++ b/Source/common/SNTDropRootPrivs.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 ///
 ///  Simple function to check and drop root privileges.

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class MOLCodesignChecker;
 

--- a/Source/common/SNTLogging.h
+++ b/Source/common/SNTLogging.h
@@ -34,7 +34,7 @@
 
 #else  // KERNEL
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 typedef enum : NSUInteger {
   LOG_LEVEL_ERROR,

--- a/Source/common/SNTRule.h
+++ b/Source/common/SNTRule.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/common/SNTSystemInfo.h
+++ b/Source/common/SNTSystemInfo.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 ///
 ///  Simple class for fetching system information

--- a/Source/common/SNTXPCBundleServiceInterface.h
+++ b/Source/common/SNTXPCBundleServiceInterface.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SNTStoredEvent;
 

--- a/Source/common/SNTXPCConnection.h
+++ b/Source/common/SNTXPCConnection.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 /**
   A wrapper around NSXPCListener and NSXPCConnection to provide client multiplexing, signature

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import <MOLCertificate/MOLCertificate.h>
 

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 #import "SNTXPCBundleServiceInterface.h"

--- a/Source/common/SNTXPCSyncdInterface.h
+++ b/Source/common/SNTXPCSyncdInterface.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/santabs/SNTBundleService.h
+++ b/Source/santabs/SNTBundleService.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTXPCBundleServiceInterface.h"
 

--- a/Source/santabs/main.m
+++ b/Source/santabs/main.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTBundleService.h"
 #import "SNTXPCBundleServiceInterface.h"

--- a/Source/santactl/Commands/SNTCommandCheckCache.m
+++ b/Source/santactl/Commands/SNTCommandCheckCache.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/SNTCommandFlushCache.m
+++ b/Source/santactl/Commands/SNTCommandFlushCache.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/SNTCommandVersion.m
+++ b/Source/santactl/Commands/SNTCommandVersion.m
@@ -12,8 +12,8 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
-@import IOKit.kext;
+#import <Foundation/Foundation.h>
+#import <IOKit/kext/KextManager.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/sync/NSData+Zlib.h
+++ b/Source/santactl/Commands/sync/NSData+Zlib.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 /// Category on NSData providing the option of getting zlib or gzip compressed data.
 @interface NSData (Zlib)

--- a/Source/santactl/Commands/sync/SNTCommandSync.m
+++ b/Source/santactl/Commands/sync/SNTCommandSync.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 #import "SNTCommandController.h"

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 extern NSString *const kXSRFToken;
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncEventUpload.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommandSyncStage.h"
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncLogUpload.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncLogUpload.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommandSyncStage.h"
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTXPCSyncdInterface.h"
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -14,7 +14,7 @@
 
 #import "SNTCommandSyncManager.h"
 
-@import SystemConfiguration;
+#import <SystemConfiguration/SystemConfiguration.h>
 
 #import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
 #import <MOLFCMClient/MOLFCMClient.h>

--- a/Source/santactl/Commands/sync/SNTCommandSyncPostflight.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPostflight.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommandSyncStage.h"
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommandSyncStage.h"
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncRuleDownload.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommandSyncStage.h"
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncStage.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncStage.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SNTCommandSyncState;
 @class SNTXPCConnection;

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/santactl/SNTCommand.h
+++ b/Source/santactl/SNTCommand.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SNTXPCConnection;
 

--- a/Source/santactl/SNTCommandController.h
+++ b/Source/santactl/SNTCommandController.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommand.h"
 

--- a/Source/santactl/main.m
+++ b/Source/santactl/main.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommandController.h"
 

--- a/Source/santad/DataLayer/SNTDatabaseTable.h
+++ b/Source/santad/DataLayer/SNTDatabaseTable.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 // This is imported in the header rather than implementation to save
 // classes that use this one from also having to import FMDB stuff.

--- a/Source/santad/DataLayer/SNTEventTable.h
+++ b/Source/santad/DataLayer/SNTEventTable.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTDatabaseTable.h"
 

--- a/Source/santad/DataLayer/SNTEventTable.m
+++ b/Source/santad/DataLayer/SNTEventTable.m
@@ -54,7 +54,7 @@
       }
 
       NSData *eventData;
-      NSNumber *idx = [rs objectForColumnName:@"idx"];
+      NSNumber *idx = [rs objectForColumn:@"idx"];
       @try {
         eventData = [NSKeyedArchiver archivedDataWithRootObject:se];
         [db executeUpdate:@"UPDATE events SET eventdata=? WHERE idx=?", eventData, idx];
@@ -141,7 +141,7 @@
       if (obj) {
         [pendingEvents addObject:obj];
       } else {
-        [db executeUpdate:@"DELETE FROM events WHERE idx=?", [rs objectForColumnName:@"idx"]];
+        [db executeUpdate:@"DELETE FROM events WHERE idx=?", [rs objectForColumn:@"idx"]];
       }
     }
 

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 #import "SNTDatabaseTable.h"

--- a/Source/santad/Logs/SNTEventLog.h
+++ b/Source/santad/Logs/SNTEventLog.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTKernelCommon.h"
 

--- a/Source/santad/Logs/SNTEventLog.m
+++ b/Source/santad/Logs/SNTEventLog.m
@@ -114,6 +114,8 @@
   char *buf = NULL;
   BOOL shouldFree = NO;
 
+  if (length < 1) return @"";
+
   // Loop through the string one character at a time, looking for the characters
   // we want to remove.
   for (const char *p = str; (c = *p) != 0; ++p) {

--- a/Source/santad/SNTApplication.h
+++ b/Source/santad/SNTApplication.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 ///
 ///  The main controller class for santad

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -14,7 +14,7 @@
 
 #import "SNTApplication.h"
 
-@import DiskArbitration;
+#import <DiskArbitration/DiskArbitration.h>
 
 #import "SNTCommonEnums.h"
 #import "SNTConfigurator.h"

--- a/Source/santad/SNTCachedDecision.h
+++ b/Source/santad/SNTCachedDecision.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTXPCControlInterface.h"
 

--- a/Source/santad/SNTDatabaseController.h
+++ b/Source/santad/SNTDatabaseController.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 // This is imported in the header rather than implementation to saves
 // classes that use this one from also having to import FMDB stuff.

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #include "SNTKernelCommon.h"
 

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -14,7 +14,7 @@
 
 #import "SNTDriverManager.h"
 
-@import IOKit.kext;
+#import <IOKit/kext/KextManager.h>
 
 #include <mach/mach_port.h>
 

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 #include "SNTKernelCommon.h"

--- a/Source/santad/SNTNotificationQueue.h
+++ b/Source/santad/SNTNotificationQueue.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SNTStoredEvent;
 @class SNTXPCConnection;

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 #import "SNTKernelCommon.h"

--- a/Source/santad/SNTSyncdQueue.h
+++ b/Source/santad/SNTSyncdQueue.h
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SNTCommonEnums.h"
 

--- a/Source/santad/main.m
+++ b/Source/santad/main.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #include "SNTLogging.h"
 

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -12,8 +12,8 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import Foundation;
-@import IOKit;
+#import <Foundation/Foundation.h>
+#import <IOKit/IOKitLib.h>
 
 #import <CommonCrypto/CommonDigest.h>
 

--- a/Tests/LogicTests/SNTCommandFileInfoTest.m
+++ b/Tests/LogicTests/SNTCommandFileInfoTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 

--- a/Tests/LogicTests/SNTCommandSyncTest.m
+++ b/Tests/LogicTests/SNTCommandSyncTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 

--- a/Tests/LogicTests/SNTEventTableTest.m
+++ b/Tests/LogicTests/SNTEventTableTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 

--- a/Tests/LogicTests/SNTExecutionControllerTest.m
+++ b/Tests/LogicTests/SNTExecutionControllerTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 

--- a/Tests/LogicTests/SNTFileInfoTest.m
+++ b/Tests/LogicTests/SNTFileInfoTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SNTFileInfo.h"
 

--- a/Tests/LogicTests/SNTRuleTableTest.m
+++ b/Tests/LogicTests/SNTRuleTableTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SNTRule.h"
 #import "SNTRuleTable.h"

--- a/Tests/LogicTests/SNTXPCConnectionTest.m
+++ b/Tests/LogicTests/SNTXPCConnectionTest.m
@@ -12,7 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <OCMock/OCMock.h>


### PR DESCRIPTION
Also stop using objectForColumnName in fmdb, use objectForColumn instead.
Also add a probably redundant length check in sanitizeCString.