### PR TITLE
Make it possible to remotely set the FullSyncInterval

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -37,6 +37,7 @@ extern NSString *const kBinaryRuleCount;
 extern NSString *const kCertificateRuleCount;
 extern NSString *const kCompilerRuleCount;
 extern NSString *const kTransitiveRuleCount;
+extern NSString *const kFullSyncInterval;
 extern NSString *const kFCMToken;
 extern NSString *const kFCMFullSyncInterval;
 extern NSString *const kFCMGlobalRuleSyncDeadline;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -37,6 +37,7 @@ NSString *const kBinaryRuleCount = @"binary_rule_count";
 NSString *const kCertificateRuleCount = @"certificate_rule_count";
 NSString *const kCompilerRuleCount = @"compiler_rule_count";
 NSString *const kTransitiveRuleCount = @"transitive_rule_count";
+NSString *const kFullSyncInterval = @"full_sync_interval";
 NSString *const kFCMToken = @"fcm_token";
 NSString *const kFCMFullSyncInterval = @"fcm_full_sync_interval";
 NSString *const kFCMGlobalRuleSyncDeadline = @"fcm_global_rule_sync_deadline";

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -55,7 +55,7 @@ static NSString *const kFCMTargetHostIDKey = @"target_host_id";
 // allowlistNotificationQueue is used to serialize access to the allowlistNotifications dictionary.
 @property(nonatomic) NSOperationQueue *allowlistNotificationQueue;
 
-@property NSUInteger FullSyncInterval;
+@property NSUInteger fullSyncInterval;
 
 @property NSUInteger FCMFullSyncInterval;
 @property NSUInteger FCMGlobalRuleSyncDeadline;
@@ -124,7 +124,7 @@ static void reachabilityHandler(
     _allowlistNotificationQueue = [[NSOperationQueue alloc] init];
     _allowlistNotificationQueue.maxConcurrentOperationCount = 1;  // make this a serial queue
 
-    _FullSyncInterval = kDefaultFullSyncInterval;
+    _fullSyncInterval = kDefaultFullSyncInterval;
     _eventBatchSize = kDefaultEventBatchSize;
     _FCMFullSyncInterval = kDefaultFCMFullSyncInterval;
     _FCMGlobalRuleSyncDeadline = kDefaultFCMGlobalRuleSyncDeadline;
@@ -353,11 +353,11 @@ static void reachabilityHandler(
       self.FCMGlobalRuleSyncDeadline = syncState.FCMGlobalRuleSyncDeadline;
       [self listenForPushNotificationsWithSyncState:syncState];
     } else if (syncState.daemon) {
-      LOGD(@"FCMToken not provided. Sync every %lu min.", syncState.FullSyncInterval / 60);
+      LOGD(@"FCMToken not provided. Sync every %lu min.", syncState.fullSyncInterval / 60);
       [self.FCMClient disconnect];
       self.FCMClient = nil;
-      self.FullSyncInterval = syncState.FullSyncInterval;
-      [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:self.FullSyncInterval];
+      self.fullSyncInterval = syncState.fullSyncInterval;
+      [self rescheduleTimerQueue:self.fullSyncTimer secondsFromNow:self.fullSyncInterval];
     }
 
     return [self eventUploadWithSyncState:syncState];

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -353,7 +353,7 @@ static void reachabilityHandler(
       self.FCMGlobalRuleSyncDeadline = syncState.FCMGlobalRuleSyncDeadline;
       [self listenForPushNotificationsWithSyncState:syncState];
     } else if (syncState.daemon) {
-      LOGI(@"FCMToken not provided. Sync every %lu min.", syncState.FullSyncInterval / 60);
+      LOGD(@"FCMToken not provided. Sync every %lu min.", syncState.FullSyncInterval / 60);
       [self.FCMClient disconnect];
       self.FCMClient = nil;
       self.FullSyncInterval = syncState.FullSyncInterval;

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -105,12 +105,17 @@
   self.syncState.FCMToken = resp[kFCMToken];
 
   // Don't let these go too low
-  NSUInteger value = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
+  NSUInteger FCMintervalValue = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
   self.syncState.FCMFullSyncInterval =
-      (value < kDefaultFullSyncInterval) ? kDefaultFCMFullSyncInterval : value;
-  value = [resp[kFCMGlobalRuleSyncDeadline] unsignedIntegerValue];
+      (FCMintervalValue < kDefaultFullSyncInterval) ? kDefaultFCMFullSyncInterval : FCMintervalValue;
+  FCMintervalValue = [resp[kFCMGlobalRuleSyncDeadline] unsignedIntegerValue];
   self.syncState.FCMGlobalRuleSyncDeadline =
-      (value < 60) ?  kDefaultFCMGlobalRuleSyncDeadline : value;
+      (FCMintervalValue < 60) ?  kDefaultFCMGlobalRuleSyncDeadline : FCMintervalValue;
+
+  // Check if our sync interval has changed
+  NSUInteger intervalValue = [resp[kFullSyncInterval] unsignedIntegerValue];
+  self.syncState.FullSyncInterval =
+      (intervalValue < 60) ? kDefaultFullSyncInterval : intervalValue;
 
   if ([resp[kClientMode] isEqual:kClientModeMonitor]) {
     self.syncState.clientMode = SNTClientModeMonitor;

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -105,16 +105,16 @@
   self.syncState.FCMToken = resp[kFCMToken];
 
   // Don't let these go too low
-  NSUInteger FCMintervalValue = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
+  NSUInteger FCMIntervalValue = [resp[kFCMFullSyncInterval] unsignedIntegerValue];
   self.syncState.FCMFullSyncInterval =
-      (FCMintervalValue < kDefaultFullSyncInterval) ? kDefaultFCMFullSyncInterval : FCMintervalValue;
-  FCMintervalValue = [resp[kFCMGlobalRuleSyncDeadline] unsignedIntegerValue];
+      (FCMIntervalValue < kDefaultFullSyncInterval) ? kDefaultFCMFullSyncInterval : FCMIntervalValue;
+  FCMIntervalValue = [resp[kFCMGlobalRuleSyncDeadline] unsignedIntegerValue];
   self.syncState.FCMGlobalRuleSyncDeadline =
-      (FCMintervalValue < 60) ?  kDefaultFCMGlobalRuleSyncDeadline : FCMintervalValue;
+      (FCMIntervalValue < 60) ?  kDefaultFCMGlobalRuleSyncDeadline : FCMIntervalValue;
 
   // Check if our sync interval has changed
   NSUInteger intervalValue = [resp[kFullSyncInterval] unsignedIntegerValue];
-  self.syncState.FullSyncInterval =
+  self.syncState.fullSyncInterval =
       (intervalValue < 60) ? kDefaultFullSyncInterval : intervalValue;
 
   if ([resp[kClientMode] isEqual:kClientModeMonitor]) {

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -35,6 +35,9 @@
 /// An XSRF token to send in the headers with each request.
 @property NSString *xsrfToken;
 
+/// Full sync interval in seconds without FCM to update kDefaultFullSyncInterval
+@property NSUInteger FullSyncInterval;
+
 /// An FCM token to subscribe to push notifications.
 @property(copy) NSString *FCMToken;
 

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -35,8 +35,9 @@
 /// An XSRF token to send in the headers with each request.
 @property NSString *xsrfToken;
 
-/// Full sync interval in seconds without FCM to update kDefaultFullSyncInterval
-@property NSUInteger FullSyncInterval;
+/// Full sync interval in seconds without FCM to update kDefaultFullSyncInterval => when FCM
+/// is not used, defaults to 10m.
+@property NSUInteger fullSyncInterval;
 
 /// An FCM token to subscribe to push notifications.
 @property(copy) NSString *FCMToken;

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -170,6 +170,7 @@ Configuration profiles have a `.mobileconfig` file extension. There are many way
 | upload_logs_url**              | String     | If set, the endpoint to send Santa's current logs. No default. |
 | allowed_path_regex             | String     | Same as the "Local Configuration" AllowedPathRegex. No default. |
 | blocked_path_regex             | String     | Same as the "Local Configuration" BlockedPathRegex. No default. |
+| full_sync_interval*            | Integer    | The max time to wait before performing a full sync with the server. |
 | fcm_token*                     | String     | The FCM token used by Santa to listen for FCM messages. Unique for every machine. No default. |
 | fcm_full_sync_interval*        | Integer    | The full sync interval if a fcm_token is set. Defaults to  14400 secs (4 hours). |
 | fcm_global_rule_sync_deadline* | Integer    | The max time to wait before performing a rule sync when a global rule sync FCM message is received. This allows syncing to be staggered for global events to avoid spikes in server load. Defaults to 600 secs (10 min). |

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -170,7 +170,7 @@ Configuration profiles have a `.mobileconfig` file extension. There are many way
 | upload_logs_url**              | String     | If set, the endpoint to send Santa's current logs. No default. |
 | allowed_path_regex             | String     | Same as the "Local Configuration" AllowedPathRegex. No default. |
 | blocked_path_regex             | String     | Same as the "Local Configuration" BlockedPathRegex. No default. |
-| full_sync_interval*            | Integer    | The max time to wait before performing a full sync with the server. |
+| full_sync_interval*            | Integer    | The max time to wait before performing a full sync with the server. Defaults to 600 secs (10 minutes) if not set. |
 | fcm_token*                     | String     | The FCM token used by Santa to listen for FCM messages. Unique for every machine. No default. |
 | fcm_full_sync_interval*        | Integer    | The full sync interval if a fcm_token is set. Defaults to  14400 secs (4 hours). |
 | fcm_global_rule_sync_deadline* | Integer    | The max time to wait before performing a rule sync when a global rule sync FCM message is received. This allows syncing to be staggered for global events to avoid spikes in server load. Defaults to 600 secs (10 min). |


### PR DESCRIPTION
Hello,

The documentation seems to suggest the ability to remotely set the default sync interval from 10 minutes. Though maybe this was only explicitly meant for FCM notifications? Either way, I'd like to be able to remotely set the sync interval for non-FCM driven deployments. Happy to discuss if was done for a specific design rationale. However, I'd like to be able to set the sync interval remotely based on different client groups.

If you're happy I'll add a follow on commit with updates to the docs.

Many thanks,

H