### PR TITLE
santa-driver: Fix some new Xcode 12 warnings

### DIFF
--- a/Source/santa_driver/BUILD
+++ b/Source/santa_driver/BUILD
@@ -23,6 +23,7 @@ cc_library(
     copts = [
         "-mkernel",
         "-fapple-kext",
+        "-Wno-ossharedptr-misuse",
         "-I__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/Headers",
     ],
     defines = [


### PR DESCRIPTION
The `ossharedptr-misuse` warning is generated from within system headers and I couldn't find a simple way to prevent that other than disabling the warning entirely. We don't use `OSSharedPtr` directly anyway.