### PR TITLE
santad: Add /usr/lib/dyld to critical system binaries

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -41,7 +41,8 @@ static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
 
 - (NSArray *)criticalSystemBinaryPaths {
   return @[
-    @"/usr/libexec/trustd", @"/usr/sbin/securityd", @"/usr/libexec/xpcproxy", @"/usr/sbin/ocspd"
+    @"/usr/libexec/trustd", @"/usr/sbin/securityd", @"/usr/libexec/xpcproxy",
+    @"/usr/sbin/ocspd", @"/usr/lib/dyld"
   ];
 }
 


### PR DESCRIPTION
dyld is also authorized by santad and a bad cache eviction plus trustd/ocspd not running can result in deadlock.

Fixes #375, probably.