### PR TITLE
resurrect action=BUNDLE logs

### DIFF
--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -250,7 +250,7 @@
 
 - (void)logBundleHashingEvents:(NSArray<SNTStoredEvent *> *)events {
   for (SNTStoredEvent *event in events) {
-    NSString *format = @"action=DISKDISAPPEAR|mount=%@|volume=%@|bsdname=%@";
+    NSString *format = @"action=BUNDLE|sha256=%@|bundlehash=%@|bundlename=%@|bundleid=%@|bundlepath=%@|path=%@";
     NSString *outLog = [NSMutableString stringWithFormat:format,
                            event.fileSHA256,
                            event.fileBundleHash,


### PR DESCRIPTION
They were lost in the refactoring of the logging utility 4a2cf9d722a4e2d88f6b0b560ddee44706ea4442.