### PR TITLE
santa-driver: Re-factor some destruction methods

### DIFF
--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -374,7 +374,6 @@ bool SantaDecisionManager::PostToDecisionQueue(santa_message_t *message) {
       LOGE("Failed to queue more than %d decision requests, killing daemon",
            kMaxDecisionQueueFailures);
       proc_signal(client_pid_, SIGKILL);
-      client_pid_ = 0;
     }
   }
   lck_mtx_unlock(decision_dataqueue_lock_);
@@ -388,10 +387,6 @@ bool SantaDecisionManager::PostToLogQueue(santa_message_t *message) {
     if (failed_log_queue_requests_++ == 0) {
       LOGW("Dropping log queue messages");
     }
-    // If enqueue failed, pop an item off the queue and try again.
-    uint32_t dataSize = 0;
-    log_dataqueue_->dequeue(0, &dataSize);
-    kr = log_dataqueue_->enqueue(message, sizeof(santa_message_t));
   } else {
     if (failed_log_queue_requests_ > 0) {
       failed_log_queue_requests_--;

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -48,23 +48,21 @@ bool SantaDriverClient::start(IOService *provider) {
 }
 
 void SantaDriverClient::stop(IOService *provider) {
-  super::stop(provider);
   myProvider = nullptr;
   decisionManager = nullptr;
+  super::stop(provider);
+}
+
+IOReturn SantaDriverClient::clientDied() {
+  LOGI("Client died.");
+  decisionManager->DisconnectClient(true);
+  return terminate() ? kIOReturnSuccess : kIOReturnError;
 }
 
 IOReturn SantaDriverClient::clientClose() {
-  decisionManager->DisconnectClient(true);
-  return terminate(kIOServiceSynchronous) ? kIOReturnSuccess : kIOReturnError;
-}
-
-bool SantaDriverClient::terminate(IOOptionBits options) {
-  decisionManager->DisconnectClient();
   LOGI("Client disconnected.");
-
-  if (myProvider && myProvider->isOpen(this)) myProvider->close(this);
-
-  return super::terminate(options);
+  decisionManager->DisconnectClient(false);
+  return terminate() ? kIOReturnSuccess : kIOReturnError;
 }
 
 #pragma mark Fetching memory and data queue notifications

--- a/Source/santa-driver/SantaDriverClient.h
+++ b/Source/santa-driver/SantaDriverClient.h
@@ -47,8 +47,10 @@ class com_google_SantaDriverClient : public IOUserClient {
   ///  Called when this class is stopping
   void stop(IOService *provider) override;
 
-  ///  Called when a client disconnects
+  ///  Called when a client manually disconnects (via IOServiceClose)
   IOReturn clientClose() override;
+
+  ///  Called when a client dies
   IOReturn clientDied() override;
 
   ///  Called in clients with IOConnectSetNotificationPort

--- a/Source/santa-driver/SantaDriverClient.h
+++ b/Source/santa-driver/SantaDriverClient.h
@@ -49,9 +49,7 @@ class com_google_SantaDriverClient : public IOUserClient {
 
   ///  Called when a client disconnects
   IOReturn clientClose() override;
-
-  ///  Called when the driver is shutting down
-  bool terminate(IOOptionBits options) override;
+  IOReturn clientDied() override;
 
   ///  Called in clients with IOConnectSetNotificationPort
   IOReturn registerNotificationPort(


### PR DESCRIPTION
This fixes IOServiceClose() being called on the driver

Also don't delete and re-enqueue the log data queue if it fails to enqueue, this is pointless.