### PR TITLE
Upgrade bazel_rules_apple to 0.31.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.21.2",
+    tag = "0.31.3",
 )
 
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")


### PR DESCRIPTION
Prior to https://github.com/bazelbuild/rules_apple/pull/1191, the macOS test runner's architecture is hardcoded to x86_64. This should let us run unit tests on M1 macs.