### PR TITLE
santad: Move signature fetching into SNTPolicyProcessor

### DIFF
--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -17,6 +17,8 @@
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTKernelCommon.h"
 
+@class MOLCertificate;
+
 ///
 ///  Store information about executions from decision making for later logging.
 ///
@@ -26,8 +28,11 @@
 @property SNTEventState decision;
 @property NSString *decisionExtra;
 @property NSString *sha256;
+
 @property NSString *certSHA256;
 @property NSString *certCommonName;
+@property NSArray<MOLCertificate *> *certChain;
+
 @property NSString *quarantineURL;
 
 @property NSString *customMsg;

--- a/Source/santad/EventProviders/SNTEndpointSecurityManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManager.mm
@@ -231,9 +231,10 @@
       NSMutableArray *args = [NSMutableArray arrayWithCapacity:argCount];
       for (int i = 0; i < argCount; ++i) {
         es_string_token_t arg = es_exec_arg(&(m->event.exec), i);
-        [args addObject:[[NSString alloc] initWithBytes:arg.data
-                                                 length:arg.length
-                                               encoding:NSUTF8StringEncoding]];
+        NSString *argStr = [[NSString alloc] initWithBytes:arg.data
+                                                    length:arg.length
+                                                  encoding:NSUTF8StringEncoding];
+        if (argStr.length) [args addObject:argStr];
       }
       sm.args_array = (void *)CFBridgingRetain(args);
       callback = self.logCallback;

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -153,8 +153,7 @@ double watchdogRAMPeak = 0;
           certificateSHA256:(NSString *)certificateSHA256
                       reply:(void (^)(SNTEventState))reply {
   reply([self.policyProcessor decisionForFilePath:filePath
-                                       fileSHA256:fileSHA256
-                                certificateSHA256:certificateSHA256].decision);
+                                       fileSHA256:fileSHA256].decision);
 }
 
 #pragma mark Config Ops

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -115,33 +115,22 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
     [self.eventProvider postAction:ACTION_RESPOND_ACK forMessage:message];
   }
 
-  // If the binary is a critical system binary, don't check its signature.
-  // The binary was validated by santad at startup.
-  SNTCachedDecision *cd = self.ruleTable.criticalSystemBinaries[binInfo.SHA256];
-  MOLCodesignChecker *csInfo; // Needed further down in this scope.
-  if (!cd) {
-    // Get codesigning info about the file but only if it's a Mach-O.
-    if (binInfo.isMachO) {
-      NSError *csError;
-      csInfo = [[MOLCodesignChecker alloc] initWithBinaryPath:binInfo.path
-                                               fileDescriptor:binInfo.fileHandle.fileDescriptor
-                                                        error:&csError];
-      // Ignore codesigning if there are any errors with the signature.
-      if (csError) csInfo = nil;
-    }
-
-    // Actually make the decision (and refresh rule access timestamp).
-    cd = [self.policyProcessor decisionForFileInfo:binInfo
-                                        fileSHA256:nil
-                                 certificateSHA256:csInfo.leafCertificate.SHA256];
-    cd.certCommonName = csInfo.leafCertificate.commonName;
-  }
-
+  SNTCachedDecision *cd = [self.policyProcessor decisionForFileInfo:binInfo];
   cd.vnodeId = message.vnode_id;
 
   // Formulate an initial action from the decision.
   santa_action_t action =
       (SNTEventStateAllow & cd.decision) ? ACTION_RESPOND_ALLOW : ACTION_RESPOND_DENY;
+
+  // Save decision details for logging the execution later.  For transitive rules, we also use
+  // the shasum stored in the decision details to update the rule's timestamp whenever an
+  // ACTION_NOTIFY_EXEC message related to the transitive rule is received.
+  NSString *ttyPath;
+  if (action == ACTION_RESPOND_ALLOW) {
+    [_eventLog cacheDecision:cd];
+  } else {
+    ttyPath = [self ttyPathForPID:message.ppid];
+  }
 
   // Upgrade the action to ACTION_RESPOND_ALLOW_COMPILER when appropriate, because we want the
   // kernel to track this information in its decision cache.
@@ -149,32 +138,18 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
     action = ACTION_RESPOND_ALLOW_COMPILER;
   }
 
-  // Save decision details for logging the execution later.  For transitive rules, we also use
-  // the shasum stored in the decision details to update the rule's timestamp whenever an
-  // ACTION_NOTIFY_EXEC message related to the transitive rule is received.
-  NSString *ttyPath;
-  if (action == ACTION_RESPOND_ALLOW || action == ACTION_RESPOND_ALLOW_COMPILER) {
-    [_eventLog cacheDecision:cd];
-  } else {
-    ttyPath = [self ttyPathForPID:message.ppid];
-  }
-
   // Send the decision to the kernel.
   [self.eventProvider postAction:action forMessage:message];
 
   // Log to database if necessary.
-  if (cd.decision != SNTEventStateAllowBinary &&
-      cd.decision != SNTEventStateAllowCompiler &&
-      cd.decision != SNTEventStateAllowTransitive &&
-      cd.decision != SNTEventStateAllowCertificate &&
-      cd.decision != SNTEventStateAllowScope) {
+  if (!(cd.decision & SNTEventStateAllow)) {
     SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
     se.occurrenceDate = [[NSDate alloc] init];
     se.fileSHA256 = cd.sha256;
     se.filePath = binInfo.path;
     se.decision = cd.decision;
 
-    se.signingChain = csInfo.certificates;
+    se.signingChain = cd.certChain;
     se.pid = @(message.pid);
     se.ppid = @(message.ppid);
     se.parentName = @(message.pname);

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -142,7 +142,11 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
   [self.eventProvider postAction:action forMessage:message];
 
   // Log to database if necessary.
-  if (!(cd.decision & SNTEventStateAllow)) {
+  if (cd.decision != SNTEventStateAllowBinary &&
+      cd.decision != SNTEventStateAllowCompiler &&
+      cd.decision != SNTEventStateAllowTransitive &&
+      cd.decision != SNTEventStateAllowCertificate &&
+      cd.decision != SNTEventStateAllowScope) {
     SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
     se.occurrenceDate = [[NSDate alloc] init];
     se.fileSHA256 = cd.sha256;

--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -48,7 +48,6 @@
   OCMStub([self.mockCodesignChecker alloc]).andReturn(self.mockCodesignChecker);
 
   OCMStub([self.mockCodesignChecker initWithBinaryPath:OCMOCK_ANY
-                                        fileDescriptor:0
                                                  error:[OCMArg setTo:NULL]])
       .andReturn(self.mockCodesignChecker);
 
@@ -61,6 +60,8 @@
   OCMStub([self.mockFileInfo alloc]).andReturn(self.mockFileInfo);
   OCMStub([self.mockFileInfo initWithPath:OCMOCK_ANY
                                     error:[OCMArg setTo:nil]]).andReturn(self.mockFileInfo);
+  OCMStub([self.mockFileInfo codesignCheckerWithError:[OCMArg setTo:nil]])
+      .andReturn(self.mockCodesignChecker);
 
   self.mockRuleDatabase = OCMClassMock([SNTRuleTable class]);
   self.mockEventDatabase = OCMClassMock([SNTEventTable class]);

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -18,6 +18,7 @@
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTKernelCommon.h"
 
+@class MOLCodesignChecker;
 @class SNTCachedDecision;
 @class SNTFileInfo;
 @class SNTRuleTable;
@@ -38,15 +39,12 @@
 ///  @param fileInfo A SNTFileInfo object.
 ///  @param fileSHA256 The pre-calculated SHA256 hash for the file, can be nil. If nil the hash will
 ///                    be calculated by this method from the filePath.
-///  @param certificateSHA256 A SHA256 hash of the signing certificate, can be nil.
-///  @note If fileSHA256 and certificateSHA256 are both passed in, the most specific rule will be
-///        returned. Binary rules take precedence over cert rules.
-///  @note This method can also be used to generate a SNTCachedDecision object without any
-///        artifacts on disk. Simply pass nil to fileInfo and pass in the desired SHA256s.
 ///
-- (nonnull SNTCachedDecision *)decisionForFileInfo:(nullable SNTFileInfo *)fileInfo
-                                        fileSHA256:(nullable NSString *)fileSHA256
-                                 certificateSHA256:(nullable NSString *)certificateSHA256;
+- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
+                                        fileSHA256:(nullable NSString *)fileSHA256;
+
+///  Convenience initializer with a nil hash.
+- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo;
 
 ///
 ///  A wrapper for decisionForFileInfo:fileSHA256:certificateSHA256:. This method is slower as it
@@ -54,8 +52,7 @@
 ///  SNTFileInfo is not SecureCoding compliant. If the SHA256 hash of the file has already been
 ///  calculated, use the fileSHA256 parameter to save a second calculation of the hash.
 ///
-- (nonnull SNTCachedDecision *)decisionForFilePath:(nullable NSString *)filePath
-                                        fileSHA256:(nullable NSString *)fileSHA256
-                                 certificateSHA256:(nullable NSString *)certificateSHA256;
+- (nonnull SNTCachedDecision *)decisionForFilePath:(nonnull NSString *)filePath
+                                        fileSHA256:(nullable NSString *)fileSHA256;
 
 @end

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -46,9 +46,7 @@
   // If the binary is a critical system binary, don't check its signature.
   // The binary was validated at startup when the rule table was initialized.
   SNTCachedDecision *systemCd = self.ruleTable.criticalSystemBinaries[cd.sha256];
-  if (systemCd) {
-    return systemCd;
-  }
+  if (systemCd) return systemCd;
 
   // Grab the code signature, if there's an error don't try to capture
   // any of the signature details.

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -14,6 +14,8 @@
 
 #import "Source/santad/SNTPolicyProcessor.h"
 
+#import <MOLCodesignChecker/MOLCodesignChecker.h>
+
 #include "Source/common/SNTLogging.h"
 
 #import "Source/common/SNTCachedDecision.h"
@@ -36,13 +38,27 @@
   return self;
 }
 
-- (SNTCachedDecision *)decisionForFileInfo:(SNTFileInfo *)fileInfo
-                                fileSHA256:(NSString *)fileSHA256
-                         certificateSHA256:(NSString *)certificateSHA256 {
-
+- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
+                                        fileSHA256:(nullable NSString *)fileSHA256 {
   SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
   cd.sha256 = fileSHA256 ?: fileInfo.SHA256;
-  cd.certSHA256 = certificateSHA256;
+
+  // If the binary is a critical system binary, don't check its signature.
+  // The binary was validated at startup when the rule table was initialized.
+  SNTCachedDecision *systemCd = self.ruleTable.criticalSystemBinaries[cd.sha256];
+  if (systemCd) {
+    return systemCd;
+  }
+
+  // Grab the code signature, if there's an error don't try to capture
+  // any of the signature details.
+  NSError *csInfoError;
+  MOLCodesignChecker *csInfo = [fileInfo codesignCheckerWithError:&csInfoError];
+  if (csInfoError) csInfo = nil;
+
+  cd.certSHA256 = csInfo.leafCertificate.SHA256;
+  cd.certCommonName = csInfo.leafCertificate.commonName;
+  cd.certChain = csInfo.certificates;
   cd.quarantineURL = fileInfo.quarantineDataURL;
 
   SNTRule *rule = [self.ruleTable ruleForBinarySHA256:cd.sha256
@@ -67,7 +83,7 @@
             if ([[SNTConfigurator configurator] enableTransitiveWhitelisting]) {
               cd.decision = SNTEventStateAllowCompiler;
             } else {
-              cd.decision = SNTEventStateAllow;
+              cd.decision = SNTEventStateAllowBinary;
             }
             return cd;
           case SNTRuleStateWhitelistTransitive:
@@ -90,6 +106,7 @@
             return cd;
           case SNTRuleStateSilentBlacklist:
             cd.silentBlock = YES;
+            // intentional fallthrough
           case SNTRuleStateBlacklist:
             cd.customMsg = rule.customMsg;
             cd.decision = SNTEventStateBlockCertificate;
@@ -129,18 +146,17 @@
   }
 }
 
-- (SNTCachedDecision *)decisionForFilePath:(NSString *)filePath
-                                fileSHA256:(NSString *)fileSHA256
-                         certificateSHA256:(NSString *)certificateSHA256 {
+- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo {
+  return [self decisionForFileInfo:fileInfo fileSHA256:nil];
+}
+
+- (nonnull SNTCachedDecision *)decisionForFilePath:(nonnull NSString *)filePath
+                                        fileSHA256:(nullable NSString *)fileSHA256 {
   SNTFileInfo *fileInfo;
-  if (filePath) {
-    NSError *error;
-    fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
-    if (!fileInfo) LOGW(@"Failed to read file %@: %@", filePath, error.localizedDescription);
-  }
-  return [self decisionForFileInfo:fileInfo
-                        fileSHA256:fileSHA256
-                 certificateSHA256:certificateSHA256];
+  NSError *error;
+  fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
+  if (!fileInfo) LOGW(@"Failed to read file %@: %@", filePath, error.localizedDescription);
+  return [self decisionForFileInfo:fileInfo fileSHA256:fileSHA256];
 }
 
 ///


### PR DESCRIPTION
This also removes an unnecessary hash and checks code signatures on non-MachO files (which is rare but possible).

It also fixes a rare crash in EndpointSecurityManager