### PR TITLE
Remove %bundle_id% and %bundle_ver% from EventDetailURL docs

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -52,8 +52,6 @@ This property contains a kind of format string to be turned into the URL to send
 | %file_sha%   | SHA-256 of the file that was blocked     |
 | %machine_id% | ID of the machine                        |
 | %username%   | The executing user                       |
-| %bundle_id%  | Bundle ID of the binary, if applicable   |
-| %bundle_ver% | Bundle version of the binary, if applicable |
 
 For example: `https://sync-server-hostname/%machine_id%/%file_sha%`
 


### PR DESCRIPTION
%bundle_id% and %bundle_ver% are not replaced any more, they were removed by https://github.com/google/santa/commit/6f417a17756ca794e3b7fc4ab6f0dccd431c1759#diff-3250262f27ab2cb96ad4b47abdc9d51fL95-L108