### PR TITLE
Project: remove py2 forcing, drop deprecation warnings back to warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 build --apple_generate_dsym --define=apple.propagate_embedded_extra_outputs=yes
-build --host_force_python=PY2
 
 build --copt=-Werror
 build --copt=-Wall
+build --copt=-Wno-error=deprecated-declarations


### PR DESCRIPTION
We still want to see deprecated declaration warnings but they shouldn't cause builds to fail as often it's not possible to migrate immediately.