### PR TITLE
tests: Create a SantaPrefixTree userland lib

### DIFF
--- a/Source/santa_driver/BUILD
+++ b/Source/santa_driver/BUILD
@@ -52,16 +52,23 @@ santa_unit_test(
     deps = ["//Source/common:SNTKernelCommon"],
 )
 
+cc_library(
+    name = "SantaPrefixTree_userland_lib",
+    srcs = ["SantaPrefixTree.cc"],
+    hdrs = ["SantaPrefixTree.h"],
+    copts = ["-std=c++1z"],
+    visibility = ["//visibility:public"],
+)
+
 santa_unit_test(
     name = "SantaPrefixTreeTest",
-    srcs = [
-        "SantaPrefixTree.cc",
-        "SantaPrefixTree.h",
-        "SantaPrefixTreeTest.mm",
-    ],
+    srcs = ["SantaPrefixTreeTest.mm"],
     copts = ["-std=c++1z"],
     minimum_os_version = "10.12",
-    deps = ["//Source/common:SNTKernelCommon"],
+    deps = [
+        ":SantaPrefixTree_userland_lib",
+        "//Source/common:SNTKernelCommon"
+    ],
 )
 
 # Full santa-driver.kext containing all Santa components


### PR DESCRIPTION
* Allows a userland version of SantaPrefixTree to be used by future rules.