### PR TITLE
Add entitlements to the santad and Santa build rules

### DIFF
--- a/Source/santa/BUILD
+++ b/Source/santa/BUILD
@@ -55,6 +55,7 @@ macos_application(
     bundle_name = "Santa",
     infoplists = ["Info.plist"],
     minimum_os_version = "10.9",
+    entitlements = "Santa.app.entitlements",
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Dev.provisionprofile",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -93,6 +93,7 @@ macos_bundle(
     infoplists = ["Info.plist"],
     linkopts = ["-execute"],
     minimum_os_version = "10.9",
+    entitlements = "com.google.santa.daemon.systemextension.entitlements",
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Daemon_Dev.provisionprofile",

--- a/Source/santad/com.google.santa.daemon.systemextension.entitlements
+++ b/Source/santad/com.google.santa.daemon.systemextension.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.application-identifier</key>
-	<string>$(TeamIdentifierPrefix)com.google.santa.daemon</string>
+	<string>com.google.santa.daemon</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>EQHXZ8M8AV</string>
 	<key>com.apple.developer.endpoint-security.client</key>


### PR DESCRIPTION
The build of Santa generated by --SANTA_BUILD_TYPE=ci currently can't actually get loaded, since the build doesn't include either of the entitlements we need. Internally, we inadvertently avoid this entire problem because the Santa provisionprofile includes the appropriate entitlements.