### PR TITLE
SantaCache: Add command to print histogram of bucket distribution

### DIFF
--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		0D10BE861A0AABD600C0C944 /* SNTDropRootPrivs.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D10BE851A0AABD600C0C944 /* SNTDropRootPrivs.m */; };
 		0D10BE871A0AABD600C0C944 /* SNTDropRootPrivs.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D10BE851A0AABD600C0C944 /* SNTDropRootPrivs.m */; };
 		0D10BE891A0AAF6700C0C944 /* SNTDropRootPrivs.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D10BE851A0AABD600C0C944 /* SNTDropRootPrivs.m */; };
+		0D10D18420C19445008251ED /* SNTCommandCacheHistogram.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D10D18320C19445008251ED /* SNTCommandCacheHistogram.m */; };
 		0D1B477019A53419008CADD3 /* SNTAboutWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D1B476E19A53419008CADD3 /* SNTAboutWindowController.m */; };
 		0D1B477119A53419008CADD3 /* AboutWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0D1B476F19A53419008CADD3 /* AboutWindow.xib */; };
 		0D202D191CDD2EE500A88F16 /* SNTCommandSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D202D181CDD2EE500A88F16 /* SNTCommandSyncTest.m */; };
@@ -286,6 +287,7 @@
 		0D0A1EC5191AB9B000B8450F /* SNTCommandSyncPostflight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCommandSyncPostflight.m; sourceTree = "<group>"; };
 		0D10BE851A0AABD600C0C944 /* SNTDropRootPrivs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTDropRootPrivs.m; sourceTree = "<group>"; };
 		0D10BE881A0AAC2100C0C944 /* SNTDropRootPrivs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SNTDropRootPrivs.h; sourceTree = "<group>"; };
+		0D10D18320C19445008251ED /* SNTCommandCacheHistogram.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SNTCommandCacheHistogram.m; sourceTree = "<group>"; };
 		0D1B476D19A53419008CADD3 /* SNTAboutWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTAboutWindowController.h; sourceTree = "<group>"; };
 		0D1B476E19A53419008CADD3 /* SNTAboutWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTAboutWindowController.m; sourceTree = "<group>"; };
 		0D1B476F19A53419008CADD3 /* AboutWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AboutWindow.xib; sourceTree = "<group>"; };
@@ -801,6 +803,7 @@
 			isa = PBXGroup;
 			children = (
 				C7DA62F81E241A02009BDF2C /* SNTCommandBundleInfo.m */,
+				0D10D18320C19445008251ED /* SNTCommandCacheHistogram.m */,
 				C76614EB1D142D3C00D150C1 /* SNTCommandCheckCache.m */,
 				0DCD5FBE1909D64A006B445C /* SNTCommandFileInfo.m */,
 				0DE4C8A518FF3B1700466D04 /* SNTCommandFlushCache.m */,
@@ -1393,6 +1396,7 @@
 				C776A1071DEE160500A56616 /* SNTCommandSyncManager.m in Sources */,
 				0DCD605C19117A90006B445C /* SNTCommandSyncPreflight.m in Sources */,
 				0D41640519197AD7006A356A /* SNTCommandSyncEventUpload.m in Sources */,
+				0D10D18420C19445008251ED /* SNTCommandCacheHistogram.m in Sources */,
 				0D42D2B919D2042900955F08 /* SNTConfigurator.m in Sources */,
 				0DF395641AB76A7900CBC520 /* NSData+Zlib.m in Sources */,
 				C7FB56F71DBFB480004E14EF /* SNTXPCSyncdInterface.m in Sources */,

--- a/Source/common/SNTKernelCommon.h
+++ b/Source/common/SNTKernelCommon.h
@@ -21,9 +21,6 @@
 #ifndef SANTA__COMMON__KERNELCOMMON_H
 #define SANTA__COMMON__KERNELCOMMON_H
 
-// Defines the lengths of paths and Vnode IDs passed around.
-#define MAX_VNODE_ID_STR 21  // digits in UINT64_MAX + 1 for NULL-terminator
-
 // Defines the name of the userclient class and the driver bundle ID.
 #define USERCLIENT_CLASS "com_google_SantaDriver"
 #define USERCLIENT_ID "com.google.santa-driver"
@@ -41,6 +38,7 @@ enum SantaDriverMethods {
   kSantaUserClientClearCache,
   kSantaUserClientCacheCount,
   kSantaUserClientCheckCache,
+  kSantaUserClientCacheBucketCount,
 
   // Any methods supported by the driver should be added above this line to
   // ensure this remains the count of methods.
@@ -98,5 +96,11 @@ typedef struct {
   // actually happens, so only take MAXPATHLEN and throw away any excess.
   char pname[MAXPATHLEN];
 } santa_message_t;
+
+// Used for the kSantaUserClientCacheBucketCount request.
+typedef struct {
+  uint16_t per_bucket[1024];
+  uint64_t start;
+} santa_bucket_count_t;
 
 #endif  // SANTA__COMMON__KERNELCOMMON_H

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -36,6 +36,7 @@
 - (void)cacheCounts:(void (^)(uint64_t rootCache, uint64_t nonRootCache))reply;
 - (void)flushCache:(void (^)(BOOL))reply;
 - (void)checkCacheForVnodeID:(uint64_t)vnodeID withReply:(void (^)(santa_action_t))reply;
+- (void)cacheBucketCount:(void (^)(NSArray *))reply;
 
 ///
 ///  Database ops

--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -266,6 +266,11 @@ void SantaDecisionManager::ClearCache(bool non_root_only) {
   non_root_decision_cache_->clear();
 }
 
+void SantaDecisionManager::CacheBucketCount(
+    uint16_t *per_bucket_counts, uint16_t *array_size, uint64_t *start_bucket) {
+  non_root_decision_cache_->bucket_counts(per_bucket_counts, array_size, start_bucket);
+}
+
 #pragma mark Decision Fetching
 
 santa_action_t SantaDecisionManager::GetFromCache(uint64_t identifier) {

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -109,6 +109,20 @@ class SantaDecisionManager : public OSObject {
   */
   void ClearCache(bool non_root_only = false);
 
+
+  /**
+    Fills out the per_bucket_counts array with the number of items in each bucket in the
+    non-root decision cache.
+
+    @param per_bucket_counts An array of uint16_t's to fill in with the number of items in each
+        bucket. The size of this array is expected to equal array_size.
+    @param array_size The size of the per_bucket_counts array on input. Upon return this will be
+        updated to the number of slots that were actually used.
+    @param start_bucket If non-zero this is the bucket in the cache to start from. Upon return this
+        will be the next numbered bucket to start from for subsequent requests.
+  */
+  void CacheBucketCount(uint16_t *per_bucket_counts, uint16_t *array_size, uint64_t *start_bucket);
+
   /// Increments the count of active callbacks pending.
   void IncrementListenerInvocations();
 

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -206,7 +206,7 @@ IOReturn SantaDriverClient::cache_bucket_count(
   const santa_bucket_count_t *input = reinterpret_cast<const santa_bucket_count_t *>(
       arguments->structureInput);
 
-  uint16_t s = 1024;
+  uint16_t s = sizeof(counts->per_bucket) / sizeof(uint16_t);
   counts->start = input->start;
   me->decisionManager->CacheBucketCount(counts->per_bucket, &s, &(counts->start));
 

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -196,6 +196,23 @@ IOReturn SantaDriverClient::check_cache(
   return kIOReturnSuccess;
 }
 
+IOReturn SantaDriverClient::cache_bucket_count(
+    OSObject *target, void *reference, IOExternalMethodArguments *arguments) {
+  SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
+  if (!me) return kIOReturnBadArgument;
+
+  santa_bucket_count_t *counts = reinterpret_cast<santa_bucket_count_t *>(
+      arguments->structureOutput);
+  const santa_bucket_count_t *input = reinterpret_cast<const santa_bucket_count_t *>(
+      arguments->structureInput);
+
+  uint16_t s = 1024;
+  counts->start = input->start;
+  me->decisionManager->CacheBucketCount(counts->per_bucket, &s, &(counts->start));
+
+  return kIOReturnSuccess;
+}
+
 #pragma mark Method Resolution
 
 IOReturn SantaDriverClient::externalMethod(
@@ -214,7 +231,9 @@ IOReturn SantaDriverClient::externalMethod(
     { &SantaDriverClient::acknowledge_binary, 1, 0, 0, 0 },
     { &SantaDriverClient::clear_cache, 1, 0, 0, 0 },
     { &SantaDriverClient::cache_count, 0, 0, 2, 0 },
-    { &SantaDriverClient::check_cache, 1, 0, 1, 0 }
+    { &SantaDriverClient::check_cache, 1, 0, 1, 0 },
+    { &SantaDriverClient::cache_bucket_count, 0, sizeof(santa_bucket_count_t),
+        0, sizeof(santa_bucket_count_t) },
   };
 
   if (selector > static_cast<UInt32>(kSantaUserClientNMethods)) {

--- a/Source/santa-driver/SantaDriverClient.h
+++ b/Source/santa-driver/SantaDriverClient.h
@@ -105,6 +105,11 @@ class com_google_SantaDriverClient : public IOUserClient {
   static IOReturn check_cache(
       OSObject *target, void *reference, IOExternalMethodArguments *arguments);
 
+  ///  The daemon calls this to find out how many items are in each cache bucket.
+  ///  Input and output are both an instance of santa_bucket_count_t.
+  static IOReturn cache_bucket_count(
+      OSObject *target, void *reference, IOExternalMethodArguments *arguments);
+
  private:
   com_google_SantaDriver *myProvider;
   SantaDecisionManager *decisionManager;

--- a/Source/santactl/Commands/SNTCommandBundleInfo.m
+++ b/Source/santactl/Commands/SNTCommandBundleInfo.m
@@ -22,14 +22,14 @@
 #import "SNTStoredEvent.h"
 #import "SNTXPCControlInterface.h"
 
+#ifdef DEBUG
+
 @interface SNTCommandBundleInfo : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandBundleInfo
 
-#ifdef DEBUG
 REGISTER_COMMAND_NAME(@"bundleinfo")
-#endif
 
 + (BOOL)requiresRoot {
   return NO;
@@ -78,3 +78,5 @@ REGISTER_COMMAND_NAME(@"bundleinfo")
 }
 
 @end
+
+#endif

--- a/Source/santactl/Commands/SNTCommandCacheHistogram.m
+++ b/Source/santactl/Commands/SNTCommandCacheHistogram.m
@@ -53,11 +53,7 @@ REGISTER_COMMAND_NAME(@"cachehistogram")
   [[self.daemonConn remoteObjectProxy] cacheBucketCount:^(NSArray *counts) {
     NSMutableDictionary<NSNumber *, NSNumber *> *k = [NSMutableDictionary dictionary];
     [counts enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-      if (!k[obj]) {
-        k[obj] = @1;
-      } else {
-        k[obj] = @([k[obj] intValue] + 1);
-      }
+      k[obj] = @([k[obj] intValue] + 1);
     }];
     printf("There are %llu empty buckets\n", [k[@0] unsignedLongLongValue]);
     for (unsigned long x = 1; x < k.count; ++x) {

--- a/Source/santactl/Commands/SNTCommandCacheHistogram.m
+++ b/Source/santactl/Commands/SNTCommandCacheHistogram.m
@@ -56,16 +56,19 @@ REGISTER_COMMAND_NAME(@"cachehistogram")
       k[obj] = @([k[obj] intValue] + 1);
     }];
     printf("There are %llu empty buckets\n", [k[@0] unsignedLongLongValue]);
-    for (unsigned long x = 1; x < k.count; ++x) {
-      uint64_t kv = [k[@(x)] unsignedLongLongValue];
-      if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-g"]) {
-        printf("%4lu: ", x);
+
+    if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-g"]) {
+      for (uint64_t x = 1; x < k.count; ++x) {
+        uint64_t kv = [k[@(x)] unsignedLongLongValue];
+        printf("%4llu: ", x);
         for (uint64_t y = 0; y < kv; ++y) {
           printf("#");
         }
         printf("\n");
-      } else {
-        printf("%4lu: %llu\n", x ,kv);
+      }
+    } else {
+      for (unsigned long x = 1; x < k.count; ++x) {
+        printf("%4lu: %llu\n", x ,[k[@(x)] unsignedLongLongValue]);
       }
     }
     exit(0);

--- a/Source/santactl/Commands/SNTCommandCheckCache.m
+++ b/Source/santactl/Commands/SNTCommandCheckCache.m
@@ -24,14 +24,14 @@
 
 #include <sys/stat.h>
 
+#ifdef DEBUG
+
 @interface SNTCommandCheckCache : SNTCommand<SNTCommandProtocol>
 @end
 
 @implementation SNTCommandCheckCache
 
-#ifdef DEBUG
 REGISTER_COMMAND_NAME(@"checkcache")
-#endif
 
 + (BOOL)requiresRoot {
   return NO;
@@ -74,3 +74,5 @@ REGISTER_COMMAND_NAME(@"checkcache")
 }
 
 @end
+
+#endif

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -75,6 +75,10 @@ double watchdogRAMPeak = 0;
   reply([counts[0] unsignedLongLongValue], [counts[1] unsignedLongLongValue]);
 }
 
+- (void)cacheBucketCount:(void (^)(NSArray *))reply {
+  reply([self.driverManager cacheBucketCount]);
+}
+
 - (void)flushCache:(void (^)(BOOL))reply {
   reply([self.driverManager flushCacheNonRootOnly:NO]);
 }

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -53,6 +53,12 @@
 - (NSArray<NSNumber *> *)cacheCounts;
 
 ///
+///  Return an array representing all buckets in the kernel's decision cache where each number
+///  is the number of items in that bucket.
+///
+- (NSArray<NSNumber *> *)cacheBucketCount;
+
+///
 ///  Flush the kernel's binary cache.
 ///
 - (BOOL)flushCacheNonRootOnly:(BOOL)nonRootOnly;

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -225,7 +225,7 @@ static const int MAX_DELAY = 15;
                               size,
                               &counts,
                               &size);
-    for (uint64_t i = 0; i < 1024; ++i) {
+    for (uint64_t i = 0; i < sizeof(counts.per_bucket) / sizeof(uint16_t); ++i) {
       [a addObject:@(counts.per_bucket[i])];
     }
   } while (counts.start > 0);

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -212,4 +212,25 @@ static const int MAX_DELAY = 15;
   return (santa_action_t)vnode_action;
 }
 
+- (NSArray *)cacheBucketCount {
+  santa_bucket_count_t counts = {};
+  size_t size = sizeof(counts);
+
+  NSMutableArray *a = [NSMutableArray array];
+
+  do {
+    IOConnectCallStructMethod(self.connection,
+                              kSantaUserClientCacheBucketCount,
+                              &counts,
+                              size,
+                              &counts,
+                              &size);
+    for (uint64_t i = 0; i < 1024; ++i) {
+      [a addObject:@(counts.per_bucket[i])];
+    }
+  } while (counts.start > 0);
+
+  return a;
+}
+
 @end


### PR DESCRIPTION
The command only exists in Debug builds.

This currently only prints the distribution of the non-root cache. In the near future I'll unify the caches again which stops this being a problem.