### PR TITLE
santactl sync: add config option to enable legacy zlib content encoding

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -333,6 +333,14 @@
 @property(readonly, nonatomic) BOOL enableDebugLogging;
 
 ///
+///  If true, compressed requests from "santactl sync" will set "Content-Encoding" to "zlib"
+///  instead of the new default "deflate". If syncing with Upvote deployed at commit 0b4477d
+///  or below, set this option to true.
+///  Defaults to false.
+///
+@property(readonly, nonatomic) BOOL enableBackwardsCompatibleContentEncoding;
+
+///
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -84,6 +84,8 @@ static NSString *const kEnableForkAndExitLogging = @"EnableForkAndExitLogging";
 static NSString *const kIgnoreOtherEndpointSecurityClients = @"IgnoreOtherEndpointSecurityClients";
 static NSString *const kEnableDebugLogging = @"EnableDebugLogging";
 
+static NSString *const kEnableBackwardsCompatibleContentEncoding = @"EnableBackwardsCompatibleContentEncoding";
+
 // The keys managed by a sync server or mobileconfig.
 static NSString *const kClientModeKey = @"ClientMode";
 static NSString *const kEnableTransitiveRulesKey = @"EnableTransitiveRules";
@@ -158,6 +160,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kEnableForkAndExitLogging : number,
       kIgnoreOtherEndpointSecurityClients : number,
       kEnableDebugLogging : number,
+      kEnableBackwardsCompatibleContentEncoding : number,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -338,6 +341,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 + (NSSet *)keyPathsForValuesAffectingEnableDebugLogging {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingEnableBackwardsCompatibleContentEncoding {
   return [self configStateSet];
 }
 
@@ -589,6 +596,11 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 - (BOOL)enableDebugLogging {
   NSNumber *number = self.configState[kEnableDebugLogging];
   return [number boolValue] || self.debugFlag;
+}
+
+- (BOOL)enableBackwardsCompatibleContentEncoding {
+  NSNumber *number = self.configState[kEnableBackwardsCompatibleContentEncoding];
+  return number ? [number boolValue] : NO;
 }
 
 #pragma mark Private

--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -482,6 +482,9 @@ static void reachabilityHandler(
   syncState.daemonConn = self.daemonConn;
   syncState.daemon = self.daemon;
 
+  syncState.compressedContentEncoding =
+      config.enableBackwardsCompatibleContentEncoding ? @"zlib" : @"deflate";
+
   dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
   return syncState;
 }

--- a/Source/santactl/Commands/sync/SNTCommandSyncStage.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncStage.m
@@ -70,7 +70,7 @@
   NSData *compressed = [requestBody zlibCompressed];
   if (compressed) {
     requestBody = compressed;
-    [req setValue:@"deflate" forHTTPHeaderField:@"Content-Encoding"];
+    [req setValue:self.syncState.compressedContentEncoding forHTTPHeaderField:@"Content-Encoding"];
   }
 
   [req setHTTPBody:requestBody];

--- a/Source/santactl/Commands/sync/SNTCommandSyncState.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncState.h
@@ -78,4 +78,8 @@
 /// Reference to the serial operation queue used for accessing allowlistNotifications.
 @property(weak) NSOperationQueue *allowlistNotificationQueue;
 
+/// The header value for ContentEncoding when sending compressed content.
+/// Either "deflate" (default) or "zlib".
+@property(copy) NSString *compressedContentEncoding;
+
 @end

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version for all Santa components."""
 
-SANTA_VERSION = "1.16"
+SANTA_VERSION = "1.17"


### PR DESCRIPTION
* Also bump version to 1.17