### PR TITLE
santa-driver: Workaround 10.15 SDK Dispatch() issue

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -98,6 +98,7 @@ cc_library(
     hdrs = ["SNTPrefixTree.h"],
     copts = [
         "-std=c++11",
+        "-mkernel",
         "-I__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/Headers",
     ],
     defines = ["KERNEL"],

--- a/Source/santa_driver/main.cc
+++ b/Source/santa_driver/main.cc
@@ -16,3 +16,14 @@ extern "C" {
 
   __private_extern__ int _kext_apple_cc = __APPLE_CC__ ;
 }
+
+#include <IOKit/IOService.h>
+#include <IOKit/IOUserClient.h>
+
+// The macOS 10.15 SDK added these Dispatch methods but they aren't
+// available on older macOS versions and so prevent kext linking.
+// Defining them here as hidden weak no-op's fixes linking and seems to work.
+kern_return_t __attribute__((visibility("hidden"))) __attribute__((weak)) OSMetaClassBase::Dispatch(const IORPC rpc) { return KERN_SUCCESS; }
+kern_return_t __attribute__((visibility("hidden"))) __attribute__((weak)) OSObject::Dispatch(const IORPC rpc) { return KERN_SUCCESS; }
+kern_return_t __attribute__((visibility("hidden"))) __attribute__((weak)) IOService::Dispatch(const IORPC rpc) { return KERN_SUCCESS; }
+kern_return_t __attribute__((visibility("hidden"))) __attribute__((weak)) IOUserClient::Dispatch(const IORPC rpc) { return KERN_SUCCESS; }


### PR DESCRIPTION
Missed this pulling into master before.