### PR TITLE
santad/santactl: Remove transitive whitelisting preference.

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -249,15 +249,6 @@
 ///
 @property BOOL enableBundles;
 
-#pragma mark Transitive Whitelisting Settings
-
-///
-///  If YES, binaries marked with SNTRuleStateWhitelistCompiler rules are allowed to transitively
-///  whitelist any executables that they produce.  If NO, SNTRuleStateWhitelistCompiler rules are
-///  interpreted as if they were simply SNTRuleStateWhitelist rules.  Defaults to NO.
-///
-@property BOOL enableTransitiveWhitelisting;
-
 #pragma mark Server Auth Settings
 
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -77,7 +77,6 @@ static NSString *const kEnableMachineIDDecoration = @"EnableMachineIDDecoration"
 
 // The keys managed by a sync server or mobileconfig.
 static NSString *const kClientModeKey = @"ClientMode";
-static NSString *const kEnableTransitiveWhitelistingKey = @"EnableTransitiveWhitelisting";
 static NSString *const kWhitelistRegexKey = @"WhitelistRegex";
 static NSString *const kBlacklistRegexKey = @"BlacklistRegex";
 
@@ -97,7 +96,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
     Class array = [NSArray class];
     _syncServerKeyTypes = @{
       kClientModeKey : number,
-      kEnableTransitiveWhitelistingKey : number,
       kWhitelistRegexKey : re,
       kBlacklistRegexKey : re,
       kFullSyncLastSuccess : date,
@@ -106,7 +104,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
     };
     _forcedConfigKeyTypes = @{
       kClientModeKey : number,
-      kEnableTransitiveWhitelistingKey : number,
       kFileChangesRegexKey : re,
       kFileChangesPrefixFiltersKey : array,
       kWhitelistRegexKey : re,
@@ -297,10 +294,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self configStateSet];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingEnableTransitiveWhitelisting {
-  return [self syncAndConfigStateSet];
-}
-
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {
@@ -323,18 +316,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   } else {
     LOGW(@"Ignoring request to change client mode to %ld", newMode);
   }
-}
-
-- (BOOL)enableTransitiveWhitelisting {
-  NSNumber *n = self.syncState[kEnableTransitiveWhitelistingKey];
-  if (n) {
-    return [n boolValue];
-  }
-  return [self.configState[kEnableTransitiveWhitelistingKey] boolValue];
-}
-
-- (void)setEnableTransitiveWhitelisting:(BOOL)enabled {
-  [self updateSyncStateForKey:kEnableTransitiveWhitelistingKey value:@(enabled)];
 }
 
 - (NSRegularExpression *)whitelistPathRegex {

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -47,7 +47,6 @@
 - (void)setWhitelistPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
 - (void)setBlacklistPathRegex:(NSString *)pattern reply:(void (^)(void))reply;
 - (void)setEnableBundles:(BOOL)bundlesEnabled reply:(void (^)(void))reply;
-- (void)setEnableTransitiveWhitelisting:(BOOL)enabled reply:(void (^)(void))reply;
 
 ///
 ///  Syncd Ops

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -72,7 +72,6 @@
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))reply;
 - (void)syncCleanRequired:(void (^)(BOOL))reply;
 - (void)enableBundles:(void (^)(BOOL))reply;
-- (void)enableTransitiveWhitelisting:(void (^)(BOOL))reply;
 
 ///
 ///  GUI Ops

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -153,17 +153,12 @@ REGISTER_COMMAND_NAME(@"status")
     }];
   }
 
-  __block BOOL transitiveWhitelistingEnabled = NO;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] enableTransitiveWhitelisting:^(BOOL response) {
-    transitiveWhitelistingEnabled = response;
-    dispatch_group_leave(group);
-  }];
-
   // Wait a maximum of 5s for stats collected from daemon to arrive.
   if (dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5))) {
     fprintf(stderr, "Failed to retrieve some stats from daemon\n\n");
   }
+
+  BOOL transitiveWhitelistingEnabled = (compilerRuleCount > 0);
 
   // Format dates
   NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -94,16 +94,6 @@
     dispatch_group_leave(group);
   }];
 
-  dispatch_group_enter(group);
-  NSNumber *enableTransitiveWhitelisting = resp[kEnableTransitiveWhitelisting];
-  if (!enableTransitiveWhitelisting) {
-    enableTransitiveWhitelisting = resp[kEnableTransitiveWhitelisting_OLD];
-  }
-  BOOL enabled = [enableTransitiveWhitelisting boolValue];
-  [[self.daemonConn remoteObjectProxy] setEnableTransitiveWhitelisting:enabled reply:^{
-    dispatch_group_leave(group);
-  }];
-
   self.syncState.eventBatchSize = [resp[kBatchSize] unsignedIntegerValue] ?: kDefaultEventBatchSize;
   self.syncState.FCMToken = resp[kFCMToken];
 

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -233,15 +233,6 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
-- (void)enableTransitiveWhitelisting:(void (^)(BOOL))reply {
-  reply([SNTConfigurator configurator].enableTransitiveWhitelisting);
-}
-
-- (void)setEnableTransitiveWhitelisting:(BOOL)enabled reply:(void (^)(void))reply {
-  [[SNTConfigurator configurator] setEnableTransitiveWhitelisting:enabled];
-  reply();
-}
-
 #pragma mark GUI Ops
 
 - (void)setNotificationListener:(NSXPCListenerEndpoint *)listener {

--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -166,7 +166,6 @@
 - (void)testBinaryWhitelistCompilerRule {
   OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
   OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
-  OCMStub([self.mockConfigurator enableTransitiveWhitelisting]).andReturn(YES);
 
   SNTRule *rule = [[SNTRule alloc] init];
   rule.state = SNTRuleStateWhitelistCompiler;
@@ -179,26 +178,9 @@
                                             forVnodeID:[self getVnodeId]]);
 }
 
-- (void)testBinaryWhitelistCompilerRuleDisabled {
-  OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
-  OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
-  OCMStub([self.mockConfigurator enableTransitiveWhitelisting]).andReturn(NO);
-
-  SNTRule *rule = [[SNTRule alloc] init];
-  rule.state = SNTRuleStateWhitelistCompiler;
-  rule.type = SNTRuleTypeBinary;
-  OCMStub([self.mockRuleDatabase ruleForBinarySHA256:@"a" certificateSHA256:nil]).andReturn(rule);
-
-  [self.sut validateBinaryWithMessage:[self getMessage]];
-
-  OCMVerify([self.mockDriverManager postToKernelAction:ACTION_RESPOND_ALLOW
-                                            forVnodeID:[self getVnodeId]]);
-}
-
 - (void)testBinaryWhitelistTransitiveRule {
   OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
   OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
-  OCMStub([self.mockConfigurator enableTransitiveWhitelisting]).andReturn(YES);
 
   SNTRule *rule = [[SNTRule alloc] init];
   rule.state = SNTRuleStateWhitelistTransitive;
@@ -208,23 +190,6 @@
   [self.sut validateBinaryWithMessage:[self getMessage]];
 
   OCMVerify([self.mockDriverManager postToKernelAction:ACTION_RESPOND_ALLOW
-                                            forVnodeID:[self getVnodeId]]);
-}
-
-- (void)testBinaryWhitelistTransitiveRuleDisabled {
-  OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
-  OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
-  OCMStub([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
-  OCMStub([self.mockConfigurator enableTransitiveWhitelisting]).andReturn(NO);
-
-  SNTRule *rule = [[SNTRule alloc] init];
-  rule.state = SNTRuleStateWhitelistTransitive;
-  rule.type = SNTRuleTypeBinary;
-  OCMStub([self.mockRuleDatabase ruleForBinarySHA256:@"a" certificateSHA256:nil]).andReturn(rule);
-
-  [self.sut validateBinaryWithMessage:[self getMessage]];
-
-  OCMVerify([self.mockDriverManager postToKernelAction:ACTION_RESPOND_DENY
                                             forVnodeID:[self getVnodeId]]);
 }
 

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -61,25 +61,11 @@
             cd.decision = SNTEventStateBlockBinary;
             return cd;
           case SNTRuleStateWhitelistCompiler:
-            // If transitive whitelisting is enabled, then SNTRuleStateWhiteListCompiler rules
-            // become SNTEventStateAllowCompiler decisions.  Otherwise we treat the rule as if
-            // it were SNTRuleStateWhitelist.
-            if ([[SNTConfigurator configurator] enableTransitiveWhitelisting]) {
-              cd.decision = SNTEventStateAllowCompiler;
-            } else {
-              cd.decision = SNTEventStateAllow;
-            }
+            cd.decision = SNTEventStateAllowCompiler;
             return cd;
           case SNTRuleStateWhitelistTransitive:
-            // If transitive whitelisting is enabled, then SNTRuleStateWhitelistTransitive
-            // rules become SNTEventStateAllowTransitive decisions.  Otherwise, we treat the
-            // rule as if it were SNTRuleStateUnknown.
-            if ([[SNTConfigurator configurator] enableTransitiveWhitelisting]) {
-              cd.decision = SNTEventStateAllowTransitive;
-              return cd;
-            } else {
-              rule.state = SNTRuleStateUnknown;
-            }
+            cd.decision = SNTEventStateAllowTransitive;
+            return cd;
           default: break;
         }
         break;


### PR DESCRIPTION
Infer whether transitive whitelisting should be enabled based on whether there are any compiler rules installed. If a sync server sent a compiler rule (or one was manually added because there is no sync server) it follows that transitive whitelisting should be enabled.