### PR TITLE
document vnode_pid_map

### DIFF
--- a/Source/santa-driver/SantaDecisionManager.cc
+++ b/Source/santa-driver/SantaDecisionManager.cc
@@ -653,12 +653,16 @@ void SantaDecisionManager::FileOpCallback(
     message->vnode_id = vnode_id;
     message->action = ACTION_NOTIFY_EXEC;
     strlcpy(message->path, path, sizeof(message->path));
+
+    // The vnode scope gets posix_spawn pid and ppid properly. The fileop scope does not.
+    // Get pid and ppid cached during vnode execution.
     uint64_t val = vnode_pid_map_->get(vnode_id);
     if (val) {
       // pid_t is 32-bit, so pid is in upper 32 bits, ppid in lower.
       message->pid = (val >> 32);
       message->ppid = (val & ~0xFFFFFFFF00000000);
     }
+
     PostToLogQueue(message);
     delete message;
     return;

--- a/Tests/LogicTests/SNTCommandFileInfoTest.m
+++ b/Tests/LogicTests/SNTCommandFileInfoTest.m
@@ -26,7 +26,7 @@
 typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 @property(nonatomic) BOOL recursive;
 @property(nonatomic) BOOL jsonOutput;
-@property(nonatomic) NSNumber *certIndex;
+@property(nonatomic) int certIndex;
 @property(nonatomic, copy) NSArray<NSString *> *outputKeyList;
 @property(nonatomic) NSDictionary<NSString *, SNTAttributeBlock> *propertyMap;
 + (NSArray *)fileInfoKeys;
@@ -73,7 +73,7 @@ typedef id (^SNTAttributeBlock)(SNTCommandFileInfo *, SNTFileInfo *);
 
 - (void)testParseArgumentsCertIndex {
   NSArray *filePaths = [self.cfi parseArguments:@[ @"--cert-index", @"1", @"/usr/bin/yes" ]];
-  XCTAssertEqualObjects(self.cfi.certIndex, @(1));
+  XCTAssertEqual(self.cfi.certIndex, 1);
   XCTAssertTrue([filePaths containsObject:@"/usr/bin/yes"]);
 }
 

--- a/Tests/LogicTests/SNTRuleTableTest.m
+++ b/Tests/LogicTests/SNTRuleTableTest.m
@@ -17,6 +17,9 @@
 #import "SNTRule.h"
 #import "SNTRuleTable.h"
 
+#import <MOLCertificate/MOLCertificate.h>
+#import <MOLCodesignChecker/MOLCodesignChecker.h>
+
 @interface SNTRuleTable (Testing)
 @property NSString *santadCertSHA;
 @property NSString *launchdCertSHA;
@@ -35,6 +38,8 @@
 
   self.dbq = [[FMDatabaseQueue alloc] init];
   self.sut = [[SNTRuleTable alloc] initWithDatabaseQueue:self.dbq];
+  // xctest is unsigned in Xcode 10.1.
+  self.sut.santadCertSHA = [[MOLCodesignChecker alloc] initWithPID:1].leafCertificate.SHA256;
 }
 
 - (SNTRule *)_exampleBinaryRule {


### PR DESCRIPTION
* remove vnode_pid_map: It is only used for logging execs. Creating a new message will get the executing PID and PPID.
* fix logic tests under Xcode 10.1