### PR TITLE
Raise the timeout delay for tests

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
@@ -86,7 +86,7 @@ const NSString *const kBenignPath = @"/some/other/path";
 
   [mockES triggerHandler:&m];
 
-  [self waitForExpectationsWithTimeout:10.0
+  [self waitForExpectationsWithTimeout:30.0
                                handler:^(NSError *error) {
                                  if (error) {
                                    XCTFail(@"Santa auth test timed out without receiving two "
@@ -147,7 +147,7 @@ const NSString *const kBenignPath = @"/some/other/path";
     };
     [mockES triggerHandler:&m];
 
-    [self waitForExpectationsWithTimeout:10.0
+    [self waitForExpectationsWithTimeout:30.0
                                  handler:^(NSError *error) {
                                    if (error) {
                                      XCTFail(@"Santa auth test timed out with error: %@", error);
@@ -199,7 +199,7 @@ const NSString *const kBenignPath = @"/some/other/path";
   };
 
   [mockES triggerHandler:&m];
-  [self waitForExpectationsWithTimeout:10.0
+  [self waitForExpectationsWithTimeout:30.0
                                handler:^(NSError *error) {
                                  if (error) {
                                    XCTFail(@"Santa auth test timed out with error: %@", error);
@@ -261,7 +261,7 @@ const NSString *const kBenignPath = @"/some/other/path";
     };
     [mockES triggerHandler:&m];
 
-    [self waitForExpectationsWithTimeout:10.0
+    [self waitForExpectationsWithTimeout:30.0
                                  handler:^(NSError *error) {
                                    if (error) {
                                      XCTFail(@"Santa auth test timed out with error: %@", error);
@@ -334,7 +334,7 @@ const NSString *const kBenignPath = @"/some/other/path";
     };
     [mockES triggerHandler:&m];
 
-    [self waitForExpectationsWithTimeout:10.0
+    [self waitForExpectationsWithTimeout:30.0
                                  handler:^(NSError *error) {
                                    if (error) {
                                      XCTFail(@"Santa auth test timed out with error: %@", error);

--- a/Source/santad/SNTApplicationTest.m
+++ b/Source/santad/SNTApplicationTest.m
@@ -63,7 +63,7 @@
     [santaInit fulfill];
   });
 
-  [self waitForExpectationsWithTimeout:5.0
+  [self waitForExpectationsWithTimeout:30.0
                                handler:^(NSError *error) {
                                  if (error) {
                                    XCTFail(@"Santa's subscription to EndpointSecurity timed out "
@@ -104,7 +104,7 @@
   es_events_t event = {.exec = exec_event};
   es_message_t m = {
     .version = 4,
-    .mach_time = 181576143417379,
+    .mach_time = DISPATCH_TIME_NOW,
     .deadline = DISPATCH_TIME_FOREVER,
     .process = &proc,
     .seq_num = 1,
@@ -116,7 +116,7 @@
   [mockES triggerHandler:&m];
 
   [self
-    waitForExpectationsWithTimeout:5.0
+    waitForExpectationsWithTimeout:30.0
                            handler:^(NSError *error) {
                              if (error) {
                                XCTFail(


### PR DESCRIPTION
These tests are flaking on internal forge runners. Maybe raising the timeout duration to a less aggressive value will help with this?

