### PR TITLE
santad: Fix transitive rules when using the sysx cache feature

### DIFF
--- a/Source/common/SNTLogging.m
+++ b/Source/common/SNTLogging.m
@@ -88,7 +88,10 @@ void logMessage(LogLevel level, FILE *destination, NSString *format, ...) {
         break;
       case LOG_LEVEL_DEBUG:
         levelName = "D";
-        syslogLevel = ASL_LEVEL_DEBUG;
+        // Log debug messages at the same ASL level as INFO.
+        // While it would make sense to use DEBUG, watching debug-level logs
+        // in Console means enabling all debug logs, which is absurdly noisy.
+        syslogLevel = ASL_LEVEL_NOTICE;
         break;
     }
 

--- a/Source/santad/EventProviders/SNTCachingEndpointSecurityManager.mm
+++ b/Source/santad/EventProviders/SNTCachingEndpointSecurityManager.mm
@@ -79,7 +79,7 @@ template<> uint64_t SantaCacheHasher<santa_vnode_id_t>(santa_vnode_id_t const& t
     }
   }
 
-  [self addToCache:vnode_id decision:ACTION_REQUEST_BINARY timeout:0];
+  [self addToCache:vnode_id decision:ACTION_REQUEST_BINARY currentTicks:0];
   return NO;
 }
 
@@ -94,18 +94,18 @@ template<> uint64_t SantaCacheHasher<santa_vnode_id_t>(santa_vnode_id_t const& t
       // we won't see future execs of the compiler in order to record the PID.
       [self addToCache:sm.vnode_id
               decision:ACTION_RESPOND_ALLOW_COMPILER
-               timeout:GetCurrentUptime()];
+          currentTicks:GetCurrentUptime()];
       ret = es_respond_auth_result(self.client, (es_message_t *)sm.es_message,
                                    ES_AUTH_RESULT_ALLOW, false);
       break;
     case ACTION_RESPOND_ALLOW:
     case ACTION_RESPOND_ALLOW_PENDING_TRANSITIVE:
-      [self addToCache:sm.vnode_id decision:ACTION_RESPOND_ALLOW timeout:GetCurrentUptime()];
+      [self addToCache:sm.vnode_id decision:ACTION_RESPOND_ALLOW currentTicks:GetCurrentUptime()];
       ret = es_respond_auth_result(self.client, (es_message_t *)sm.es_message,
                                    ES_AUTH_RESULT_ALLOW, true);
       break;
     case ACTION_RESPOND_DENY:
-      [self addToCache:sm.vnode_id decision:ACTION_RESPOND_DENY timeout:GetCurrentUptime()];
+      [self addToCache:sm.vnode_id decision:ACTION_RESPOND_DENY currentTicks:GetCurrentUptime()];
       OS_FALLTHROUGH;
     case ACTION_RESPOND_TOOLONG:
       ret = es_respond_auth_result(self.client, (es_message_t *)sm.es_message,
@@ -122,7 +122,7 @@ template<> uint64_t SantaCacheHasher<santa_vnode_id_t>(santa_vnode_id_t const& t
 
 - (void)addToCache:(santa_vnode_id_t)identifier
           decision:(santa_action_t)decision
-           timeout:(uint64_t)microsecs {
+      currentTicks:(uint64_t)microsecs {
   switch (decision) {
     case ACTION_REQUEST_BINARY:
       _decisionCache->set(identifier, (uint64_t)ACTION_REQUEST_BINARY << 56, 0);

--- a/Source/santad/EventProviders/SNTEndpointSecurityManager.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManager.h
@@ -25,6 +25,10 @@ const pid_t PID_MAX = 99999;
 @interface SNTEndpointSecurityManager : NSObject<SNTEventProvider>
 - (santa_vnode_id_t)vnodeIDForFile:(es_file_t *)file;
 
+- (BOOL)isCompilerPID:(pid_t)pid;
+- (void)setIsCompilerPID:(pid_t)pid;
+- (void)setNotCompilerPID:(pid_t)pid;
+
 @property(readonly, nonatomic) es_client_t *client;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManager.mm
@@ -117,6 +117,9 @@
                    sm.path, pid);
               break;
             }
+            if ([@(sm.path) hasPrefix:@"/dev/"]) {
+              break;
+            }
             sm.action = ACTION_NOTIFY_WHITELIST;
             sm.pid = pid;
             sm.pidversion = pidversion;
@@ -137,6 +140,9 @@
             if (truncated) {
               LOGE(@"RENAME: error creating transitive rule, the path is truncated: path=%s pid=%d",
                    sm.path, pid);
+              break;
+            }
+            if ([@(sm.path) hasPrefix:@"/dev/"]) {
               break;
             }
             sm.action = ACTION_NOTIFY_WHITELIST;

--- a/Source/santad/EventProviders/SNTEndpointSecurityManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManager.mm
@@ -191,12 +191,12 @@
 
       switch (m->action_type) {
         case ES_ACTION_TYPE_AUTH: {
-          // Create a timer to deny the execution 2 seconds before the deadline,
+          // Create a timer to deny the execution 5 seconds before the deadline,
           // if a response hasn't already been sent. This block will still be enqueued if
-          // the the deadline - 2 secs is < DISPATCH_TIME_NOW.
-          // As of 10.15.2, a typical deadline is 60 seconds.
+          // the the deadline - 5 secs is < DISPATCH_TIME_NOW.
+          // As of 10.15.5, a typical deadline is 60 seconds.
           auto responded = std::make_shared<std::atomic<bool>>(false);
-          dispatch_after(dispatch_time(m->deadline, NSEC_PER_SEC * -2), self.esAuthQueue, ^(void) {
+          dispatch_after(dispatch_time(m->deadline, NSEC_PER_SEC * -5), self.esAuthQueue, ^(void) {
             if (responded->load()) return;
             LOGE(@"Deadline reached: deny pid=%d ret=%d",
                  pid, es_respond_auth_result(self.client, m, ES_AUTH_RESULT_DENY, false));

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version for all Santa components."""
 
-SANTA_VERSION = "2021.2"
+SANTA_VERSION = "2021.3"


### PR DESCRIPTION
There are a few related changes - the increase of the deadline timeout is because 2s seems just a fraction too short sometimes and adjusting the DEBUG log mapping was just to help debugging of this feature.

Fixes #539