### PR TITLE
Project: update Apple rules to 0.19.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "97951dce38d",
+    tag = "0.19.0",
 )
 
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")


### PR DESCRIPTION
This version is compatible with bazel 2.0, which is what Travis is using.