### PR TITLE
Run Unit Tests & Coverage in CI first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build Userspace
-      run: bazel build --apple_generate_dsym -c opt :release --define=SANTA_BUILD_TYPE=ci
-    - name: Build Driver
-      run: bazel build --apple_generate_dsym -c opt :release_driver --define=SANTA_BUILD_TYPE=ci
     - name: Test
       run: bazel test :unit_tests --define=SANTA_BUILD_TYPE=ci
     - name: Generate test coverage
@@ -31,3 +27,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./CoverageData/info.lcov
         flag-name: Unit
+    - name: Build Userspace
+      run: bazel build --apple_generate_dsym -c opt :release --define=SANTA_BUILD_TYPE=ci
+    - name: Build Driver
+      run: bazel build --apple_generate_dsym -c opt :release_driver --define=SANTA_BUILD_TYPE=ci


### PR DESCRIPTION
Especially due to https://github.com/actions/virtual-environments/issues/3885, a full build of the driver takes several minutes. Switch our CI steps to run our unit tests first, which are more likely to fail those build stages anyways.