### PR TITLE
Explicitly include the TeamIdentifierPrefix to santad's entitlement

### DIFF
--- a/Source/santad/com.google.santa.daemon.systemextension.entitlements
+++ b/Source/santad/com.google.santa.daemon.systemextension.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.application-identifier</key>
-	<string>com.google.santa.daemon</string>
+	<string>EQHXZ8M8AV.com.google.santa.daemon</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>EQHXZ8M8AV</string>
 	<key>com.apple.developer.endpoint-security.client</key>


### PR DESCRIPTION
The TeamIdentifierPrefix is required, but bazel fails to fill in `$(TeamIdentifierPrefix)` when using the `entitlements` parameter in a rule. 

We can just avoid this problem by explicitly filling it in instead.