### PR TITLE
Support for %hostname%, %uuid% and %serial% to eventDetailURLForEvent

### DIFF
--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -126,15 +126,15 @@
     formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%machine_id%"
                                                      withString:config.machineID];
   }
-  if (hostname) {
+  if (hostname.length) {
     formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%hostname%"
                                                      withString:hostname];
   }
-  if (uuid) {
+  if (uuid.length) {
     formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%uuid%"
                                                      withString:uuid];
   }
-  if (serial) {
+  if (serial.length) {
     formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%serial%"
                                                      withString:serial];
   }

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -17,6 +17,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
+#import "Source/common/SNTSystemInfo.h"
 
 @implementation SNTBlockMessage
 
@@ -106,6 +107,9 @@
 + (NSURL *)eventDetailURLForEvent:(SNTStoredEvent *)event {
   SNTConfigurator *config = [SNTConfigurator configurator];
 
+  NSString *hostname = [SNTSystemInfo longHostname];
+  NSString *uuid = [SNTSystemInfo hardwareUUID];
+  NSString *serial = [SNTSystemInfo serialNumber];
   NSString *formatStr = config.eventDetailURL;
   if (!formatStr.length) return nil;
 
@@ -121,6 +125,18 @@
   if (config.machineID) {
     formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%machine_id%"
                                                      withString:config.machineID];
+  }
+  if (hostname) {
+    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%hostname%"
+                                                     withString:hostname];
+  }
+  if (uuid) {
+    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%uuid%"
+                                                     withString:uuid];
+  }
+  if (serial) {
+    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%serial%"
+                                                     withString:serial];
   }
 
   return [NSURL URLWithString:formatStr];

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -191,6 +191,9 @@
 ///  %file_sha%    -- SHA-256 of the file that was blocked.
 ///  %machine_id%  -- ID of the machine.
 ///  %username%    -- executing user.
+///  %serial%      -- System's serial number.
+///  %uuid%        -- System's UUID.
+///  %hostname%    -- System's full hostname.
 ///
 ///  @note: This is not an NSURL because the format-string parsing is done elsewhere.
 ///

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -52,6 +52,9 @@ This property contains a kind of format string to be turned into the URL to send
 | %file_sha%   | SHA-256 of the file that was blocked     |
 | %machine_id% | ID of the machine                        |
 | %username%   | The executing user                       |
+| %serial%     | System's serial number                   |
+| %uuid%       | System's UUID                            |
+| %hostname%   | System's full hostname                   |
 
 For example: `https://sync-server-hostname/%machine_id%/%file_sha%`
 


### PR DESCRIPTION
Hello,

I've added support for `%hostname%`, `%uuid%` and `%serial%` to eventDetailURLForEvent to provide additional system information for blocked events. We're using the `%machine_id%` as our own unique identifier and it'd be useful to be able to provide some additional system information in event detail URLs for external systems that don't have access to the machine_id. 

Thanks

Best,

H