### PR TITLE
Add example System Extension and TCC configuration profiles

### DIFF
--- a/docs/deployment/system-extension-policy.santa.example.mobileconfig
+++ b/docs/deployment/system-extension-policy.santa.example.mobileconfig
@@ -1,0 +1,65 @@
+
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1">
+<dict>
+	<!-- See https://developer.apple.com/documentation/devicemanagement/systemextensions for payload descriptions -->
+	<key>PayloadUUID</key>
+	<string>40C19D5B-76D7-4C1C-BC9D-2F7EB29CFF4D</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadOrganization</key>
+	<string></string>
+	<key>PayloadIdentifier</key>
+	<string>com.google.santa.system-extension-policy.40C19D5B-76D7-4C1C-BC9D-2F7EB29CFF4D</string>
+	<key>PayloadDisplayName</key>
+	<string>System Extensions</string>
+	<key>PayloadDescription</key>
+	<string>Configures your Mac to automatically enable Santa's EndpointSecurityExtension</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadUUID</key>
+			<string>98D01A7B-ADC1-43C8-AB8E-8BDC25FCA3C9</string>
+			<key>PayloadType</key>
+			<string>com.apple.system-extension-policy</string>
+			<key>PayloadOrganization</key>
+			<string></string>
+			<key>PayloadIdentifier</key>
+			<string>com.google.santa.system-extension-policy.98D01A7B-ADC1-43C8-AB8E-8BDC25FCA3C9</string>
+			<key>PayloadDisplayName</key>
+			<string>System Extensions</string>
+			<key>PayloadDescription</key>
+			<string/>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>AllowUserOverrides</key>
+			<true/>
+			<key>AllowedSystemExtensions</key>
+			<dict>
+				<key>EQHXZ8M8AV</key>
+				<array>
+					<string>com.google.santa.daemon</string>
+				</array>
+			</dict>
+			<key>AllowedSystemExtensionTypes</key>
+			<dict>
+				<key>EQHXZ8M8AV</key>
+				<array>
+					<string>EndpointSecurityExtension</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/docs/deployment/tcc.configuration-profile-policy.santa.example.mobileconfig
+++ b/docs/deployment/tcc.configuration-profile-policy.santa.example.mobileconfig
@@ -32,7 +32,7 @@
 						<key>Comment</key>
 						<string></string>
 						<key>Identifier</key>
-						<string>com.google.santa.daemon.systemextension</string>
+						<string>com.google.santa.daemon</string>
 						<key>IdentifierType</key>
 						<string>bundleID</string>
 						<key>StaticCode</key>

--- a/docs/deployment/tcc.configuration-profile-policy.santa.example.mobileconfig
+++ b/docs/deployment/tcc.configuration-profile-policy.santa.example.mobileconfig
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- See https://developer.apple.com/documentation/devicemanagement/privacypreferencespolicycontrol for payload descriptions -->
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDescription</key>
+			<string>Configures Privacy Preferences Policy Control settings</string>
+			<key>PayloadDisplayName</key>
+			<string>Privacy Preferences Policy Control</string>
+			<key>PayloadIdentifier</key>
+			<string>com.google.santa.TCC.configuration-profile-policy.2416BA4B-CBFC-4719-B02F-20251B881D6F</string>
+			<key>PayloadOrganization</key>
+			<string></string>
+			<key>PayloadType</key>
+			<string>com.apple.TCC.configuration-profile-policy</string>
+			<key>PayloadUUID</key>
+			<string>2416BA4B-CBFC-4719-B02F-20251B881D6F</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Services</key>
+			<dict>
+				<key>SystemPolicyAllFiles</key>
+				<array>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.google.santa.daemon" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
+						<key>Comment</key>
+						<string></string>
+						<key>Identifier</key>
+						<string>com.google.santa.daemon.systemextension</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<false/>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.google.santa.bundleservice" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
+						<key>Comment</key>
+						<string></string>
+						<key>Identifier</key>
+						<string>com.google.santa.bundleservice</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<false/>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.google.santa" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
+						<key>Comment</key>
+						<string></string>
+						<key>Identifier</key>
+						<string>com.google.santa</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<false/>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>tcc.configuration-profile-policy.santa.example</string>
+	<key>PayloadDisplayName</key>
+	<string>tcc.configuration-profile-policy.santa.example</string>
+	<key>PayloadIdentifier</key>
+	<string>com.google.santa.TCC.configuration-profile-policy.089CBCFB-F2AA-407C-9F2A-A12967FE20BC</string>
+	<key>PayloadOrganization</key>
+	<string></string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>089CBCFB-F2AA-407C-9F2A-A12967FE20BC</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Since the release of https://github.com/google/santa/releases/tag/1.0.3 Santa now requires additional SystemExtension and TCC permissions in order to run on 10.15+.

It took me a better part of a day to figure out the correct profile structure for each. So, I wanted to contribute some examples for future admins to reference.

These configurations are working in my deployment. I don't receive a System Extension prompt upon install nor do I receive a TCC related prompt for `com.google.santa.daemon.systemextension`.

Output of `santactl status`:

```
 santactl status
>>> Daemon Info
  Driver Connected          | Yes
  Mode                      | Monitor
  File Logging              | No
  Watchdog CPU Events       | 1  (Peak: 34.22%)
  Watchdog RAM Events       | 0  (Peak: 41.33MB)
>>> Database Info
  Binary Rules              | 0
  Certificate Rules         | 0
  Compiler Rules            | 0
  Transitive Rules          | 0
  Events Pending Upload     | 163
```

