### PR TITLE
santad: add critical system binaries

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,11 +7,11 @@ PODS:
   - MOLCertificate (1.9)
   - MOLCodesignChecker (1.10):
     - MOLCertificate (~> 1.8)
-  - MOLFCMClient (1.7):
+  - MOLFCMClient (1.8):
     - MOLAuthenticatingURLSession (~> 2.4)
   - MOLXPCConnection (1.2):
     - MOLCodesignChecker (~> 1.9)
-  - OCMock (3.4.1)
+  - OCMock (3.4.2)
 
 DEPENDENCIES:
   - FMDB
@@ -37,9 +37,9 @@ SPEC CHECKSUMS:
   MOLAuthenticatingURLSession: c238aa1c9a7b1077eb39a6f40204bfe76a7d204e
   MOLCertificate: e9e88a396c57032cab847f51a46e20c730cd752a
   MOLCodesignChecker: b0d5db9d2f9bd94e0fd093891a5d40e5ad77cbc0
-  MOLFCMClient: ee45348909351f232e2759c580329072ae7e02d4
+  MOLFCMClient: 2bfbacd45cc11e1ca3c077e97b80401c4e4a54f1
   MOLXPCConnection: c27af5cb1c43b18319698b0e568a8ddc2fc1e306
-  OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
+  OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
 
 PODFILE CHECKSUM: ddca043a7ace9ec600c108621c56d13a50d17236
 

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -17,6 +17,7 @@
 #import "SNTCommonEnums.h"
 #import "SNTDatabaseTable.h"
 
+@class SNTCachedDecision;
 @class SNTRule;
 @class SNTNotificationMessage;
 
@@ -87,5 +88,13 @@
 ///  Remove transitive rules that haven't been used in a long time.
 ///
 - (void)removeOutdatedTransitiveRules;
+
+
+///
+///  A map of a file hashes to cached decisions. This is used to pre-validate and whitelist
+///  certain critical system binaries that are integral to Santa's functionality.
+///
+@property(readonly, nonatomic)
+    NSDictionary<NSString *, SNTCachedDecision *> *criticalSystemBinaries;
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -94,7 +94,7 @@ static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
   // Setup critical system binaries
   // TODO(tburgin): Add the Santa components to this feature and remove the santadCertSHA rule.
   NSMutableDictionary *bins = [NSMutableDictionary dictionary];
-  for (NSString *path in @[ @"/usr/libexec/trustd" ]) {
+  for (NSString *path in @[ @"/usr/libexec/trustd", @"/usr/sbin/securityd" ]) {
     SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:path];
     MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:NULL];
 
@@ -111,6 +111,9 @@ static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
       cd.certCommonName = csInfo.leafCertificate.commonName;
 
       bins[binInfo.SHA256] = cd;
+    } else {
+      LOGE(@"Unable to validate critical system binary. pid 1: %@ and %@: %@ do not match.",
+           launchdCSInfo.leafCertificate, path, csInfo.leafCertificate);
     }
   }
 

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -34,9 +34,14 @@ static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
 @property NSString *launchdCertSHA;
 @property NSDate *lastTransitiveRuleCulling;
 @property NSDictionary *criticalSystemBinaries;
+@property(readonly) NSArray *criticalSystemBinaryPaths;
 @end
 
 @implementation SNTRuleTable
+
+- (NSArray *)criticalSystemBinaryPaths {
+  return @[ @"/usr/libexec/trustd", @"/usr/sbin/securityd", @"/usr/libexec/xpcproxy" ];
+}
 
 - (uint32_t)initializeDatabase:(FMDatabase *)db fromVersion:(uint32_t)version {
   // Lock this database from other processes
@@ -94,7 +99,7 @@ static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
   // Setup critical system binaries
   // TODO(tburgin): Add the Santa components to this feature and remove the santadCertSHA rule.
   NSMutableDictionary *bins = [NSMutableDictionary dictionary];
-  for (NSString *path in @[ @"/usr/libexec/trustd", @"/usr/sbin/securityd" ]) {
+  for (NSString *path in self.criticalSystemBinaryPaths) {
     SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:path];
     MOLCodesignChecker *csInfo = [binInfo codesignCheckerWithError:NULL];
 

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -115,26 +115,25 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
     [_driverManager postToKernelAction:ACTION_RESPOND_ACK forVnodeID:message.vnode_id];
   }
 
-  // Get codesigning info about the file but only if it's a Mach-O.
-  // If the binary is a critical system binary, don't check its signiture. The binary was validated
+  // If the binary is a critical system binary, don't check its signature. The binary was validated
   // by santad at startup.
   SNTCachedDecision *cd = self.ruleTable.criticalSystemBinaries[binInfo.SHA256];
-  MOLCodesignChecker *csInfo;
-  if (!cd && binInfo.isMachO) {
-    NSError *csError;
-    csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:binInfo.path
-                                             fileDescriptor:binInfo.fileHandle.fileDescriptor
-                                                      error:&csError];
-
-    // Ignore codesigning if there are any errors with the signature.
-    if (csError) csInfo = nil;
-  }
-
-  // If needed, actually make the decision (and refresh rule access timestamp).
+  MOLCodesignChecker *csInfo; // Needed further down in this scope.
   if (!cd) {
+    // Get codesigning info about the file but only if it's a Mach-O.
+    if (binInfo.isMachO) {
+      NSError *csError;
+      csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:binInfo.path
+                                               fileDescriptor:binInfo.fileHandle.fileDescriptor
+                                                        error:&csError];
+      // Ignore codesigning if there are any errors with the signature.
+      if (csError) csInfo = nil;
+    }
+
+    // Actually make the decision (and refresh rule access timestamp).
     cd = [self.policyProcessor decisionForFileInfo:binInfo
-                                                         fileSHA256:nil
-                                                  certificateSHA256:csInfo.leafCertificate.SHA256];
+                                        fileSHA256:nil
+                                 certificateSHA256:csInfo.leafCertificate.SHA256];
     cd.certCommonName = csInfo.leafCertificate.commonName;
   }
 


### PR DESCRIPTION
* In Mojave `/usr/libexec/trustd` needs to run in order to check arbitrary code signatures. This may be a departure from previous version of macOS. If `trustd` is killed, Santa can cause a deadlock. This fix pre-validates and whitelists `trustd` at `santad` startup time.
* Fixes #295