### PR TITLE
Project: Bump dependency versions, fix reload command

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -74,9 +74,9 @@ set -e
 
 rm -rf /tmp/bazel_santa_reload
 unzip -d /tmp/bazel_santa_reload \
-    $${BUILD_WORKSPACE_DIRECTORY}/bazel-out/*/bin/Source/santa_driver/santa_driver.zip >/dev/null
+    $${BUILD_WORKSPACE_DIRECTORY}/bazel-out/*$(COMPILATION_MODE)*/bin/Source/santa_driver/santa_driver.zip >/dev/null
 unzip -d /tmp/bazel_santa_reload \
-    $${BUILD_WORKSPACE_DIRECTORY}/bazel-out/*/bin/Source/santa/Santa.zip >/dev/null
+    $${BUILD_WORKSPACE_DIRECTORY}/bazel-out/*$(COMPILATION_MODE)*/bin/Source/santa/Santa.zip >/dev/null
 echo "You may be asked for your password for sudo"
 sudo BINARIES=/tmp/bazel_santa_reload CONF=$${BUILD_WORKSPACE_DIRECTORY}/Conf \
     $${BUILD_WORKSPACE_DIRECTORY}/Conf/install.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,12 +14,15 @@ git_repository(
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
 apple_rules_dependencies()
 
+load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+apple_support_dependencies()
+
 # Macops MOL* dependencies
 
 git_repository(
     name = "MOLAuthenticatingURLSession",
     remote = "https://github.com/google/macops-molauthenticatingurlsession.git",
-    tag = "v2.9",
+    tag = "v3.0",
 )
 
 git_repository(
@@ -35,15 +38,9 @@ git_repository(
 )
 
 git_repository(
-    name = "MOLFCMClient",
-    remote = "https://github.com/google/macops-molfcmclient.git",
-    tag = "v2.0",
-)
-
-git_repository(
     name = "MOLXPCConnection",
     remote = "https://github.com/google/macops-molxpcconnection.git",
-    tag = "v2.0",
+    tag = "v2.1",
 )
 
 # FMDB
@@ -51,7 +48,7 @@ git_repository(
 new_git_repository(
     name = "FMDB",
     remote = "https://github.com/ccgus/fmdb.git",
-    tag = "v2.7",
+    tag = "2.7.7",
     build_file_content = """
 objc_library(
     name = "FMDB",
@@ -69,7 +66,7 @@ objc_library(
 new_git_repository(
     name = "OCMock",
     remote = "https://github.com/erikdoe/ocmock",
-    tag = "v3.4.3",
+    tag = "v3.8.1",
     build_file_content = """
 objc_library(
     name = "OCMock",

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version for all Santa components."""
 
-SANTA_VERSION = "2021.3"
+SANTA_VERSION = "2021.5"


### PR DESCRIPTION
The reload command would previously fail if you used multiple compilation modes for building as it would try extracting the versions from both comp modes.

The dependency bump includes a fix for #553.

Bump Santa version to 2021.5