### PR TITLE
add in-kernel filemod prefix filter

### DIFF
--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -154,7 +154,6 @@
 		B352A545B76783D568A6D0C5 /* libPods-Santa.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 90E9D568200AB9B642E06272 /* libPods-Santa.a */; };
 		C714F8B11D8044D400700EDF /* SNTCommandFileInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD5FBE1909D64A006B445C /* SNTCommandFileInfo.m */; };
 		C714F8B21D8044FE00700EDF /* SNTCommandController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D35BDAB18FD7CFD00921A21 /* SNTCommandController.m */; };
-		C7197269218A3AF600979487 /* SantaPrefixTree.h in Headers */ = {isa = PBXBuildFile; fileRef = C7197268218A3AF600979487 /* SantaPrefixTree.h */; };
 		C719726B218A419B00979487 /* SantaPrefixTree.cc in Sources */ = {isa = PBXBuildFile; fileRef = C719726A218A419B00979487 /* SantaPrefixTree.cc */; };
 		C72E8D941D7F399900C86DD3 /* SNTCommandFileInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C72E8D931D7F399900C86DD3 /* SNTCommandFileInfoTest.m */; };
 		C73A4B9A1DC10753007B6789 /* SNTSyncdQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = C7FB56FF1DBFC213004E14EF /* SNTSyncdQueue.m */; };
@@ -922,7 +921,6 @@
 				0D4644C6182AF81700098690 /* SantaDecisionManager.h in Headers */,
 				0D9A7F341759144800035EB5 /* SantaDriver.h in Headers */,
 				0D9A7F381759148E00035EB5 /* SantaDriverClient.h in Headers */,
-				C7197269218A3AF600979487 /* SantaPrefixTree.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		B352A545B76783D568A6D0C5 /* libPods-Santa.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 90E9D568200AB9B642E06272 /* libPods-Santa.a */; };
 		C714F8B11D8044D400700EDF /* SNTCommandFileInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD5FBE1909D64A006B445C /* SNTCommandFileInfo.m */; };
 		C714F8B21D8044FE00700EDF /* SNTCommandController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D35BDAB18FD7CFD00921A21 /* SNTCommandController.m */; };
+		C7197269218A3AF600979487 /* SantaPrefixTree.h in Headers */ = {isa = PBXBuildFile; fileRef = C7197268218A3AF600979487 /* SantaPrefixTree.h */; };
+		C719726B218A419B00979487 /* SantaPrefixTree.cc in Sources */ = {isa = PBXBuildFile; fileRef = C719726A218A419B00979487 /* SantaPrefixTree.cc */; };
 		C72E8D941D7F399900C86DD3 /* SNTCommandFileInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C72E8D931D7F399900C86DD3 /* SNTCommandFileInfoTest.m */; };
 		C73A4B9A1DC10753007B6789 /* SNTSyncdQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = C7FB56FF1DBFC213004E14EF /* SNTSyncdQueue.m */; };
 		C73A4B9B1DC10758007B6789 /* SNTXPCSyncdInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = C7FB56F51DBFB480004E14EF /* SNTXPCSyncdInterface.m */; };
@@ -433,6 +435,8 @@
 		90E9D568200AB9B642E06272 /* libPods-Santa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Santa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A91785C40257CC156B4F05 /* Pods-Santa.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Santa.release.xcconfig"; path = "Pods/Target Support Files/Pods-Santa/Pods-Santa.release.xcconfig"; sourceTree = "<group>"; };
 		C11A10A5D6E112788769CF70 /* libPods-santad.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-santad.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7197268218A3AF600979487 /* SantaPrefixTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SantaPrefixTree.h; sourceTree = "<group>"; };
+		C719726A218A419B00979487 /* SantaPrefixTree.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SantaPrefixTree.cc; sourceTree = "<group>"; };
 		C72E8D931D7F399900C86DD3 /* SNTCommandFileInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCommandFileInfoTest.m; sourceTree = "<group>"; };
 		C748E8A1206964DE006CFD1B /* SNTEventLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SNTEventLog.h; sourceTree = "<group>"; };
 		C748E8A2206964DE006CFD1B /* SNTEventLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SNTEventLog.m; sourceTree = "<group>"; };
@@ -721,6 +725,8 @@
 				0D9A7F311759144800035EB5 /* SantaDriver.cc */,
 				0D9A7F361759148E00035EB5 /* SantaDriverClient.h */,
 				0D9A7F351759148E00035EB5 /* SantaDriverClient.cc */,
+				C7197268218A3AF600979487 /* SantaPrefixTree.h */,
+				C719726A218A419B00979487 /* SantaPrefixTree.cc */,
 				0DA36C1F199EA46600A129D6 /* Resources */,
 			);
 			path = "santa-driver";
@@ -916,6 +922,7 @@
 				0D4644C6182AF81700098690 /* SantaDecisionManager.h in Headers */,
 				0D9A7F341759144800035EB5 /* SantaDriver.h in Headers */,
 				0D9A7F381759148E00035EB5 /* SantaDriverClient.h in Headers */,
+				C7197269218A3AF600979487 /* SantaPrefixTree.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1467,6 +1474,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D9A7F331759144800035EB5 /* SantaDriver.cc in Sources */,
+				C719726B218A419B00979487 /* SantaPrefixTree.cc in Sources */,
 				0D9A7F371759148E00035EB5 /* SantaDriverClient.cc in Sources */,
 				0D4644C5182AF81700098690 /* SantaDecisionManager.cc in Sources */,
 			);

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -76,13 +76,14 @@
 ///  A list of ignore prefixes which are checked in-kernel.
 ///  This is more performant than FileChangesRegex when ignoring whole directory trees.
 ///
-///  For example adding a prefix of "/tmp/" will turn off file change log generation in-kernel
-//   for that entire tree. Since they are ignored by the kernel, they never reach santad and are
-///  not seen by the fileChangesRegex. Note the trailing "/", without it any file or directory
-///  starting with "/tmp" would be ignored.
+///  For example adding a prefix of "/private/tmp/" will turn off file change log generation
+///  in-kernel for that entire tree. Since they are ignored by the kernel, they never reach santad
+///  and are not seen by the fileChangesRegex. Note the trailing "/", without it any file or
+///  directory starting with "/private/tmp" would be ignored.
 ///
 ///  By default "/." and "/dev/" are added.
-///  32 additional entries are allowed. Anything over 32 will be ignored.
+///  Memory in the kernel is precious. 256 total bytes are allowed, use them wisely. Anything
+///  totaling up to more than 256 bytes will be ignored.
 ///
 ///  To disable file change logging completely add "/".
 ///  Filters are only applied on santad startup.

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -109,7 +109,9 @@
 ///  "/🖖"
 ///
 ///                          -> [0xa4] -> [0x98]
+///
 ///  [/] -> [0xf0] -> [0x9f]
+///
 ///                          -> [0x96] -> [0x96]
 ///
 ///  To disable file change logging completely add "/".

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -83,10 +83,11 @@
 ///
 ///  By default "/." and "/dev/" are added.
 ///
-///  Memory in the kernel is precious. A total of 256 nodes are allowed for this configuration.
+///  Memory in the kernel is precious. A total of MAXPATHLEN (1024) nodes are allowed.
+///  Using all 1024 nodes will result in santa-driver allocating ~2MB of wired memory.
 ///  An ASCII character uses 1 node. An UTF-8 encoded Unicode character uses 1-4 nodes.
-///  Prefixes are added to the running config in-order one by one. The prefix will be ignored if
-///  (the running config's current size) + (the prefix's size) totals up to more than 256 nodes.
+///  Prefixes are added to the running config in-order, one by one. The prefix will be ignored if
+///  (the running config's current size) + (the prefix's size) totals up to more than 1024 nodes.
 ///  The running config is stored in a prefix tree.
 ///  Prefixes that share prefixes are effectively de-duped; their shared node sized components only
 ///  take up 1 node. For example these 3 prefixes all have a common prefix of "/private/".

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -83,14 +83,14 @@
 ///
 ///  By default "/." and "/dev/" are added.
 ///
-///  Memory in the kernel is precious. A total of 256 bytes are allowed for this configuration.
-///  An ASCII character uses 1 byte. An UTF-8 encoded Unicode character uses 1-4 bytes.
+///  Memory in the kernel is precious. A total of 256 nodes are allowed for this configuration.
+///  An ASCII character uses 1 node. An UTF-8 encoded Unicode character uses 1-4 nodes.
 ///  Prefixes are added to the running config in-order one by one. The prefix will be ignored if
-///  (the running config's current size) + (the prefix's size) totals up to more than 256 bytes.
-///  The running config is stored in a prefix tree. Each node in the tree represents 1 byte.
-///  Prefixes that share prefixes are effectively de-duped; their shared byte sized components only
-///  take up 1 byte. For example these 3 prefixes all have a common prefix of "/private/".
-///  They will only take up 21 bytes instead of 39.
+///  (the running config's current size) + (the prefix's size) totals up to more than 256 nodes.
+///  The running config is stored in a prefix tree.
+///  Prefixes that share prefixes are effectively de-duped; their shared node sized components only
+///  take up 1 node. For example these 3 prefixes all have a common prefix of "/private/".
+///  They will only take up 21 nodes instead of 39.
 ///
 ///  "/private/tmp/"
 ///  "/private/var/"
@@ -103,7 +103,7 @@
 ///                                                              -> [n] -> [e] -> [w] -> [/]
 ///
 ///  Prefixes with Unicode characters work similarly. Assuming a UTF-8 encoding these two prefixes
-///  are actually the same for the first 3 bytes. They take up 7 bytes instead of 10.
+///  are actually the same for the first 3 nodes. They take up 7 nodes instead of 10.
 ///
 ///  "/🤘"
 ///  "/🖖"

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -82,11 +82,41 @@
 ///  directory starting with "/private/tmp" would be ignored.
 ///
 ///  By default "/." and "/dev/" are added.
-///  Memory in the kernel is precious. 256 total bytes are allowed, use them wisely. Anything
-///  totaling up to more than 256 bytes will be ignored.
+///
+///  Memory in the kernel is precious. A total of 256 bytes are allowed for this configuration.
+///  An ASCII character uses 1 byte. An UTF-8 encoded Unicode character uses 1-4 bytes.
+///  Prefixes are added to the running config in-order one by one. The prefix will be ignored if
+///  (the running config's current size) + (the prefix's size) totals up to more than 256 bytes.
+///  The running config is stored in a prefix tree. Each node in the tree represents 1 byte.
+///  Prefixes that share prefixes are effectively de-duped; their shared byte sized components only
+///  take up 1 byte. For example these 3 prefixes all have a common prefix of "/private/".
+///  They will only take up 21 bytes instead of 39.
+///
+///  "/private/tmp/"
+///  "/private/var/"
+///  "/private/new/"
+///
+///                                                              -> [t] -> [m] -> [p] -> [/]
+///
+///  [/] -> [p] -> [r] -> [i] -> [v] -> [a] -> [t] -> [e] -> [/] -> [v] -> [a] -> [r] -> [/]
+///
+///                                                              -> [n] -> [e] -> [w] -> [/]
+///
+///  Prefixes with Unicode characters work similarly. Assuming a UTF-8 encoding these two prefixes
+///  are actually the same for the first 3 bytes. They take up 7 bytes instead of 10.
+///
+///  "/🤘"
+///  "/🖖"
+///
+///                          -> [0xa4] -> [0x98]
+///  [/] -> [0xf0] -> [0x9f]
+///                          -> [0x96] -> [0x96]
 ///
 ///  To disable file change logging completely add "/".
+///  TODO(bur): Make this default if no FileChangesRegex is set.
+///
 ///  Filters are only applied on santad startup.
+///  TODO(bur): Support add / remove of filters while santad is running.
 ///
 @property(readonly, nonatomic) NSArray *fileChangesPrefixFilters;
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -73,6 +73,23 @@
 @property(readonly, nonatomic) NSRegularExpression *fileChangesRegex;
 
 ///
+///  A list of ignore prefixes which are checked in-kernel.
+///  This is more performant than FileChangesRegex when ignoring whole directory trees.
+///
+///  For example adding a prefix of "/tmp/" will turn off file change log generation in-kernel
+//   for that entire tree. Since they are ignored by the kernel, they never reach santad and are
+///  not seen by the fileChangesRegex. Note the trailing "/", without it any file or directory
+///  starting with "/tmp" would be ignored.
+///
+///  By default "/." and "/dev/" are added.
+///  32 additional entries are allowed. Anything over 32 will be ignored.
+///
+///  To disable file change logging completely add "/".
+///  Filters are only applied on santad startup.
+///
+@property(readonly, nonatomic) NSArray *fileChangesPrefixFilters;
+
+///
 ///  Enable __PAGEZERO protection, defaults to YES
 ///  If this flag is set to NO, 32-bit binaries that are missing
 ///  the __PAGEZERO segment will not be blocked.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -360,7 +360,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 - (NSArray *)fileChangesPrefixFilters {
   NSArray *filters = self.configState[kFileChangesPrefixFiltersKey];
   for (id filter in filters) {
-    if (![filter isKindOfClass:[NSString class]]) return nil;
+    if (![filter isKindOfClass:[NSString class]]) {
+      LOGE(@"Ignoring FileChangesPrefixFilters: array contains a non-string %@", filter);
+      return nil;
+    }
   }
   return filters;
 }

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -68,6 +68,7 @@ static NSString *const kModeNotificationLockdown = @"ModeNotificationLockdown";
 static NSString *const kEnablePageZeroProtectionKey = @"EnablePageZeroProtection";
 
 static NSString *const kFileChangesRegexKey = @"FileChangesRegex";
+static NSString *const kFileChangesPrefixFiltersKey = @"FileChangesPrefixFilters";
 
 static NSString *const kEventLogType = @"EventLogType";
 static NSString *const kEventLogPath = @"EventLogPath";
@@ -93,6 +94,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
     Class date = [NSDate class];
     Class string = [NSString class];
     Class data = [NSData class];
+    Class array = [NSArray class];
     _syncServerKeyTypes = @{
       kClientModeKey : number,
       kEnableTransitiveWhitelistingKey : number,
@@ -106,6 +108,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kClientModeKey : number,
       kEnableTransitiveWhitelistingKey : number,
       kFileChangesRegexKey : re,
+      kFileChangesPrefixFiltersKey : array,
       kWhitelistRegexKey : re,
       kBlacklistRegexKey : re,
       kEnablePageZeroProtectionKey : number,
@@ -195,6 +198,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 + (NSSet *)keyPathsForValuesAffectingFileChangesRegex {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingFileChangesPrefixFiltersKey {
   return [self configStateSet];
 }
 
@@ -348,6 +355,14 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (NSRegularExpression *)fileChangesRegex {
   return self.configState[kFileChangesRegexKey];
+}
+
+- (NSArray *)fileChangesPrefixFilters {
+  NSArray *filters = self.configState[kFileChangesPrefixFiltersKey];
+  for (id filter in filters) {
+    if (![filter isKindOfClass:[NSString class]]) return nil;
+  }
+  return filters;
 }
 
 - (NSURL *)syncBaseURL {

--- a/Source/common/SNTKernelCommon.h
+++ b/Source/common/SNTKernelCommon.h
@@ -41,6 +41,7 @@ enum SantaDriverMethods {
   kSantaUserClientCacheCount,
   kSantaUserClientCheckCache,
   kSantaUserClientCacheBucketCount,
+  kSantaUserClientAddFilemodPrefixFilter,
 
   // Any methods supported by the driver should be added above this line to
   // ensure this remains the count of methods.

--- a/Source/common/SNTKernelCommon.h
+++ b/Source/common/SNTKernelCommon.h
@@ -41,7 +41,8 @@ enum SantaDriverMethods {
   kSantaUserClientCacheCount,
   kSantaUserClientCheckCache,
   kSantaUserClientCacheBucketCount,
-  kSantaUserClientAddFilemodPrefixFilter,
+  kSantaUserClientFilemodPrefixFilterAdd,
+  kSantaUserClientFilemodPrefixFilterReset,
 
   // Any methods supported by the driver should be added above this line to
   // ensure this remains the count of methods.

--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -58,16 +58,7 @@ bool SantaDecisionManager::init() {
   root_fsid_ = 0;
 
   // Setup file modification prefix filter.
-  filemod_prefix_filter_ = new SantaPrefixTree;
-  if (!filemod_prefix_filter_->init()) {
-    filemod_prefix_filter_->release();
-    filemod_prefix_filter_ = nullptr;
-    LOGE("Unable to initialize file modification filter tree.");
-  } else {
-    // Default prefixes to filter.
-    filemod_prefix_filter_->AddPrefix("/.");
-    filemod_prefix_filter_->AddPrefix("/dev/"); // Notice the trailing the "/".
-  }
+  filemod_prefix_filter_ = new SantaPrefixTree();
 
   return true;
 }
@@ -107,7 +98,7 @@ void SantaDecisionManager::free() {
   OSSafeReleaseNULL(decision_dataqueue_);
   OSSafeReleaseNULL(log_dataqueue_);
 
-  OSSafeReleaseNULL(filemod_prefix_filter_);
+  delete filemod_prefix_filter_;
 
   super::free();
 }
@@ -705,7 +696,7 @@ void SantaDecisionManager::FileOpCallback(
 
   // Filter out modifications to locations that are definitely
   // not useful or made by santad.
-  if (!filemod_prefix_filter_ || !filemod_prefix_filter_->HasPrefix(path)) {
+  if (!filemod_prefix_filter_->HasPrefix(path)) {
     auto message = NewMessage(nullptr);
     strlcpy(message->path, path, sizeof(message->path));
     if (new_path) strlcpy(message->newpath, new_path, sizeof(message->newpath));

--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -125,10 +125,6 @@ void SantaDecisionManager::ConnectClient(pid_t pid) {
   // connected should be cleared
   ClearCache();
 
-  // Reset the filter from any previous connections.
-  // The daemon will add prefixes as needed.
-  FilemodPrefixFilterReset();
-
   failed_decision_queue_requests_ = 0;
   failed_log_queue_requests_ = 0;
 }
@@ -159,6 +155,10 @@ void SantaDecisionManager::DisconnectClient(bool itDied, pid_t pid) {
         kMaxLogQueueEvents, sizeof(santa_message_t));
     lck_mtx_unlock(log_dataqueue_lock_);
   }
+
+  // Reset the filter.
+  // On startup the daemon will add prefixes as needed.
+  FilemodPrefixFilterReset();
 }
 
 bool SantaDecisionManager::ClientConnected() const {

--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -125,6 +125,10 @@ void SantaDecisionManager::ConnectClient(pid_t pid) {
   // connected should be cleared
   ClearCache();
 
+  // Reset the filter from any previous connections.
+  // The daemon will add prefixes as needed.
+  FilemodPrefixFilterReset();
+
   failed_decision_queue_requests_ = 0;
   failed_log_queue_requests_ = 0;
 }

--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -64,9 +64,9 @@ bool SantaDecisionManager::init() {
     filemod_prefix_filter_ = nullptr;
     LOGE("Unable to initialize file modification filter tree.");
   } else {
-    // Default prefixes to filter. Notice the trailing the "/".
+    // Default prefixes to filter.
     filemod_prefix_filter_->AddPrefix("/.");
-    filemod_prefix_filter_->AddPrefix("/dev/");
+    filemod_prefix_filter_->AddPrefix("/dev/"); // Notice the trailing the "/".
   }
 
   return true;

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -174,8 +174,8 @@ class SantaDecisionManager : public OSObject {
   /**
     Reset the file modification prefix filter tree.
   */
-  inline void FilemodPrefixFilterReset(uint64_t *node_count = nullptr) {
-    filemod_prefix_filter_->Reset(node_count);
+  inline void FilemodPrefixFilterReset() {
+    filemod_prefix_filter_->Reset();
   }
 
   /**

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -19,12 +19,12 @@
 #include <IOKit/IOLib.h>
 #include <IOKit/IOMemoryDescriptor.h>
 #include <IOKit/IOSharedDataQueue.h>
-#include <libkern/c++/OSDictionary.h>
 #include <sys/kauth.h>
 #include <sys/proc.h>
 #include <sys/vnode.h>
 
 #include "SantaCache.h"
+#include "SantaPrefixTree.h"
 #include "SNTKernelCommon.h"
 #include "SNTLogging.h"
 
@@ -163,6 +163,10 @@ class SantaDecisionManager : public OSObject {
     processes of the pid.
   */
   bool IsCompilerProcess(pid_t pid);
+
+  void AddFilemodPrefixFilter(const char *prefix) {
+    filemod_prefix_filter_->AddPrefix(prefix);
+  }
 
   /**
    Fetches the vnode_id for a given vnode.
@@ -332,6 +336,8 @@ class SantaDecisionManager : public OSObject {
   SantaCache<santa_vnode_id_t, uint64_t> *non_root_decision_cache_;
   SantaCache<santa_vnode_id_t, uint64_t> *vnode_pid_map_;
   SantaCache<pid_t, pid_t> *compiler_pid_set_;
+
+  SantaPrefixTree *filemod_prefix_filter_;
 
   /**
    Return the correct cache for a given identifier.

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -167,14 +167,14 @@ class SantaDecisionManager : public OSObject {
   /**
     Add a file modification prefix filter.
   */
-  inline IOReturn AddFilemodPrefixFilter(const char *prefix, uint32_t *node_count) {
+  inline IOReturn AddFilemodPrefixFilter(const char *prefix, uint64_t *node_count) {
     return filemod_prefix_filter_->AddPrefix(prefix, node_count);
   }
 
   /**
     Reset the file modification prefix filter tree.
   */
-  inline void ResetFilemodPrefixFilter(uint32_t *node_count) {
+  inline void ResetFilemodPrefixFilter(uint64_t *node_count) {
     filemod_prefix_filter_->Reset(node_count);
   }
 

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -164,7 +164,10 @@ class SantaDecisionManager : public OSObject {
   */
   bool IsCompilerProcess(pid_t pid);
 
-  void AddFilemodPrefixFilter(const char *prefix) {
+  /**
+    Add a file modification prefix filter.
+  */
+  inline void AddFilemodPrefixFilter(const char *prefix) {
     filemod_prefix_filter_->AddPrefix(prefix);
   }
 

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -167,8 +167,15 @@ class SantaDecisionManager : public OSObject {
   /**
     Add a file modification prefix filter.
   */
-  inline void AddFilemodPrefixFilter(const char *prefix) {
-    filemod_prefix_filter_->AddPrefix(prefix);
+  inline IOReturn AddFilemodPrefixFilter(const char *prefix, uint32_t *node_count) {
+    return filemod_prefix_filter_->AddPrefix(prefix, node_count);
+  }
+
+  /**
+    Reset the file modification prefix filter tree.
+  */
+  inline void ResetFilemodPrefixFilter(uint32_t *node_count) {
+    filemod_prefix_filter_->Reset(node_count);
   }
 
   /**

--- a/Source/santa-driver/SantaDecisionManager.h
+++ b/Source/santa-driver/SantaDecisionManager.h
@@ -167,14 +167,14 @@ class SantaDecisionManager : public OSObject {
   /**
     Add a file modification prefix filter.
   */
-  inline IOReturn AddFilemodPrefixFilter(const char *prefix, uint64_t *node_count) {
+  inline IOReturn FilemodPrefixFilterAdd(const char *prefix, uint64_t *node_count = nullptr) {
     return filemod_prefix_filter_->AddPrefix(prefix, node_count);
   }
 
   /**
     Reset the file modification prefix filter tree.
   */
-  inline void ResetFilemodPrefixFilter(uint64_t *node_count) {
+  inline void FilemodPrefixFilterReset(uint64_t *node_count = nullptr) {
     filemod_prefix_filter_->Reset(node_count);
   }
 

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -248,6 +248,18 @@ IOReturn SantaDriverClient::cache_bucket_count(
   return kIOReturnSuccess;
 }
 
+IOReturn SantaDriverClient::add_filemod_prefix_filter(
+    OSObject *target, void *reference, IOExternalMethodArguments *arguments) {
+  SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
+  if (!me) return kIOReturnBadArgument;
+
+  if (arguments->structureInputSize != sizeof(const char[MAXPATHLEN])) return kIOReturnInvalid;
+  const char *prefix = reinterpret_cast<const char *>(arguments->structureInput);
+  me->decisionManager->AddFilemodPrefixFilter(prefix);
+
+  return kIOReturnSuccess;
+}
+
 #pragma mark Method Resolution
 
 IOReturn SantaDriverClient::externalMethod(
@@ -271,6 +283,7 @@ IOReturn SantaDriverClient::externalMethod(
     { &SantaDriverClient::check_cache, 0, sizeof(santa_vnode_id_t), 1, 0 },
     { &SantaDriverClient::cache_bucket_count, 0, sizeof(santa_bucket_count_t),
         0, sizeof(santa_bucket_count_t) },
+    { &SantaDriverClient::add_filemod_prefix_filter, 0, sizeof(const char[MAXPATHLEN]), 0, 0 },
   };
 
   if (selector > static_cast<UInt32>(kSantaUserClientNMethods)) {

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -254,8 +254,6 @@ IOReturn SantaDriverClient::filemod_prefix_filter_add(
   if (!me) return kIOReturnBadArgument;
 
   const char *prefix = reinterpret_cast<const char *>(arguments->structureInput);
-  if (prefix[0] == '\0') return kIOReturnBadArgument;
-
   return me->decisionManager->FilemodPrefixFilterAdd(prefix, arguments->scalarOutput);
 }
 

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -256,7 +256,7 @@ IOReturn SantaDriverClient::filemod_prefix_filter_add(
   const char *prefix = reinterpret_cast<const char *>(arguments->structureInput);
   if (prefix[0] == '\0') return kIOReturnBadArgument;
 
-  return me->decisionManager->AddFilemodPrefixFilter(prefix, arguments->scalarOutput);
+  return me->decisionManager->FilemodPrefixFilterAdd(prefix, arguments->scalarOutput);
 }
 
 IOReturn SantaDriverClient::filemod_prefix_filter_reset(
@@ -264,7 +264,7 @@ IOReturn SantaDriverClient::filemod_prefix_filter_reset(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  me->decisionManager->ResetFilemodPrefixFilter(arguments->scalarOutput);
+  me->decisionManager->FilemodPrefixFilterReset(arguments->scalarOutput);
   return kIOReturnSuccess;
 }
 

--- a/Source/santa-driver/SantaDriverClient.cc
+++ b/Source/santa-driver/SantaDriverClient.cc
@@ -262,7 +262,7 @@ IOReturn SantaDriverClient::filemod_prefix_filter_reset(
   SantaDriverClient *me = OSDynamicCast(SantaDriverClient, target);
   if (!me) return kIOReturnBadArgument;
 
-  me->decisionManager->FilemodPrefixFilterReset(arguments->scalarOutput);
+  me->decisionManager->FilemodPrefixFilterReset();
   return kIOReturnSuccess;
 }
 
@@ -290,7 +290,7 @@ IOReturn SantaDriverClient::externalMethod(
     { &SantaDriverClient::cache_bucket_count, 0, sizeof(santa_bucket_count_t),
         0, sizeof(santa_bucket_count_t) },
     { &SantaDriverClient::filemod_prefix_filter_add, 0, sizeof(const char[MAXPATHLEN]), 1, 0 },
-    { &SantaDriverClient::filemod_prefix_filter_reset, 0, 0, 1, 0 },
+    { &SantaDriverClient::filemod_prefix_filter_reset, 0, 0, 0, 0 },
   };
 
   if (selector > static_cast<UInt32>(kSantaUserClientNMethods)) {

--- a/Source/santa-driver/SantaDriverClient.h
+++ b/Source/santa-driver/SantaDriverClient.h
@@ -121,6 +121,10 @@ class com_google_SantaDriverClient : public IOUserClient {
   static IOReturn cache_bucket_count(
       OSObject *target, void *reference, IOExternalMethodArguments *arguments);
 
+  ///  The daemon calls this to add additional filemod prefix filters at daemon startup.
+  static IOReturn add_filemod_prefix_filter(
+    OSObject *target, void *reference, IOExternalMethodArguments *arguments);
+
  private:
   com_google_SantaDriver *myProvider;
   SantaDecisionManager *decisionManager;

--- a/Source/santa-driver/SantaDriverClient.h
+++ b/Source/santa-driver/SantaDriverClient.h
@@ -121,9 +121,13 @@ class com_google_SantaDriverClient : public IOUserClient {
   static IOReturn cache_bucket_count(
       OSObject *target, void *reference, IOExternalMethodArguments *arguments);
 
-  ///  The daemon calls this to add additional filemod prefix filters at daemon startup.
-  static IOReturn add_filemod_prefix_filter(
-    OSObject *target, void *reference, IOExternalMethodArguments *arguments);
+  ///  The daemon calls this to add filemod prefix filters at daemon startup.
+  static IOReturn filemod_prefix_filter_add(
+      OSObject *target, void *reference, IOExternalMethodArguments *arguments);
+
+  ///  The daemon calls this to reset the prefix filter tree.
+  static IOReturn filemod_prefix_filter_reset(
+      OSObject *target, void *reference, IOExternalMethodArguments *arguments);
 
  private:
   com_google_SantaDriver *myProvider;

--- a/Source/santa-driver/SantaPrefixTree.cc
+++ b/Source/santa-driver/SantaPrefixTree.cc
@@ -120,6 +120,8 @@ bool SantaPrefixTree::HasPrefix(const char *string) {
   auto found = false;
 
   SantaPrefixNode *node = root_;
+
+  // TODO(bur): Avoid using strlen().
   size_t len = strlen(string);
   for (int i = 0; i < len; ++i) {
     // Only process a byte at a time.

--- a/Source/santa-driver/SantaPrefixTree.cc
+++ b/Source/santa-driver/SantaPrefixTree.cc
@@ -156,7 +156,7 @@ void SantaPrefixTree::PruneNode(SantaPrefixNode *target) {
 
   // For deep trees, a recursive approach will generate too many stack frames. Make a "stack"
   // and walk the tree.
-  auto stack = new SantaPrefixNode *[sizeof(SantaPrefixNode *) * (node_count_ + 1)];
+  auto stack = new SantaPrefixNode *[node_count_ + 1];
   if (!stack) {
     LOGE("Unable to prune tree!");
     return;

--- a/Source/santa-driver/SantaPrefixTree.cc
+++ b/Source/santa-driver/SantaPrefixTree.cc
@@ -1,0 +1,147 @@
+/// Copyright 2018 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#include "SantaPrefixTree.h"
+
+#include "SNTLogging.h"
+
+#define super OSObject
+OSDefineMetaClassAndStructors(SantaPrefixTree, OSObject);
+
+bool SantaPrefixTree::init() {
+  if (!super::init()) return false;
+  root_ = new SantaPrefixNode;
+  root_->init();
+
+  spt_lock_grp_attr_ = lck_grp_attr_alloc_init();
+  spt_lock_grp_ = lck_grp_alloc_init("santa-prefix-tree-lock", spt_lock_grp_attr_);
+  spt_lock_attr_ = lck_attr_alloc_init();
+  spt_lock_ = lck_rw_alloc_init(spt_lock_grp_, spt_lock_attr_);
+
+  return true;
+}
+
+void SantaPrefixTree::AddPrefix(const char *prefix) {
+  LOGD("Trying to add prefix: %s", prefix);
+
+  lck_rw_lock_exclusive(spt_lock_);
+
+  SantaPrefixNode *node = root_;
+  size_t len = strlen(prefix);
+  for (int i = 0; i < len; ++i) {
+    // If there is a node in the path that is considered a prefix, stop adding.
+    // For our purposes we only care about the shortest path that matches.
+    if (node->isPrefix) break;
+
+    // Create a single char string.
+    const char value[2] = {prefix[i], '\0'};
+
+    // Create a new node if needed
+    if (!node->children->getObject(value)) {
+      SantaPrefixNode *newNode = new SantaPrefixNode;
+      newNode->init();
+      node->children->setObject(value, newNode);
+    }
+
+    // Get ready for the next iteration.
+    node = OSDynamicCast(SantaPrefixNode, node->children->getObject(value));
+
+    // If this is the end, mark the node as a prefix.
+    if (i + 1 == len) {
+      LOGD("Added prefix: %s", prefix);
+      node->isPrefix = true;
+      break;  // Unnecessary, but clear.
+    }
+  }
+
+  lck_rw_unlock_exclusive(spt_lock_);
+}
+
+bool SantaPrefixTree::HasPrefix(const char *string) {
+  lck_rw_lock_shared(spt_lock_);
+
+  auto found = false;
+
+  SantaPrefixNode *node = root_;
+  size_t len = strlen(string);
+  for (int i = 0; i < len; ++i) {
+    // Create a single char string.
+    const char value[2] = {string[i], '\0'};
+
+    // Get the next char string.
+    node = OSDynamicCast(SantaPrefixNode, node->children->getObject(value));
+
+    // If it doesn't exist in the tree, no match.
+    if (!node) break;
+
+    // If it does exist, is it a prefix?
+    if (node->isPrefix) {
+      found = true;
+      break;
+    }
+  }
+
+  lck_rw_unlock_shared(spt_lock_);
+
+  return found;
+}
+
+void SantaPrefixTree::free() {
+  if (spt_lock_) {
+    lck_rw_free(spt_lock_, spt_lock_grp_);
+    spt_lock_ = nullptr;
+  }
+
+  if (spt_lock_attr_) {
+    lck_attr_free(spt_lock_attr_);
+    spt_lock_attr_ = nullptr;
+  }
+
+  if (spt_lock_grp_) {
+    lck_grp_free(spt_lock_grp_);
+    spt_lock_grp_ = nullptr;
+  }
+
+  if (spt_lock_grp_attr_) {
+    lck_grp_attr_free(spt_lock_grp_attr_);
+    spt_lock_grp_attr_ = nullptr;
+  }
+
+  root_->release();
+  super::free();
+}
+
+OSDefineMetaClassAndStructors(SantaPrefixNode, OSObject);
+
+bool SantaPrefixNode::init() {
+  if (!super::init()) return false;
+  children = OSDictionary::withCapacity(1);
+  isPrefix = false;
+  return true;
+}
+
+void SantaPrefixNode::free() {
+  children->OSCollection::iterateObjects(^bool(OSObject *key) {
+    // Counter init()
+    children->getObject((OSString *)key)->release();
+    return false;
+  });
+
+  // Counter setObject();
+  children->flushCollection();
+
+  // Counter withCapacity()
+  children->release();
+  super::free();
+}

--- a/Source/santa-driver/SantaPrefixTree.cc
+++ b/Source/santa-driver/SantaPrefixTree.cc
@@ -17,9 +17,8 @@
 #include "SNTLogging.h"
 
 #include <libkern/c++/OSArray.h>
-#include <libkern/c++/OSSet.h>
 #include <libkern/c++/OSNumber.h>
-
+#include <libkern/c++/OSSet.h>
 
 SantaPrefixTree::SantaPrefixTree() {
   root_ = new SantaPrefixNode();
@@ -174,7 +173,7 @@ void SantaPrefixTree::PruneNode(SantaPrefixNode *target) {
     auto pointer = OSDynamicCast(OSNumber, stack->getLastObject());
     if (!pointer) {
       LOGE("Unable complete prune!");
-      break; // Bail walking the tree, but still delete any seen nodes.
+      break;  // Bail walking the tree, but still delete any seen nodes.
     }
 
     seen->setObject(pointer);
@@ -194,7 +193,7 @@ void SantaPrefixTree::PruneNode(SantaPrefixNode *target) {
     auto pointer = OSDynamicCast(OSNumber, object);
     if (!pointer) {
       LOGE("Unable delete node!");
-      return false; // Continue trying to delete the rest of the nodes.
+      return false;  // Continue trying to delete the rest of the nodes.
     }
     auto node = (SantaPrefixNode *)pointer->unsigned64BitValue();
     delete node;

--- a/Source/santa-driver/SantaPrefixTree.h
+++ b/Source/santa-driver/SantaPrefixTree.h
@@ -19,8 +19,6 @@
 #include <libkern/locks.h>
 #include <sys/param.h>
 
-#include "SNTLogging.h"
-
 ///
 ///  SantaPrefixTree is a simple prefix tree implementation.
 ///  Operations are thread safe.
@@ -35,8 +33,7 @@ class SantaPrefixTree {
   bool HasPrefix(const char *string);
 
   // Reset the tree.
-  // Optionally pass node_count to get the number of nodes after the reset. It should be 1.
-  void Reset(uint64_t *node_count = nullptr);
+  void Reset();
 
   SantaPrefixTree();
   ~SantaPrefixTree();

--- a/Source/santa-driver/SantaPrefixTree.h
+++ b/Source/santa-driver/SantaPrefixTree.h
@@ -17,6 +17,7 @@
 
 #include <IOKit/IOReturn.h>
 #include <libkern/locks.h>
+#include <sys/param.h>
 
 #include "SNTLogging.h"
 
@@ -74,8 +75,8 @@ class SantaPrefixTree {
 
   SantaPrefixNode *root_;
 
-  // Each node takes up ~2k, max out at ~512k.
-  static const uint32_t kMaxNodes = 256;
+  // Each node takes up ~2k, assuming MAXPATHLEN is 1024 max out at ~2MB.
+  static const uint32_t kMaxNodes = MAXPATHLEN;
   uint32_t node_count_;
 
   lck_grp_t *spt_lock_grp_;

--- a/Source/santa-driver/SantaPrefixTree.h
+++ b/Source/santa-driver/SantaPrefixTree.h
@@ -1,0 +1,67 @@
+/// Copyright 2018 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#ifndef SANTA__SANTA_DRIVER__SANTAPREFIXTREE_H
+#define SANTA__SANTA_DRIVER__SANTAPREFIXTREE_H
+
+#include <libkern/c++/OSDictionary.h>
+#include <libkern/locks.h>
+
+///
+///  SantaPrefixNode is wrapper class representing one char in a prefix.
+///
+///  OSDefineMetaClassAndStructors is picky so this can't be a nested class.
+///
+class SantaPrefixNode : public OSObject {
+  OSDeclareDefaultStructors(SantaPrefixNode);
+
+ public:
+  bool init() override;
+  void free() override;
+
+  bool isPrefix;
+  // TODO(bur): After writing this I noticed OSDictionary has an O(n) runtime.
+  //            Switch to an int[256] lookup table and get rid of SantaPrefixNode.
+  OSDictionary *children;
+};
+
+///
+///  SantaPrefixTree is a simple prefix tree implementation.
+///  The runtime for lookup is is not quite linear.
+///  Adding and checking prefixes are thread safe.
+///
+class SantaPrefixTree : public OSObject {
+  OSDeclareDefaultStructors(SantaPrefixTree);
+
+ public:
+  bool init() override;
+  void free() override;
+
+  void AddPrefix(const char *);
+  bool HasPrefix(const char *);
+  // TODO(bur): Add RemoveAll(). This will allow santad to reset / add prefixes while running.
+
+ private:
+  SantaPrefixNode *root_;
+
+  // Locking is probably not needed since we only add prefixes at santad startup before
+  // it starts listening for file changes. The read / write lock is cheap, so leaving it in place
+  // for now.
+  lck_grp_t *spt_lock_grp_;
+  lck_grp_attr_t *spt_lock_grp_attr_;
+  lck_attr_t *spt_lock_attr_;
+  lck_rw_t *spt_lock_;
+};
+
+#endif /* SANTA__SANTA_DRIVER__SANTAPREFIXTREE_H */

--- a/Source/santa-driver/SantaPrefixTree.h
+++ b/Source/santa-driver/SantaPrefixTree.h
@@ -28,14 +28,14 @@ class SantaPrefixTree {
  public:
   // Add a prefix to the tree.
   // Optionally pass node_count to get the number of nodes after the add.
-  IOReturn AddPrefix(const char *, uint32_t *node_count = nullptr);
+  IOReturn AddPrefix(const char *, uint64_t *node_count = nullptr);
 
   // Check if the tree has a prefix for string.
   bool HasPrefix(const char *string);
 
   // Reset the tree.
   // Optionally pass node_count to get the number of nodes after the reset. It should be 1.
-  void Reset(uint32_t *node_count = nullptr);
+  void Reset(uint64_t *node_count = nullptr);
 
   SantaPrefixTree();
   ~SantaPrefixTree();
@@ -63,11 +63,12 @@ class SantaPrefixTree {
   class SantaPrefixNode {
    public:
     bool isPrefix;
-    void *children[256];
+    SantaPrefixNode *children[256];
   };
 
   // PruneNode will remove the passed in node from the tree.
   // The passed in node and all subnodes will be deleted.
+  // It is the caller's responsibility to reset the pointer to this node (held by the parent).
   // If the tree is in use grab the exclusive lock.
   void PruneNode(SantaPrefixNode *);
 

--- a/Source/santa-driver/SantaPrefixTree.h
+++ b/Source/santa-driver/SantaPrefixTree.h
@@ -25,7 +25,6 @@
 ///  Operations are thread safe.
 ///
 class SantaPrefixTree {
-
  public:
   // Add a prefix to the tree.
   // Optionally pass node_count to get the number of nodes after the add.

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -84,7 +84,7 @@
         break;
     }
 
-    // The filter is reset when santad connects to the driver.
+    // The filter is reset when santad disconnects from the driver.
     // Add the default filters.
     [_driverManager fileModificationPrefixFilterAdd:@[ @"/.", @"/dev/" ]];
 

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -84,6 +84,8 @@
         break;
     }
 
+    [_driverManager setFilemodPrefixFilters:[configurator fileChangesPrefixFilters]];
+
     self.notQueue = [[SNTNotificationQueue alloc] init];
     SNTSyncdQueue *syncdQueue = [[SNTSyncdQueue alloc] init];
 

--- a/Source/santad/SNTApplication.m
+++ b/Source/santad/SNTApplication.m
@@ -84,7 +84,12 @@
         break;
     }
 
-    [_driverManager setFilemodPrefixFilters:[configurator fileChangesPrefixFilters]];
+    // The filter is reset when santad connects to the driver.
+    // Add the default filters.
+    [_driverManager fileModificationPrefixFilterAdd:@[ @"/.", @"/dev/" ]];
+
+    // TODO(bur): Add KVO handling for fileChangesPrefixFilters.
+    [_driverManager fileModificationPrefixFilterAdd:[configurator fileChangesPrefixFilters]];
 
     self.notQueue = [[SNTNotificationQueue alloc] init];
     SNTSyncdQueue *syncdQueue = [[SNTSyncdQueue alloc] init];

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -76,4 +76,11 @@
 ///
 - (kern_return_t)removeCacheEntryForVnodeID:(santa_vnode_id_t)vnodeId;
 
+
+///
+///  Adds in-kernel prefix filters for file modification logs.
+///  Only allow a sane number of entries, say 32.
+///
+- (void)setFilemodPrefixFilters:(NSArray *)filters;
+
 @end

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -80,7 +80,6 @@
 
 ///
 ///  Adds in-kernel prefix filters for file modification logs.
-///  Only allow a sane number bytes, currently 256.
 ///
 - (void)fileModificationPrefixFilterAdd:(NSArray *)filters;
 

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -79,7 +79,7 @@
 
 ///
 ///  Adds in-kernel prefix filters for file modification logs.
-///  Only allow a sane number of entries, say 32.
+///  Only allow a sane number bytes, currently 256.
 ///
 - (void)setFilemodPrefixFilters:(NSArray *)filters;
 

--- a/Source/santad/SNTDriverManager.h
+++ b/Source/santad/SNTDriverManager.h
@@ -68,7 +68,9 @@
 ///
 - (santa_action_t)checkCache:(santa_vnode_id_t)vnodeID;
 
+///
 ///  Returns whether the connection to the driver has been established.
+///
 @property(readonly) BOOL connectionEstablished;
 
 ///
@@ -76,11 +78,15 @@
 ///
 - (kern_return_t)removeCacheEntryForVnodeID:(santa_vnode_id_t)vnodeId;
 
-
 ///
 ///  Adds in-kernel prefix filters for file modification logs.
 ///  Only allow a sane number bytes, currently 256.
 ///
-- (void)setFilemodPrefixFilters:(NSArray *)filters;
+- (void)fileModificationPrefixFilterAdd:(NSArray *)filters;
+
+///
+///  Resets the filter.
+///
+- (void)fileModificationPrefixFilterReset;
 
 @end

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -282,11 +282,9 @@ static void driverAppearedHandler(void *info, io_iterator_t iterator) {
   uint64_t n = 0;
   uint32_t n_len = 1;
 
-  const char *reset = "";
-  kern_return_t ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
-                                          NULL, 0, reset, sizeof(const char[MAXPATHLEN]),
-                                          &n, &n_len, NULL, NULL);
-  if (ret != kIOReturnSuccess || n != 1) {
+  IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset,
+                            0, 0, &n, &n_len);
+  if (n != 1) {
     LOGE(@"Failed to reset the prefix filter: got %llu nodes expected 1", n);
     return;
   }
@@ -298,9 +296,9 @@ static void driverAppearedHandler(void *info, io_iterator_t iterator) {
       continue;
     }
 
-    ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
-                              NULL, 0, buffer, sizeof(const char[MAXPATHLEN]),
-                              &n, &n_len, NULL, NULL);
+    kern_return_t ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd,
+                                            NULL, 0, buffer, sizeof(const char[MAXPATHLEN]),
+                                            &n, &n_len, NULL, NULL);
 
     if (ret != kIOReturnSuccess) {
       LOGE(@"Failed to add prefix filter: %s error: 0x%x", buffer, ret);

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -278,4 +278,23 @@ static void driverAppearedHandler(void *info, io_iterator_t iterator) {
   return a;
 }
 
+- (void)setFilemodPrefixFilters:(NSArray *)filters {
+  // Max out at 32K, don't want to accidentally fill up wired kernel memory.
+  NSInteger n = filters.count > 32 ? 32 : filters.count;
+  for (NSString *filter in [filters subarrayWithRange:NSMakeRange(0, n)]) {
+    char buffer[MAXPATHLEN];
+    if (![filter getFileSystemRepresentation:buffer maxLength:MAXPATHLEN]) {
+      LOGE(@"Invalid filemod prefix filter: %@", filter);
+      continue;
+    }
+
+    IOConnectCallStructMethod(self.connection,
+                              kSantaUserClientAddFilemodPrefixFilter,
+                              &buffer,
+                              sizeof(const char[MAXPATHLEN]),
+                              0,
+                              0);
+  }
+}
+
 @end

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -278,18 +278,11 @@ static void driverAppearedHandler(void *info, io_iterator_t iterator) {
   return a;
 }
 
-- (void)setFilemodPrefixFilters:(NSArray *)filters {
+- (void)fileModificationPrefixFilterAdd:(NSArray *)filters {
   uint64_t n = 0;
   uint32_t n_len = 1;
 
-  IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset,
-                            0, 0, &n, &n_len);
-  if (n != 1) {
-    LOGE(@"Failed to reset the prefix filter: got %llu nodes expected 1", n);
-    return;
-  }
-
-  for (NSString *filter in [@[ @"/.", @"/dev/" ] arrayByAddingObjectsFromArray:filters]) {
+  for (NSString *filter in filters) {
     char buffer[MAXPATHLEN];
     if (![filter getFileSystemRepresentation:buffer maxLength:MAXPATHLEN]) {
       LOGE(@"Invalid filemod prefix filter: %@", filter);
@@ -312,6 +305,15 @@ static void driverAppearedHandler(void *info, io_iterator_t iterator) {
       }
     }
   }
+}
+
+- (void)fileModificationPrefixFilterReset {
+  uint64_t n = 0;
+  uint32_t n_len = 1;
+
+  IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset,
+                            0, 0, &n, &n_len);
+  if (n != 1) LOGE(@"Failed to reset the prefix filter: got %llu nodes expected 1", n);
 }
 
 @end

--- a/Source/santad/SNTDriverManager.m
+++ b/Source/santad/SNTDriverManager.m
@@ -308,12 +308,8 @@ static void driverAppearedHandler(void *info, io_iterator_t iterator) {
 }
 
 - (void)fileModificationPrefixFilterReset {
-  uint64_t n = 0;
-  uint32_t n_len = 1;
-
   IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset,
-                            0, 0, &n, &n_len);
-  if (n != 1) LOGE(@"Failed to reset the prefix filter: got %llu nodes expected 1", n);
+                            NULL, 0, NULL, NULL);
 }
 
 @end

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -718,6 +718,7 @@
   uint64_t n = 0;
   uint32_t n_len = 1;
 
+  // The filter is reset when KernelTests connects to the driver.
   // Fill up the 256 node capacity.
   kern_return_t ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd,
                                           NULL, 0, buffer, sizeof(const char[MAXPATHLEN]),

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -18,14 +18,14 @@
 
 #import <CommonCrypto/CommonDigest.h>
 
-#include <libkern/OSKextLib.h>
-#include <mach/mach.h>
-#include <sys/ptrace.h>
-#include <sys/types.h>
 #include <cmath>
 #include <ctime>
 #include <iostream>
+#include <libkern/OSKextLib.h>
+#include <mach/mach.h>
 #include <numeric>
+#include <sys/ptrace.h>
+#include <sys/types.h>
 #include <vector>
 
 #include "SNTKernelCommon.h"
@@ -38,30 +38,24 @@
 /// any existing driver (and daemon) if necessary.
 ///
 
-#define TSTART(testName)           \
-  do {                             \
-    printf("   %-50s ", testName); \
-  } while (0)
-#define TPASS()       \
-  do {                \
-    printf("PASS\n"); \
-  } while (0)
-#define TPASSINFO(fmt, ...)                         \
-  do {                                              \
-    printf("PASS\n      " fmt "\n", ##__VA_ARGS__); \
-  } while (0)
-#define TFAIL()             \
-  do {                      \
-    printf("FAIL\n");       \
-    [self unloadExtension]; \
-    exit(1);                \
-  } while (0)
-#define TFAILINFO(fmt, ...)                                           \
-  do {                                                                \
-    printf("FAIL\n   -> " fmt "\n\nTest failed.\n\n", ##__VA_ARGS__); \
-    [self unloadExtension];                                           \
-    exit(1);                                                          \
-  } while (0)
+#define TSTART(testName) \
+    do { printf("   %-50s ", testName); } while (0)
+#define TPASS() \
+    do { printf("PASS\n"); } while (0)
+#define TPASSINFO(fmt, ...) \
+    do { printf("PASS\n      " fmt "\n", ##__VA_ARGS__); } while (0)
+#define TFAIL() \
+    do { \
+      printf("FAIL\n"); \
+      [self unloadExtension]; \
+      exit(1); \
+    } while (0)
+#define TFAILINFO(fmt, ...) \
+    do { \
+      printf("FAIL\n   -> " fmt "\n\nTest failed.\n\n", ##__VA_ARGS__); \
+      [self unloadExtension]; \
+      exit(1); \
+    } while (0)
 
 @interface SantaKernelTests : NSObject
 @property io_connect_t connection;
@@ -93,7 +87,9 @@
 
 - (NSString *)sha256ForPath:(NSString *)path {
   unsigned char sha256[CC_SHA256_DIGEST_LENGTH];
-  NSData *fData = [NSData dataWithContentsOfFile:path options:NSDataReadingMappedIfSafe error:nil];
+  NSData *fData = [NSData dataWithContentsOfFile:path
+                                         options:NSDataReadingMappedIfSafe
+                                           error:nil];
   CC_SHA256([fData bytes], (unsigned int)[fData length], sha256);
   char buf[CC_SHA256_DIGEST_LENGTH * 2 + 1];
   for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; ++i) {
@@ -108,7 +104,7 @@
   static NSString *path;
   if (!path) {
     NSTask *xcrun = [self taskWithPath:@"/usr/bin/xcrun"];
-    xcrun.arguments = @[ @"-f", @"ld" ];
+    xcrun.arguments = @[@"-f", @"ld"];
     xcrun.standardOutput = [NSPipe pipe];
     @try {
       [xcrun launch];
@@ -120,7 +116,7 @@
     NSData *data = [[xcrun.standardOutput fileHandleForReading] readDataToEndOfFile];
     if (!data) return nil;
     path = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
-        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
   }
   return path;
 }
@@ -132,20 +128,20 @@
 - (void)postToKernelAction:(santa_action_t)action forVnodeID:(santa_vnode_id_t)vnodeid {
   switch (action) {
     case ACTION_RESPOND_ALLOW:
-      IOConnectCallStructMethod(self.connection, kSantaUserClientAllowBinary, &vnodeid,
-                                sizeof(vnodeid), 0, 0);
+      IOConnectCallStructMethod(self.connection, kSantaUserClientAllowBinary,
+                                &vnodeid, sizeof(vnodeid), 0, 0);
       break;
     case ACTION_RESPOND_DENY:
-      IOConnectCallStructMethod(self.connection, kSantaUserClientDenyBinary, &vnodeid,
-                                sizeof(vnodeid), 0, 0);
+      IOConnectCallStructMethod(self.connection, kSantaUserClientDenyBinary,
+                                &vnodeid, sizeof(vnodeid), 0, 0);
       break;
     case ACTION_RESPOND_ACK:
-      IOConnectCallStructMethod(self.connection, kSantaUserClientAcknowledgeBinary, &vnodeid,
-                                sizeof(vnodeid), 0, 0);
+      IOConnectCallStructMethod(self.connection, kSantaUserClientAcknowledgeBinary,
+                                &vnodeid, sizeof(vnodeid), 0, 0);
       break;
     case ACTION_RESPOND_ALLOW_COMPILER:
-      IOConnectCallStructMethod(self.connection, kSantaUserClientAllowCompiler, &vnodeid,
-                                sizeof(vnodeid), 0, 0);
+      IOConnectCallStructMethod(self.connection, kSantaUserClientAllowCompiler,
+                                &vnodeid, sizeof(vnodeid), 0, 0);
       break;
     default:
       TFAILINFO("postToKernelAction:forVnodeID: received unknown action type: %d", action);
@@ -233,8 +229,8 @@
   TPASS();
 
   TSTART("Registers the notification port");
-  kern_return_t kr =
-      IOConnectSetNotificationPort(self.connection, QUEUETYPE_DECISION, receivePort, 0);
+  kern_return_t kr = IOConnectSetNotificationPort(
+      self.connection, QUEUETYPE_DECISION, receivePort, 0);
   if (kr != kIOReturnSuccess) {
     mach_port_destroy(mach_task_self(), receivePort);
     TFAILINFO("KR: %d", kr);
@@ -245,8 +241,8 @@
   TSTART("Maps shared memory");
   mach_vm_address_t address = 0;
   mach_vm_size_t size = 0;
-  kr = IOConnectMapMemory(self.connection, QUEUETYPE_DECISION, mach_task_self(), &address, &size,
-                          kIOMapAnywhere);
+  kr = IOConnectMapMemory(self.connection, QUEUETYPE_DECISION, mach_task_self(),
+                          &address, &size, kIOMapAnywhere);
   if (kr != kIOReturnSuccess) {
     mach_port_destroy(mach_task_self(), receivePort);
     TFAILINFO("KR: %d", kr);
@@ -295,7 +291,8 @@
     [ed launch];
     [ed waitUntilExit];
     TFAIL();
-  } @catch (NSException *exception) {
+  }
+  @catch (NSException *exception) {
     TPASS();
   }
 }
@@ -430,9 +427,10 @@
   // Replace file contents using dd, which doesn't close FDs
   NSDictionary *attrs = [fm attributesOfItemAtPath:@"/bin/ed" error:NULL];
   NSTask *dd = [self taskWithPath:@"/bin/dd"];
-  dd.arguments = @[
-    @"if=/bin/ed", @"of=invalidacachetest_tmp", @"bs=1",
-    [NSString stringWithFormat:@"count=%@", attrs[NSFileSize]]
+  dd.arguments = @[ @"if=/bin/ed",
+                    @"of=invalidacachetest_tmp",
+                    @"bs=1",
+                    [NSString stringWithFormat:@"count=%@", attrs[NSFileSize]]
   ];
   [dd launch];
   [dd waitUntilExit];
@@ -493,8 +491,7 @@
     TFAILINFO("Failed to fork");
   } else if (pid > 0) {
     int status;
-    while (waitpid(pid, &status, 0) != pid)
-      ;  // handle EINTR
+    while (waitpid(pid, &status, 0) != pid); // handle EINTR
     if (WIFEXITED(status) && WEXITSTATUS(status) == EPERM) {
       TPASS();
     } else if (WIFSTOPPED(status)) {
@@ -531,16 +528,17 @@
 
   // Sort and remove first 10 and last 10 entries.
   std::sort(times.begin(), times.end());
-  times.erase(times.begin(), times.begin() + 10);
-  times.erase(times.end() - 10, times.end());
+  times.erase(times.begin(), times.begin()+10);
+  times.erase(times.end()-10, times.end());
 
   // Calculate mean
   double mean = std::accumulate(times.begin(), times.end(), 0.0) / times.size();
 
   // Calculate stdev
   double accum = 0.0;
-  std::for_each(times.begin(), times.end(),
-                [&](const double d) { accum += (d - mean) * (d - mean); });
+  std::for_each(times.begin(), times.end(), [&](const double d) {
+    accum += (d - mean) * (d - mean);
+  });
   double stdev = sqrt(accum / (times.size() - 1));
 
   if (mean > 80 || stdev > 10) {
@@ -561,8 +559,8 @@
       if (calCount++) TFAILINFO("Large binary should not re-request");
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC),
                      dispatch_get_global_queue(0, 0), ^{
-                       [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:msg.vnode_id];
-                     });
+        [self postToKernelAction:ACTION_RESPOND_ALLOW forVnodeID:msg.vnode_id];
+      });
       return ACTION_RESPOND_ACK;
     }
     return ACTION_RESPOND_ALLOW;
@@ -612,7 +610,7 @@
   fclose(out);
   // Then compile it with clang and ld, the latter of which has been marked as a compiler.
   NSTask *clang = [self taskWithPath:@"/usr/bin/clang"];
-  clang.arguments = @[ @"-o", @"/private/tmp/hello", @"/private/tmp/hello.c" ];
+  clang.arguments = @[@"-o", @"/private/tmp/hello", @"/private/tmp/hello.c"];
   [clang launch];
   [clang waitUntilExit];
   // Make sure that our version of ld marked as compiler was run.  This assumes that
@@ -671,7 +669,7 @@
   fclose(out);
   // Then compile it with clang and ld, neither of which have been marked as a compiler.
   NSTask *clang = [self taskWithPath:@"/usr/bin/clang"];
-  clang.arguments = @[ @"-o", @"/private/tmp/hello", @"/private/tmp/hello.c" ];
+  clang.arguments = @[@"-o", @"/private/tmp/hello", @"/private/tmp/hello.c"];
   @try {
     [clang launch];
     [clang waitUntilExit];
@@ -704,8 +702,8 @@
   TPASS();
 }
 
-- (void)testAddFilemodPrefixFilter {
-  TSTART("Adds filemod prefix filter");
+- (void)testFilemodPrefixFilter {
+  TSTART("Testing filemod prefix filter");
 
   NSString *filter =
       @"Albert Einstein, in his theory of special relativity, determined that the laws of physics "
@@ -713,13 +711,13 @@
       @"within a vacuum is the same no matter the speed at which an observer travels.";
 
   // Create a buffer that has 1024 bytes of characters, non-terminating.
-  char buffer[MAXPATHLEN];
+  char buffer[MAXPATHLEN + 1];  // +1 is for the null byte from strlcpy(). It falls off the ledge.
   for (int i = 0; i < 4; ++i) {
     if (![filter getFileSystemRepresentation:buffer + (i * filter.length) maxLength:MAXPATHLEN]) {
       TFAILINFO("Invalid filemod prefix filter: %s", filter.UTF8String);
     }
   }
-  strcpy(&buffer[1016], "E = mc²");
+  strlcpy(&buffer[1016], "E = mc²", 9);  // Fill in the last 8 bytes.
 
   uint64_t n = 0;
   uint32_t n_len = 1;
@@ -727,8 +725,8 @@
   // The filter is reset when KernelTests connects to the driver.
   // Fill up the 1024 node capacity.
   kern_return_t ret =
-      IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd, NULL, 0, buffer,
-                          sizeof(const char[MAXPATHLEN]), &n, &n_len, NULL, NULL);
+  IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd, NULL, 0, buffer,
+                      sizeof(const char[MAXPATHLEN]), &n, &n_len, NULL, NULL);
 
   if (ret != kIOReturnSuccess || n != 1024) {
     TFAILINFO("Failed to fill the prefix filter: got %llu nodes expected 1024", n);
@@ -751,12 +749,9 @@
     TFAILINFO("Failed to prune the prefix filter: got %llu nodes expected 1", n);
   }
 
-  // Make sure it will reset.
-  IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset, 0, 0, &n,
-                            &n_len);
-  if (n != 0) {
-    TFAILINFO("Failed to reset the prefix filter: got %llu nodes expected 0", n);
-  }
+  // Reset.
+  IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset, NULL, 0,
+                            NULL, NULL);
 
   // And fill it back up again.
   ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd, NULL, 0,
@@ -796,15 +791,15 @@
 
   NSString *src = [[fm currentDirectoryPath] stringByAppendingPathComponent:@"santa-driver.kext"];
   NSString *dest = [NSTemporaryDirectory() stringByAppendingPathComponent:@"santa-driver.kext"];
-  [fm removeItemAtPath:dest error:NULL];  // ensure dest is free
+  [fm removeItemAtPath:dest error:NULL]; // ensure dest is free
   if (![fm copyItemAtPath:src toPath:dest error:&error] || error) {
     TFAILINFO("Failed to copy kext: %s", error.description.UTF8String);
   }
 
   NSDictionary *attrs = @{
-    NSFileOwnerAccountName : @"root",
-    NSFileGroupOwnerAccountName : @"wheel",
-    NSFilePosixPermissions : @0755
+      NSFileOwnerAccountName : @"root",
+      NSFileGroupOwnerAccountName : @"wheel",
+      NSFilePosixPermissions : @0755
   };
 
   [fm setAttributes:attrs ofItemAtPath:dest error:NULL];
@@ -844,7 +839,7 @@
   [self testLargeBinary];
   [self testPendingTransitiveRules];
   [self testNoTransitiveRules];
-  [self testAddFilemodPrefixFilter];
+  [self testFilemodPrefixFilter];
 
   printf("\n-> Performance tests:\n");
   [self testCachePerformance];

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -722,7 +722,7 @@
   uint64_t n = 0;
   uint32_t n_len = 1;
 
-  // The filter is reset when KernelTests connects to the driver.
+  // The filter should currently be empty. It is reset when the client disconnects.
   // Fill up the 1024 node capacity.
   kern_return_t ret =
   IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd, NULL, 0, buffer,

--- a/Tests/KernelTests/main.mm
+++ b/Tests/KernelTests/main.mm
@@ -719,7 +719,7 @@
   uint32_t n_len = 1;
 
   // Fill up the 256 node capacity.
-  kern_return_t ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
+  kern_return_t ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd,
                                           NULL, 0, buffer, sizeof(const char[MAXPATHLEN]),
                                           &n, &n_len, NULL, NULL);
 
@@ -729,7 +729,7 @@
 
   // Make sure it will enforce capacity.
   const char *too_much = "/B";
-  ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
+  ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd,
                             NULL, 0, too_much, sizeof(const char[MAXPATHLEN]),
                             &n, &n_len, NULL, NULL);
   if (ret != kIOReturnNoResources || n != 256) {
@@ -738,7 +738,7 @@
 
   // Make sure it will prune.
   const char *ignore_it_all = "/";
-  ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
+  ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd,
                             NULL, 0, ignore_it_all, sizeof(const char[MAXPATHLEN]),
                             &n, &n_len, NULL, NULL);
   // Expect 2 nodes, one for root and one for '/'.
@@ -747,17 +747,15 @@
   }
 
   // Make sure it will reset.
-  const char *reset = "";
-  ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
-                            NULL, 0, reset, sizeof(const char[MAXPATHLEN]),
-                            &n, &n_len, NULL, NULL);
+  IOConnectCallScalarMethod(self.connection, kSantaUserClientFilemodPrefixFilterReset,
+                            0, 0, &n, &n_len);
   // Expect 1 root node.
-  if (ret != kIOReturnSuccess || n != 1) {
+  if (n != 1) {
     TFAILINFO("Failed to reset the prefix filter: got %llu nodes expected 1", n);
   }
 
   // And fill it back up again.
-  ret = IOConnectCallMethod(self.connection, kSantaUserClientAddFilemodPrefixFilter,
+  ret = IOConnectCallMethod(self.connection, kSantaUserClientFilemodPrefixFilterAdd,
                             NULL, 0, buffer, sizeof(const char[MAXPATHLEN]),
                             &n, &n_len, NULL, NULL);
 


### PR DESCRIPTION
* Allow santa-driver to ignore file changes with a prefix filter.
* Stops unnecessary generation of events that would be ignored by santad with a regex or lack of one.
* Prefixes are configurable with the mobileconfig.