### PR TITLE
Enable -Werror -Wall on our build rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,4 @@ build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
 build --host_force_python=PY2
 
 build --copt=-Wreorder-init-list
+build --copt=-Wunused-variable

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
 build --host_force_python=PY2
 
-build --copt=-Wreorder-init-list
-build --copt=-Wunused-variable
+build --copt=-Werror
+build --copt=-Wall

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,4 @@
 build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
 build --host_force_python=PY2
+
+build --copt=-Wreorder-init-list

--- a/Source/common/SantaCache.h
+++ b/Source/common/SantaCache.h
@@ -51,7 +51,7 @@
 */
 template <typename T>
 uint64_t SantaCacheHasher(T const &t) {
-  return t * 11400714819323198549UL;
+  return (uint64_t)t * 11400714819323198549UL;
 };
 
 /**
@@ -80,7 +80,7 @@ class SantaCache {
     usage. Cannot be higher than 64 to try and ensure buckets don't overflow.
   */
   SantaCache(uint64_t maximum_size = 10000, uint8_t per_bucket = 5) {
-    if (unlikely(per_bucket > maximum_size)) per_bucket = maximum_size;
+    if (unlikely(per_bucket > maximum_size)) per_bucket = (uint8_t)maximum_size;
     if (unlikely(per_bucket < 1)) per_bucket = 1;
     if (unlikely(per_bucket > 64)) per_bucket = 64;
     max_size_ = maximum_size;
@@ -214,7 +214,7 @@ class SantaCache {
     }
 
     uint16_t size = *array_size;
-    if (start + size > bucket_count_) size = bucket_count_ - start;
+    if (start + size > bucket_count_) size = (uint16_t)(bucket_count_ - start);
 
     for (uint16_t i = 0; i < size; ++i) {
       uint16_t count = 0;

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.h
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.h
@@ -17,7 +17,7 @@
 #include <bsm/libbsm.h>
 
 CF_EXTERN_C_BEGIN
-es_string_token_t MakeStringToken(const NSString *s);
+es_string_token_t MakeStringToken(const NSString *_Nonnull s);
 CF_EXTERN_C_END
 
 @interface ESResponse : NSObject
@@ -25,17 +25,17 @@ CF_EXTERN_C_END
 @property(nonatomic) bool shouldCache;
 @end
 
-typedef void (^ESCallback)(ESResponse *);
+typedef void (^ESCallback)(ESResponse *_Nonnull);
 
 // Singleton wrapper around all of the kernel-level EndpointSecurity framework functions.
 @interface MockEndpointSecurity : NSObject
 @property BOOL subscribed;
 - (void)reset;
-- (void)registerResponseCallback:(ESCallback)callback;
-- (void)triggerHandler:(es_message_t *)msg;
+- (void)registerResponseCallback:(ESCallback _Nonnull)callback;
+- (void)triggerHandler:(es_message_t *_Nonnull)msg;
 
 ///  Retrieve an initialized singleton MockEndpointSecurity object
-+ (instancetype)mockEndpointSecurity;
++ (instancetype _Nonnull)mockEndpointSecurity;
 @end
 
 API_UNAVAILABLE(ios, tvos, watchos)
@@ -64,6 +64,6 @@ API_AVAILABLE(macos(10.15))
 API_UNAVAILABLE(ios, tvos, watchos) es_return_t es_delete_client(es_client_t *_Nullable client);
 
 API_AVAILABLE(macos(10.15))
-API_UNAVAILABLE(ios, tvos, watchos) es_return_t
-  es_unsubscribe(es_client_t *_Nonnull client, const es_event_type_t *_Nonnull events,
-                 uint32_t event_count);
+API_UNAVAILABLE(ios, tvos, watchos)
+es_return_t es_unsubscribe(es_client_t *_Nonnull client, const es_event_type_t *_Nonnull events,
+                           uint32_t event_count);

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
@@ -19,7 +19,7 @@
 #import "Source/santad/EventProviders/EndpointSecurityTestUtil.h"
 
 CF_EXTERN_C_BEGIN
-es_string_token_t MakeStringToken(const NSString *s) {
+es_string_token_t MakeStringToken(const NSString *_Nonnull s) {
   return (es_string_token_t){
     .length = [s length],
     .data = [s UTF8String],
@@ -65,11 +65,11 @@ CF_EXTERN_C_END
   self.handler = handler;
 }
 
-- (void)triggerHandler:(es_message_t *)msg {
-  self.handler((__bridge es_client_t *)self.client, msg);
+- (void)triggerHandler:(es_message_t *_Nonnull)msg {
+  self.handler((__bridge es_client_t *_Nullable)self.client, msg);
 }
 
-- (void)registerResponseCallback:(ESCallback)callback {
+- (void)registerResponseCallback:(ESCallback _Nonnull)callback {
   @synchronized(self) {
     [self.responseCallbacks addObject:callback];
   }
@@ -89,7 +89,7 @@ CF_EXTERN_C_END
   return ES_RESPOND_RESULT_SUCCESS;
 };
 
-+ (instancetype)mockEndpointSecurity {
++ (instancetype _Nonnull)mockEndpointSecurity {
   static MockEndpointSecurity *sharedES;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
@@ -21,8 +21,8 @@
 CF_EXTERN_C_BEGIN
 es_string_token_t MakeStringToken(const NSString *s) {
   return (es_string_token_t){
-    .data = [s UTF8String],
     .length = [s length],
+    .data = [s UTF8String],
   };
 }
 CF_EXTERN_C_END

--- a/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
@@ -42,6 +42,7 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
   MockEndpointSecurity *mockES = [MockEndpointSecurity mockEndpointSecurity];
   [mockES reset];
   SNTEndpointSecurityManager *snt = [[SNTEndpointSecurityManager alloc] init];
+  (void)snt;  // Make it appear used for the sake of -Wunused-variable
 
   XCTestExpectation *expectation =
     [self expectationWithDescription:@"Wait for santa's Auth dispatch queue"];
@@ -105,6 +106,7 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
     MockEndpointSecurity *mockES = [MockEndpointSecurity mockEndpointSecurity];
     [mockES reset];
     SNTEndpointSecurityManager *snt = [[SNTEndpointSecurityManager alloc] init];
+    (void)snt;  // Make it appear used for the sake of -Wunused-variable
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for response from ES"];
     __block ESResponse *got;
@@ -155,9 +157,9 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
   MockEndpointSecurity *mockES = [MockEndpointSecurity mockEndpointSecurity];
   [mockES reset];
   SNTEndpointSecurityManager *snt = [[SNTEndpointSecurityManager alloc] init];
+  (void)snt;  // Make it appear used for the sake of -Wunused-variable
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for response from ES"];
-
   __block ESResponse *got;
   [mockES registerResponseCallback:^(ESResponse *r) {
     got = r;
@@ -205,6 +207,7 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
     MockEndpointSecurity *mockES = [MockEndpointSecurity mockEndpointSecurity];
     [mockES reset];
     SNTEndpointSecurityManager *snt = [[SNTEndpointSecurityManager alloc] init];
+    (void)snt;  // Make it appear used for the sake of -Wunused-variable
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for response from ES"];
     __block ESResponse *got;
@@ -264,6 +267,7 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
     MockEndpointSecurity *mockES = [MockEndpointSecurity mockEndpointSecurity];
     [mockES reset];
     SNTEndpointSecurityManager *snt = [[SNTEndpointSecurityManager alloc] init];
+    (void)snt;  // Make it appear used for the sake of -Wunused-variable
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for response from ES"];
     __block ESResponse *got;

--- a/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
@@ -60,26 +60,26 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
   es_file_t dbFile = {.path = MakeStringToken(kEventsDBPath)};
   es_file_t otherBinary = {.path = MakeStringToken(@"somebinary")};
   es_process_t proc = {
-    .executable = &otherBinary,
-    .is_es_client = false,
-    .codesigning_flags = 570509313,
-    .session_id = 12345,
-    .group_id = 12345,
     .ppid = 12345,
     .original_ppid = 12345,
+    .group_id = 12345,
+    .session_id = 12345,
+    .codesigning_flags = 570509313,
     .is_platform_binary = false,
+    .is_es_client = false,
+    .executable = &otherBinary,
   };
   es_event_unlink_t unlink_event = {.target = &dbFile};
   es_events_t event = {.unlink = unlink_event};
   es_message_t m = {
     .version = 4,
-    .event_type = ES_EVENT_TYPE_AUTH_UNLINK,
-    .event = event,
     .mach_time = 1234,
-    .action_type = ES_ACTION_TYPE_AUTH,
     .deadline = 1234,
     .process = &proc,
     .seq_num = 1337,
+    .action_type = ES_ACTION_TYPE_AUTH,
+    .event_type = ES_EVENT_TYPE_AUTH_UNLINK,
+    .event = event,
   };
 
   [mockES triggerHandler:&m];
@@ -116,26 +116,25 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
     es_file_t dbFile = {.path = MakeStringToken(testPath)};
     es_file_t otherBinary = {.path = MakeStringToken(@"somebinary")};
     es_process_t proc = {
-      .executable = &otherBinary,
-      .is_es_client = false,
-      .codesigning_flags = 570509313,
-      .session_id = 12345,
-      .group_id = 12345,
       .ppid = 12345,
       .original_ppid = 12345,
+      .group_id = 12345,
+      .session_id = 12345,
+      .codesigning_flags = 570509313,
       .is_platform_binary = false,
+      .is_es_client = false,
     };
     es_event_unlink_t unlink_event = {.target = &dbFile};
     es_events_t event = {.unlink = unlink_event};
     es_message_t m = {
       .version = 4,
-      .event_type = ES_EVENT_TYPE_AUTH_UNLINK,
-      .event = event,
       .mach_time = DISPATCH_TIME_NOW,
-      .action_type = ES_ACTION_TYPE_AUTH,
       .deadline = DISPATCH_TIME_FOREVER,
       .process = &proc,
       .seq_num = 1337,
+      .action_type = ES_ACTION_TYPE_AUTH,
+      .event_type = ES_EVENT_TYPE_AUTH_UNLINK,
+      .event = event,
     };
     [mockES triggerHandler:&m];
 
@@ -167,26 +166,26 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
   es_file_t dbFile = {.path = MakeStringToken(@"/some/other/path")};
   es_file_t otherBinary = {.path = MakeStringToken(@"somebinary")};
   es_process_t proc = {
-    .executable = &otherBinary,
-    .is_es_client = true,
-    .codesigning_flags = 570509313,
-    .session_id = 12345,
-    .group_id = 12345,
     .ppid = 12345,
     .original_ppid = 12345,
+    .group_id = 12345,
+    .session_id = 12345,
+    .codesigning_flags = 570509313,
     .is_platform_binary = false,
+    .is_es_client = true,
+    .executable = &otherBinary,
   };
   es_event_unlink_t unlink_event = {.target = &dbFile};
   es_events_t event = {.unlink = unlink_event};
   es_message_t m = {
     .version = 4,
-    .event_type = ES_EVENT_TYPE_AUTH_UNLINK,
-    .event = event,
     .mach_time = DISPATCH_TIME_NOW,
-    .action_type = ES_ACTION_TYPE_AUTH,
     .deadline = DISPATCH_TIME_FOREVER,
     .process = &proc,
     .seq_num = 1337,
+    .action_type = ES_ACTION_TYPE_AUTH,
+    .event_type = ES_EVENT_TYPE_AUTH_UNLINK,
+    .event = event,
   };
 
   [mockES triggerHandler:&m];
@@ -216,33 +215,33 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
     es_file_t dbFile = {.path = MakeStringToken(testPath)};
 
     es_event_rename_t renameEvent = {
-      .destination_type = ES_DESTINATION_TYPE_EXISTING_FILE,
       .source = &otherFile,
+      .destination_type = ES_DESTINATION_TYPE_EXISTING_FILE,
       .destination = {.existing_file = &dbFile},
     };
 
     es_file_t otherBinary = {.path = MakeStringToken(@"somebinary")};
     es_process_t proc = {
-      .executable = &otherBinary,
-      .is_es_client = false,
-      .codesigning_flags = 570509313,
-      .session_id = 12345,
-      .group_id = 12345,
       .ppid = 12345,
       .original_ppid = 12345,
+      .group_id = 12345,
+      .session_id = 12345,
+      .codesigning_flags = 570509313,
       .is_platform_binary = false,
+      .is_es_client = false,
+      .executable = &otherBinary,
     };
 
     es_events_t event = {.rename = renameEvent};
     es_message_t m = {
       .version = 4,
-      .event_type = ES_EVENT_TYPE_AUTH_RENAME,
-      .event = event,
       .mach_time = DISPATCH_TIME_NOW,
-      .action_type = ES_ACTION_TYPE_AUTH,
       .deadline = DISPATCH_TIME_FOREVER,
       .process = &proc,
       .seq_num = 1337,
+      .action_type = ES_ACTION_TYPE_AUTH,
+      .event_type = ES_EVENT_TYPE_AUTH_RENAME,
+      .event = event,
     };
     [mockES triggerHandler:&m];
 
@@ -289,26 +288,26 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
 
     es_file_t otherBinary = {.path = MakeStringToken(@"somebinary")};
     es_process_t proc = {
-      .executable = &otherBinary,
-      .is_es_client = false,
-      .codesigning_flags = 570509313,
-      .session_id = 12345,
-      .group_id = 12345,
       .ppid = 12345,
       .original_ppid = 12345,
+      .group_id = 12345,
+      .session_id = 12345,
+      .codesigning_flags = 570509313,
       .is_platform_binary = false,
+      .is_es_client = false,
+      .executable = &otherBinary,
     };
 
     es_events_t event = {.rename = renameEvent};
     es_message_t m = {
       .version = 4,
-      .event_type = ES_EVENT_TYPE_AUTH_RENAME,
-      .event = event,
       .mach_time = DISPATCH_TIME_NOW,
-      .action_type = ES_ACTION_TYPE_AUTH,
       .deadline = DISPATCH_TIME_FOREVER,
       .process = &proc,
       .seq_num = 1337,
+      .action_type = ES_ACTION_TYPE_AUTH,
+      .event_type = ES_EVENT_TYPE_AUTH_RENAME,
+      .event = event,
     };
     [mockES triggerHandler:&m];
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
@@ -123,6 +123,7 @@ const NSString *const kRulesDBPath = @"/private/var/db/santa/rules.db";
       .codesigning_flags = 570509313,
       .is_platform_binary = false,
       .is_es_client = false,
+      .executable = &otherBinary,
     };
     es_event_unlink_t unlink_event = {.target = &dbFile};
     es_events_t event = {.unlink = unlink_event};

--- a/Source/santad/SNTApplicationTest.m
+++ b/Source/santad/SNTApplicationTest.m
@@ -85,14 +85,14 @@
   NSString *binaryPath = [NSString pathWithComponents:@[ testPath, binaryName ]];
   es_file_t binary = {.path = MakeStringToken(binaryPath)};
   es_process_t proc = {
-    .executable = &binary,
-    .is_es_client = false,
-    .codesigning_flags = 570509313,
-    .session_id = 12345,
-    .group_id = 12345,
     .ppid = 12345,
     .original_ppid = 12345,
+    .group_id = 12345,
+    .session_id = 12345,
+    .codesigning_flags = 570509313,
     .is_platform_binary = false,
+    .is_es_client = false,
+    .executable = &binary,
   };
   es_event_exec_t exec_event = {
     .target = &proc,
@@ -101,12 +101,12 @@
   es_message_t m = {
     .version = 4,
     .mach_time = 181576143417379,
-    .event_type = ES_EVENT_TYPE_AUTH_EXEC,
-    .event = event,
-    .action_type = ES_ACTION_TYPE_AUTH,
     .deadline = DISPATCH_TIME_FOREVER,
     .process = &proc,
     .seq_num = 1,
+    .action_type = ES_ACTION_TYPE_AUTH,
+    .event_type = ES_EVENT_TYPE_AUTH_EXEC,
+    .event = event,
   };
 
   [mockES triggerHandler:&m];


### PR DESCRIPTION
This PR enables -Werror -Wall on our build rules and fixes the following warnings:
*  Corrected signed/unsigned int conversions in SNTPrefixTree and Santacache
*  Nullability annotations to the rest of EndpointSecurityTestUtil
*  Reorder init lists in SNTEndpointSecurityManagerTest and SNTApplicationTest
*  Add annotations for "unused" (actually used) variables in SNTEndpointSecurityManagerTest

This should bring us in-line with internal warnings.