### PR TITLE
simplify santabundleservice xpc connection protocol

### DIFF
--- a/Conf/com.google.santa.bundleservice.plist
+++ b/Conf/com.google.santa.bundleservice.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.google.santa.bundleservice</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/Santa.app/Contents/MacOS/santabundleservice</string>
+		<string>--syslog</string>
+	</array>
+	<key>MachServices</key>
+	<dict>
+		<key>com.google.santa.bundleservice</key>
+		<true/>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Interactive</string>
+	<key>ThrottleInterval</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/Santa.xcodeproj/project.pbxproj
+++ b/Santa.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		C7CDA6FC233E73D80013622B /* SNTFileInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = C7658AD02322B84F00F36578 /* SNTFileInfo.m */; };
 		C7CDA6FD233E73E40013622B /* SNTStoredEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = C7658ADC2322B84F00F36578 /* SNTStoredEvent.m */; };
 		C7CDA6FE233E73ED0013622B /* SNTXPCNotifierInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = C7658ACF2322B84F00F36578 /* SNTXPCNotifierInterface.m */; };
+		C7CDA6FF233E80160013622B /* SNTLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = C7658AD82322B84F00F36578 /* SNTLogging.m */; };
+		C7CDA700233EB21A0013622B /* SNTXPCBundleServiceInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = C7658ACC2322B84F00F36578 /* SNTXPCBundleServiceInterface.m */; };
 		C7D35DE42322C99B000C5EB4 /* SantaDecisionManager.cc in Sources */ = {isa = PBXBuildFile; fileRef = C7658B002322B84F00F36578 /* SantaDecisionManager.cc */; };
 		C7D35DE52322C99E000C5EB4 /* SantaDriver.cc in Sources */ = {isa = PBXBuildFile; fileRef = C7658AFF2322B84F00F36578 /* SantaDriver.cc */; };
 		C7D35DE62322C9A1000C5EB4 /* SantaDriverClient.cc in Sources */ = {isa = PBXBuildFile; fileRef = C7658AFA2322B84F00F36578 /* SantaDriverClient.cc */; };
@@ -1148,6 +1150,7 @@
 				C7658B512322C19D00F36578 /* NSData+Zlib.m in Sources */,
 				C7658B4B2322C18900F36578 /* SNTCommandFileInfo.m in Sources */,
 				C7658B572322C1AB00F36578 /* SNTCommandSyncPreflight.m in Sources */,
+				C7CDA700233EB21A0013622B /* SNTXPCBundleServiceInterface.m in Sources */,
 				C7658B642322C2F300F36578 /* SNTXPCUnprivilegedControlInterface.m in Sources */,
 				C7658B562322C1A900F36578 /* SNTCommandSyncPostflight.m in Sources */,
 				C7658B502322C19900F36578 /* SNTCommandVersion.m in Sources */,
@@ -1246,6 +1249,7 @@
 			files = (
 				C7CDA6FB233E73D20013622B /* SNTXPCBundleServiceInterface.m in Sources */,
 				C7CDA6FC233E73D80013622B /* SNTFileInfo.m in Sources */,
+				C7CDA6FF233E80160013622B /* SNTLogging.m in Sources */,
 				C7CDA6FD233E73E40013622B /* SNTStoredEvent.m in Sources */,
 				C7CDA6FE233E73ED0013622B /* SNTXPCNotifierInterface.m in Sources */,
 				C7F5C1AE233E72CC00A3F7FD /* main.m in Sources */,
@@ -1580,7 +1584,6 @@
 				DEVELOPMENT_TEAM = 998Z9C32TC;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/santabundleservice/Resources/santabundleservice-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.santa.bundleservice;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1595,7 +1598,6 @@
 				DEVELOPMENT_TEAM = 998Z9C32TC;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/santabundleservice/Resources/santabundleservice-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.santa.bundleservice;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -117,7 +117,10 @@ objc_library(
     name = "SNTXPCBundleServiceInterface",
     srcs = ["SNTXPCBundleServiceInterface.m"],
     hdrs = ["SNTXPCBundleServiceInterface.h"],
-    deps = [":SNTStoredEvent"],
+    deps = [
+        ":SNTStoredEvent"
+        "@MOLXPCConnection",
+    ],
 )
 
 objc_library(

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -118,7 +118,7 @@ objc_library(
     srcs = ["SNTXPCBundleServiceInterface.m"],
     hdrs = ["SNTXPCBundleServiceInterface.h"],
     deps = [
-        ":SNTStoredEvent"
+        ":SNTStoredEvent",
         "@MOLXPCConnection",
     ],
 )

--- a/Source/common/SNTXPCBundleServiceInterface.h
+++ b/Source/common/SNTXPCBundleServiceInterface.h
@@ -42,7 +42,7 @@ typedef void (^SNTBundleHashBlock)(NSString *, NSArray<SNTStoredEvent *> *, NSNu
 - (void)hashBundleBinariesForEvent:(SNTStoredEvent *)event reply:(SNTBundleHashBlock)reply;
 
 ///
-///  santabundleservice is launched on demand by launchd, call spindown to let santabundleservice you are done with it.
+///  santabundleservice is launched on demand by launchd, call spindown to let santabundleservice know you are done with it.
 ///
 - (void)spindown;
 

--- a/Source/common/SNTXPCBundleServiceInterface.h
+++ b/Source/common/SNTXPCBundleServiceInterface.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <MOLXPCConnection/MOLXPCConnection.h>
+
 @class SNTStoredEvent;
 
 ///  A block that takes the calculated bundle hash, associated events and hashing time in ms.
@@ -25,7 +27,7 @@ typedef void (^SNTBundleHashBlock)(NSString *, NSArray<SNTStoredEvent *> *, NSNu
 ///
 ///  @param listener The listener to connect back to the SantaGUI.
 ///
-- (void)setBundleNotificationListener:(NSXPCListenerEndpoint *)listener;
+- (void)setNotificationListener:(NSXPCListenerEndpoint *)listener;
 
 ///
 ///  Hash a bundle for an event. The SNTBundleHashBlock will be called with nil parameters if a
@@ -38,6 +40,11 @@ typedef void (^SNTBundleHashBlock)(NSString *, NSArray<SNTStoredEvent *> *, NSNu
 ///  @note If there is a current NSProgress when called this method will report back its progress.
 ///
 - (void)hashBundleBinariesForEvent:(SNTStoredEvent *)event reply:(SNTBundleHashBlock)reply;
+
+///
+///  santabundleservice is launched on demand by launchd, call spindown to let santabundleservice you are done with it.
+///
+- (void)spindown;
 
 @end
 
@@ -53,5 +60,11 @@ typedef void (^SNTBundleHashBlock)(NSString *, NSArray<SNTStoredEvent *> *, NSNu
 ///  Returns the MachService ID for this service.
 ///
 + (NSString *)serviceID;
+
+///
+///  Retrieve a pre-configured MOLXPCConnection for communicating with santabundleservice.
+///  Connections just needs any handlers set and then can be resumed and used.
+///
++ (MOLXPCConnection *)configuredConnection;
 
 @end

--- a/Source/common/SNTXPCBundleServiceInterface.m
+++ b/Source/common/SNTXPCBundleServiceInterface.m
@@ -33,4 +33,11 @@
   return @"com.google.santa.bundleservice";
 }
 
++ (MOLXPCConnection *)configuredConnection {
+  MOLXPCConnection *c = [[MOLXPCConnection alloc] initClientWithName:[self serviceID]
+                                                          privileged:YES];
+  c.remoteInterface = [self bundleServiceInterface];
+  return c;
+}
+
 @end

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -24,16 +24,10 @@
 - (void)postBlockNotification:(SNTStoredEvent *)event withCustomMessage:(NSString *)message;
 - (void)postClientModeNotification:(SNTClientMode)clientmode;
 - (void)postRuleSyncNotificationWithCustomMessage:(NSString *)message;
-@end
-
-/// Protocol implemented by SantaGUI and utilized by santabs
-@protocol SNTBundleNotifierXPC
 - (void)updateCountsForEvent:(SNTStoredEvent *)event
                  binaryCount:(uint64_t)binaryCount
                    fileCount:(uint64_t)fileCount
                  hashedCount:(uint64_t)hashedCount;
-
-- (void)setBundleServiceListener:(NSXPCListenerEndpoint *)listener;
 @end
 
 @interface SNTXPCNotifierInterface : NSObject
@@ -43,11 +37,5 @@
 ///  Ensures any methods that accept custom classes as arguments are set-up before returning
 ///
 + (NSXPCInterface *)notifierInterface;
-
-///
-///  @return an initialized NSXPCInterface for the SNTBundleNotifierXPC protocol.
-///  Ensures any methods that accept custom classes as arguments are set-up before returning
-///
-+ (NSXPCInterface *)bundleNotifierInterface;
 
 @end

--- a/Source/common/SNTXPCNotifierInterface.m
+++ b/Source/common/SNTXPCNotifierInterface.m
@@ -20,8 +20,4 @@
   return [NSXPCInterface interfaceWithProtocol:@protocol(SNTNotifierXPC)];
 }
 
-+ (NSXPCInterface *)bundleNotifierInterface {
-  return [NSXPCInterface interfaceWithProtocol:@protocol(SNTBundleNotifierXPC)];
-}
-
 @end

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -17,7 +17,6 @@
 
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTKernelCommon.h"
-#import "Source/common/SNTXPCBundleServiceInterface.h"
 
 @class SNTRule;
 @class SNTStoredEvent;
@@ -78,7 +77,6 @@
 ///  GUI Ops
 ///
 - (void)setNotificationListener:(NSXPCListenerEndpoint *)listener;
-- (void)setBundleNotificationListener:(NSXPCListenerEndpoint *)listener;
 
 ///
 ///  Syncd Ops
@@ -88,7 +86,6 @@
 ///
 ///  Bundle Ops
 ///
-- (void)hashBundleBinariesForEvent:(SNTStoredEvent *)event reply:(SNTBundleHashBlock)reply;
 - (void)syncBundleEvent:(SNTStoredEvent *)event relatedEvents:(NSArray<SNTStoredEvent *> *)events;
 
 @end

--- a/Source/common/SNTXPCUnprivilegedControlInterface.m
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.m
@@ -23,11 +23,6 @@
 
 + (void)initializeControlInterface:(NSXPCInterface *)r {
   [r setClasses:[NSSet setWithObjects:[NSArray class], [SNTStoredEvent class], nil]
-        forSelector:@selector(hashBundleBinariesForEvent:reply:)
-      argumentIndex:1
-            ofReply:YES];
-
-  [r setClasses:[NSSet setWithObjects:[NSArray class], [SNTStoredEvent class], nil]
         forSelector:@selector(syncBundleEvent:relatedEvents:)
       argumentIndex:1
             ofReply:NO];

--- a/Source/santa/SNTNotificationManager.h
+++ b/Source/santa/SNTNotificationManager.h
@@ -20,7 +20,8 @@
 ///
 ///  Keeps track of pending notifications and ensures only one is presented to the user at a time.
 ///
-@interface SNTNotificationManager : NSObject<SNTMessageWindowControllerDelegate,
-                                             SNTNotifierXPC, SNTBundleNotifierXPC>
+@interface SNTNotificationManager : NSObject<SNTMessageWindowControllerDelegate, SNTNotifierXPC>
+
+@property NSXPCListenerEndpoint *notificationListener;
 
 @end

--- a/Source/santabundleservice/main.m
+++ b/Source/santabundleservice/main.m
@@ -13,15 +13,24 @@
 ///    limitations under the License.
 
 #import <Foundation/Foundation.h>
+
 #import <MOLXPCConnection/MOLXPCConnection.h>
 
-#import "Source/santabundleservice/SNTBundleService.h"
+#import "Source/common/SNTLogging.h"
 #import "Source/common/SNTXPCBundleServiceInterface.h"
+#import "Source/santabundleservice/SNTBundleService.h"
+
 
 int main(int argc, const char *argv[]) {
-  MOLXPCConnection *c =
-      [[MOLXPCConnection alloc] initServerWithListener:[NSXPCListener serviceListener]];
-  c.privilegedInterface = c.unprivilegedInterface = [SNTXPCBundleServiceInterface bundleServiceInterface];
-  c.exportedObject = [[SNTBundleService alloc] init];
-  [c resume];
+  @autoreleasepool {
+    NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
+    LOGI(@"Started, version %@", infoDict[@"CFBundleVersion"]);
+    MOLXPCConnection *c =
+        [[MOLXPCConnection alloc] initServerWithName:[SNTXPCBundleServiceInterface serviceID]];
+    c.privilegedInterface = c.unprivilegedInterface =
+        [SNTXPCBundleServiceInterface bundleServiceInterface];
+    c.exportedObject = [[SNTBundleService alloc] init];
+    [c resume];
+    [[NSRunLoop mainRunLoop] run];
+  }
 }

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -253,15 +253,6 @@ double watchdogRAMPeak = 0;
   self.notQueue.notifierConnection = c;
 }
 
-- (void)setBundleNotificationListener:(NSXPCListenerEndpoint *)listener {
-  NSString *bundleServiceID = [SNTXPCBundleServiceInterface serviceID];
-  MOLXPCConnection *bs = [[MOLXPCConnection alloc] initClientWithServiceName:bundleServiceID];
-  bs.remoteInterface = [SNTXPCBundleServiceInterface bundleServiceInterface];
-  [bs resume];
-  [[bs remoteObjectProxy] setBundleNotificationListener:listener];
-  [bs invalidate];
-}
-
 #pragma mark syncd Ops
 
 - (void)setSyncdListener:(NSXPCListenerEndpoint *)listener {
@@ -292,29 +283,6 @@ double watchdogRAMPeak = 0;
   [[self.notQueue.notifierConnection remoteObjectProxy]
       postRuleSyncNotificationWithCustomMessage:message];
   reply();
-}
-
-#pragma mark Bundle ops
-
-///
-///  This method is only used for santactl's bundleinfo command. For blocked executions, SantaGUI
-///  calls on santabs directly.
-///
-///  Hash a bundle for an event. The SNTBundleHashBlock will be called with nil parameters if a
-///  failure or cancellation occurs.
-///
-///  @param event The event that includes the fileBundlePath to be hashed.
-///  @param reply A SNTBundleHashBlock to be executed upon completion or cancellation.
-///
-///  @note If there is a current NSProgress when called this method will report back it's progress.
-///
-- (void)hashBundleBinariesForEvent:(SNTStoredEvent *)event
-                             reply:(SNTBundleHashBlock)reply {
-  MOLXPCConnection *bs =
-      [[MOLXPCConnection alloc] initClientWithServiceName:[SNTXPCBundleServiceInterface serviceID]];
-  bs.remoteInterface = [SNTXPCBundleServiceInterface bundleServiceInterface];
-  [bs resume];
-  [[bs remoteObjectProxy] hashBundleBinariesForEvent:event reply:reply];
 }
 
 ///


### PR DESCRIPTION
* santabundleservice and Santa.app now talk directly without any proxying by santad.
* santabundleservice now runs on-demand.