### PR TITLE
santactl/sync: retry individual requests during a sync

### DIFF
--- a/Source/santactl/Commands/sync/SNTCommandSyncManager.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncManager.m
@@ -337,6 +337,7 @@ static void reachabilityHandler(
 #pragma mark syncing chain
 
 - (void)preflight {
+  LOGD(@"Preflight starting");
   SNTCommandSyncState *syncState = [self createSyncState];
   SNTCommandSyncPreflight *p = [[SNTCommandSyncPreflight alloc] initWithState:syncState];
   if ([p sync]) {
@@ -373,6 +374,7 @@ static void reachabilityHandler(
 }
 
 - (void)eventUploadWithSyncState:(SNTCommandSyncState *)syncState {
+  LOGD(@"Event upload starting");
   SNTCommandSyncEventUpload *p = [[SNTCommandSyncEventUpload alloc] initWithState:syncState];
   if ([p sync]) {
     LOGD(@"Event upload complete");
@@ -384,6 +386,7 @@ static void reachabilityHandler(
 }
 
 - (void)ruleDownloadWithSyncState:(SNTCommandSyncState *)syncState {
+  LOGD(@"Rule download starting");
   SNTCommandSyncRuleDownload *p = [[SNTCommandSyncRuleDownload alloc] initWithState:syncState];
   if ([p sync]) {
     LOGD(@"Rule download complete");
@@ -395,6 +398,7 @@ static void reachabilityHandler(
 }
 
 - (void)postflightWithSyncState:(SNTCommandSyncState *)syncState {
+  LOGD(@"Postflight starting");
   SNTCommandSyncPostflight *p = [[SNTCommandSyncPostflight alloc] initWithState:syncState];
   if ([p sync]) {
     LOGD(@"Postflight complete");

--- a/Source/santactl/Commands/sync/SNTCommandSyncStage.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncStage.m
@@ -85,7 +85,12 @@
   NSError *error;
   NSData *data;
 
-  for (int attempt = 1; attempt < 4; ++attempt) {
+  for (int attempt = 1; attempt < 6; ++attempt) {
+    if (attempt > 1) {
+      struct timespec ts = {.tv_sec = (attempt * 2)};
+      nanosleep(&ts, NULL);
+    }
+
     LOGD(@"Performing request, attempt %d", attempt);
     data = [self performRequest:request timeout:timeout response:&response error:&error];
     if (response.statusCode == 200) break;
@@ -102,9 +107,6 @@
       request = mutableRequest;
       continue;
     }
-
-    struct timespec ts = {.tv_sec = (attempt * 2)};
-    nanosleep(&ts, NULL);
   }
 
   // If the final attempt resulted in an error, log the error and return nil.

--- a/Source/santactl/Commands/sync/SNTCommandSyncStage.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncStage.m
@@ -83,20 +83,31 @@
 - (NSDictionary *)performRequest:(NSURLRequest *)request timeout:(NSTimeInterval)timeout {
   NSHTTPURLResponse *response;
   NSError *error;
-  NSData *data = [self performRequest:request timeout:timeout response:&response error:&error];
+  NSData *data;
 
-  // If the original request failed, attempt to get a new XSRF token and try again.
-  // Unfortunately some servers cause NSURLSession to return 'client cert required' or
-  // 'could not parse response' when a 403 occurs and SSL cert auth is enabled.
-  if ((response.statusCode == 403 ||
-       error.code == NSURLErrorClientCertificateRequired ||
-       error.code == NSURLErrorCannotParseResponse) &&
-      [self fetchXSRFToken]) {
-    NSMutableURLRequest *mutableRequest = [request mutableCopy];
-    [mutableRequest setValue:self.syncState.xsrfToken forHTTPHeaderField:kXSRFToken];
-    return [self performRequest:mutableRequest timeout:timeout];
+  for (int attempt = 1; attempt < 4; ++attempt) {
+    LOGD(@"Performing request, attempt %d", attempt);
+    data = [self performRequest:request timeout:timeout response:&response error:&error];
+    if (response.statusCode == 200) break;
+
+    // If the original request failed because of an auth error, attempt to get a new XSRF token and
+    // try again. Unfortunately some servers cause NSURLSession to return 'client cert required' or
+    // 'could not parse response' when a 403 occurs and SSL cert auth is enabled.
+    if ((response.statusCode == 403 ||
+         error.code == NSURLErrorClientCertificateRequired ||
+         error.code == NSURLErrorCannotParseResponse) &&
+        [self fetchXSRFToken]) {
+      NSMutableURLRequest *mutableRequest = [request mutableCopy];
+      [mutableRequest setValue:self.syncState.xsrfToken forHTTPHeaderField:kXSRFToken];
+      request = mutableRequest;
+      continue;
+    }
+
+    struct timespec ts = {.tv_sec = (attempt * 2)};
+    nanosleep(&ts, NULL);
   }
 
+  // If the final attempt resulted in an error, log the error and return nil.
   if (response.statusCode != 200) {
     long code;
     NSString *errStr;


### PR DESCRIPTION
Each request is retried up to 3 times with gaps of 2s, 4s, 6s