### PR TITLE
Optional MachineID for Logs

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -105,7 +105,6 @@
 ///
 @property(readonly, nonatomic) BOOL enableMachineIDDecoration;
 
-
 #pragma mark - GUI Settings
 
 ///

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -98,6 +98,13 @@
 ///
 @property(readonly, nonatomic) NSString *eventLogPath;
 
+///
+/// Enabling UUID decoration appends the host uuid to the end of each log line.
+/// Defaults to NO.
+///
+@property(readonly, nonatomic) BOOL enableUUIDDecoration;
+
+
 #pragma mark - GUI Settings
 
 ///

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -99,10 +99,11 @@
 @property(readonly, nonatomic) NSString *eventLogPath;
 
 ///
-/// Enabling UUID decoration appends the host uuid to the end of each log line.
+/// Enabling this appends the Santa machine ID to the end of each log line. If nothing
+/// has been overriden, this is the host's UUID.
 /// Defaults to NO.
 ///
-@property(readonly, nonatomic) BOOL enableUUIDDecoration;
+@property(readonly, nonatomic) BOOL enableMachineIDDecoration;
 
 
 #pragma mark - GUI Settings

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -283,6 +283,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self configStateSet];
 }
 
++ (NSSet *)keyPathsForValuesAffectingEnableMachineIDDecoration {
+  return [self configStateSet];
+}
+
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -72,7 +72,7 @@ static NSString *const kFileChangesRegexKey = @"FileChangesRegex";
 static NSString *const kEventLogType = @"EventLogType";
 static NSString *const kEventLogPath = @"EventLogPath";
 
-static NSString *const kEnableUUIDDecoration = @"EnableUUIDDecoration";
+static NSString *const kEnableMachineIDDecoration = @"EnableMachineIDDecoration";
 
 // The keys managed by a sync server or mobileconfig.
 static NSString *const kClientModeKey = @"ClientMode";
@@ -128,7 +128,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kMachineIDPlistKeyKey : string,
       kEventLogType : string,
       kEventLogPath : string,
-      kEnableUUIDDecoration : number,
+      kEnableMachineIDDecoration : number,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -454,9 +454,9 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return self.configState[kEventLogPath] ?: @"/var/db/santa/santa.log";
 }
 
-- (BOOL)enableUUIDDecoration {
-  NSNumber *number = self.configState[kEnableUUIDDecoration];
-  return number ? [number boolValue] : YES;
+- (BOOL)enableMachineIDDecoration {
+  NSNumber *number = self.configState[kEnableMachineIDDecoration];
+  return number ? [number boolValue] : NO;
 }
 
 #pragma mark Private

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -72,6 +72,8 @@ static NSString *const kFileChangesRegexKey = @"FileChangesRegex";
 static NSString *const kEventLogType = @"EventLogType";
 static NSString *const kEventLogPath = @"EventLogPath";
 
+static NSString *const kEnableUUIDDecoration = @"EnableUUIDDecoration";
+
 // The keys managed by a sync server or mobileconfig.
 static NSString *const kClientModeKey = @"ClientMode";
 static NSString *const kWhitelistRegexKey = @"WhitelistRegex";
@@ -126,6 +128,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kMachineIDPlistKeyKey : string,
       kEventLogType : string,
       kEventLogPath : string,
+      kEnableUUIDDecoration : number,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -449,6 +452,11 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (NSString *)eventLogPath {
   return self.configState[kEventLogPath] ?: @"/var/db/santa/santa.log";
+}
+
+- (BOOL)enableUUIDDecoration {
+  NSNumber *number = self.configState[kEnableUUIDDecoration];
+  return number ? [number boolValue] : YES;
 }
 
 #pragma mark Private

--- a/Source/santad/Logs/SNTEventLog.h
+++ b/Source/santad/Logs/SNTEventLog.h
@@ -51,5 +51,5 @@
 
 // A UTC Date formatter.
 @property(readonly, nonatomic) NSDateFormatter *dateFormatter;
-@property(readonly, nonatomic) NSString *hostuuid;
+@property(readonly, nonatomic) NSString *machineID;
 @end

--- a/Source/santad/Logs/SNTEventLog.h
+++ b/Source/santad/Logs/SNTEventLog.h
@@ -51,4 +51,5 @@
 
 // A UTC Date formatter.
 @property(readonly, nonatomic) NSDateFormatter *dateFormatter;
+@property(readonly, nonatomic) NSString *hostuuid;
 @end

--- a/Source/santad/Logs/SNTEventLog.m
+++ b/Source/santad/Logs/SNTEventLog.m
@@ -20,6 +20,7 @@
 #include <sys/sysctl.h>
 
 #import "SNTCachedDecision.h"
+#import "SNTSystemInfo.h"
 
 @interface SNTEventLog ()
 @property NSMutableDictionary<NSNumber *, SNTCachedDecision *> *detailStore;
@@ -43,6 +44,9 @@
     _dateFormatter = [[NSDateFormatter alloc] init];
     _dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     _dateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+
+    // Grab the system UUID on init
+     _hostuuid = [SNTSystemInfo hardwareUUID];
   }
   return self;
 }

--- a/Source/santad/Logs/SNTEventLog.m
+++ b/Source/santad/Logs/SNTEventLog.m
@@ -20,7 +20,7 @@
 #include <sys/sysctl.h>
 
 #import "SNTCachedDecision.h"
-#import "SNTSystemInfo.h"
+#import "SNTConfigurator.h"
 
 @interface SNTEventLog ()
 @property NSMutableDictionary<NSNumber *, SNTCachedDecision *> *detailStore;
@@ -46,7 +46,7 @@
     _dateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
 
     // Grab the system UUID on init
-     _hostuuid = [SNTSystemInfo hardwareUUID];
+     _machineID = [[SNTConfigurator configurator] machineID];
   }
   return self;
 }

--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -20,7 +20,6 @@
 #import "SNTConfigurator.h"
 #import "SNTLogging.h"
 #import "SNTStoredEvent.h"
-#import "SNTSystemInfo.h"
 
 @implementation SNTSyslogEventLog
 
@@ -69,7 +68,7 @@
       message.pid, message.ppid, message.pname, ppath,
       message.uid, [self nameForUID:message.uid],
       message.gid, [self nameForGID:message.gid],
-      [SNTSystemInfo hardwareUUID]];
+      self.hostuuid];
 
   [self writeLog:outStr];
 }
@@ -156,7 +155,7 @@
       message.uid, [self nameForUID:message.uid],
       message.gid, [self nameForGID:message.gid],
       mode, [self sanitizeString:@(message.path)],
-      [SNTSystemInfo hardwareUUID]];
+      self.hostuuid];
 
   // Check for app translocation by GateKeeper, and log original path if the case.
   NSString *originalPath = [self originalPathForTranslocation:message];

--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -64,11 +64,14 @@
   char ppath[PATH_MAX] = "(null)";
   proc_pidpath(message.pid, ppath, PATH_MAX);
 
-  [outStr appendFormat:@"|pid=%d|ppid=%d|process=%s|processpath=%s|uid=%d|user=%@|gid=%d|group=%@|uuid=%@",
+  [outStr appendFormat:@"|pid=%d|ppid=%d|process=%s|processpath=%s|uid=%d|user=%@|gid=%d|group=%@",
       message.pid, message.ppid, message.pname, ppath,
       message.uid, [self nameForUID:message.uid],
-      message.gid, [self nameForGID:message.gid],
-      self.hostuuid];
+      message.gid, [self nameForGID:message.gid]];
+  
+  if ([[SNTConfigurator configurator] enableUUIDDecoration]) {
+    [outStr appendFormat:@"|uuid=%@", self.hostuuid];
+  }
 
   [self writeLog:outStr];
 }
@@ -150,12 +153,11 @@
       mode = @"U"; break;
   }
 
-  [outLog appendFormat:@"|pid=%d|ppid=%d|uid=%d|user=%@|gid=%d|group=%@|mode=%@|path=%@|uuid=%@",
+  [outLog appendFormat:@"|pid=%d|ppid=%d|uid=%d|user=%@|gid=%d|group=%@|mode=%@|path=%@",
       message.pid, message.ppid,
       message.uid, [self nameForUID:message.uid],
       message.gid, [self nameForGID:message.gid],
-      mode, [self sanitizeString:@(message.path)],
-      self.hostuuid];
+      mode, [self sanitizeString:@(message.path)]];
 
   // Check for app translocation by GateKeeper, and log original path if the case.
   NSString *originalPath = [self originalPathForTranslocation:message];
@@ -165,6 +167,10 @@
 
   if (logArgs) {
     [self addArgsForPid:message.pid toString:outLog];
+  }
+
+  if ([[SNTConfigurator configurator] enableUUIDDecoration]) {
+    [outLog appendFormat:@"|uuid=%@", self.hostuuid];
   }
 
   [self writeLog:outLog];

--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -20,6 +20,7 @@
 #import "SNTConfigurator.h"
 #import "SNTLogging.h"
 #import "SNTStoredEvent.h"
+#import "SNTSystemInfo.h"
 
 @implementation SNTSyslogEventLog
 
@@ -64,10 +65,11 @@
   char ppath[PATH_MAX] = "(null)";
   proc_pidpath(message.pid, ppath, PATH_MAX);
 
-  [outStr appendFormat:@"|pid=%d|ppid=%d|process=%s|processpath=%s|uid=%d|user=%@|gid=%d|group=%@",
+  [outStr appendFormat:@"|pid=%d|ppid=%d|process=%s|processpath=%s|uid=%d|user=%@|gid=%d|group=%@|uuid=%@",
       message.pid, message.ppid, message.pname, ppath,
       message.uid, [self nameForUID:message.uid],
-      message.gid, [self nameForGID:message.gid]];
+      message.gid, [self nameForGID:message.gid],
+      [SNTSystemInfo hardwareUUID]];
 
   [self writeLog:outStr];
 }
@@ -149,11 +151,12 @@
       mode = @"U"; break;
   }
 
-  [outLog appendFormat:@"|pid=%d|ppid=%d|uid=%d|user=%@|gid=%d|group=%@|mode=%@|path=%@",
+  [outLog appendFormat:@"|pid=%d|ppid=%d|uid=%d|user=%@|gid=%d|group=%@|mode=%@|path=%@|uuid=%@",
       message.pid, message.ppid,
       message.uid, [self nameForUID:message.uid],
       message.gid, [self nameForGID:message.gid],
-      mode, [self sanitizeString:@(message.path)]];
+      mode, [self sanitizeString:@(message.path)],
+      [SNTSystemInfo hardwareUUID]];
 
   // Check for app translocation by GateKeeper, and log original path if the case.
   NSString *originalPath = [self originalPathForTranslocation:message];

--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -69,8 +69,8 @@
       message.uid, [self nameForUID:message.uid],
       message.gid, [self nameForGID:message.gid]];
   
-  if ([[SNTConfigurator configurator] enableUUIDDecoration]) {
-    [outStr appendFormat:@"|uuid=%@", self.hostuuid];
+  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
+    [outStr appendFormat:@"|machineid=%@", self.machineID];
   }
 
   [self writeLog:outStr];
@@ -169,8 +169,8 @@
     [self addArgsForPid:message.pid toString:outLog];
   }
 
-  if ([[SNTConfigurator configurator] enableUUIDDecoration]) {
-    [outLog appendFormat:@"|uuid=%@", self.hostuuid];
+  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
+    [outLog appendFormat:@"|machineid=%@", self.machineID];
   }
 
   [self writeLog:outLog];


### PR DESCRIPTION
The way we aggregate logs means it can be hard to tell where they are coming from when they get to our backend. This PR adds a new ~`UUID`~ `machineid` field to logs if ~EnableUUIDDecoration~ EnableMachineIDDecoration is set.

~I'm still working on testing this with a configuration profile and will update when I confirm it works the way I expect.~

This is also planned to be contributed on behalf of @Facebook so I've also started an internal authorization for CLA signing.

**Testing:**

Here is a snippet of the mobileconfig I installed locally on my machine:
```
<key>EnableMachineIDDecoration</key>
<integer>1</integer>
```
I confirmed that logs get have:
```
|machineid=XXX...XXX
```
appended to them and when I reinstall the profile with a 0 the field is no longer present.