### PR TITLE
Use updated deps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
+build --host_force_python=PY2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+os: osx
+osx_image: xcode10.2
 language: objective-c
 sudo: false
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "46611296946be1eb0fe2e7e46b8b26b4662606b3",
+    tag = "0.17.2",
 )
 
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
@@ -19,19 +19,19 @@ apple_rules_dependencies()
 git_repository(
     name = "MOLAuthenticatingURLSession",
     remote = "https://github.com/google/macops-molauthenticatingurlsession.git",
-    tag = "v2.5",
+    tag = "v2.6",
 )
 
 git_repository(
     name = "MOLCertificate",
     remote = "https://github.com/google/macops-molcertificate.git",
-    tag = "v2.0",
+    tag = "v2.1",
 )
 
 git_repository(
     name = "MOLCodesignChecker",
     remote = "https://github.com/google/macops-molcodesignchecker.git",
-    tag = "v2.1",
+    tag = "v2.2",
 )
 
 git_repository(


### PR DESCRIPTION
* bazel 0.27.0 defaults to python 3 - added a flag to .bazelrc to force python 2