### PR TITLE
santa-driver: add IOMatchCategory

### DIFF
--- a/Source/santa-driver/Resources/santa-driver-Info.plist
+++ b/Source/santa-driver/Resources/santa-driver-Info.plist
@@ -32,6 +32,8 @@
 			<string>IOKit</string>
 			<key>IOUserClientClass</key>
 			<string>com_google_SantaDriverClient</string>
+			<key>IOMatchCategory</key>
+			<string>com_google_SantaDriver</string>
 		</dict>
 	</dict>
 	<key>OSBundleLibraries</key>


### PR DESCRIPTION
It seems this was not needed <= 10.13, but 10.14 will not match on IOResources alone.