### PR TITLE
Include an integration test setup and fixture with moroz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ CoverageData/*
 *.tulsiconf-user
 xcuserdata
 tulsigen-*
+*.crt
+*.key
+*.pem
+*.p12
+*.keychain

--- a/Source/santa/BUILD
+++ b/Source/santa/BUILD
@@ -56,6 +56,11 @@ macos_application(
     infoplists = ["Info.plist"],
     minimum_os_version = "10.9",
     entitlements = "Santa.app.entitlements",
+    codesignopts = [
+        "--timestamp",
+        "--force",
+        "--options library,kill,runtime",
+    ],
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Dev.provisionprofile",

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -84,6 +84,11 @@ macos_command_line_application(
     bundle_id = "com.google.santa.ctl",
     infoplists = ["Info.plist"],
     minimum_os_version = "10.9",
+    codesignopts = [
+        "--timestamp",
+        "--force",
+        "--options library,kill,runtime",
+    ],
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":santactl_lib"],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -94,6 +94,11 @@ macos_bundle(
     linkopts = ["-execute"],
     minimum_os_version = "10.9",
     entitlements = "com.google.santa.daemon.systemextension.entitlements",
+    codesignopts = [
+        "--timestamp",
+        "--force",
+        "--options library,kill,runtime",
+    ],
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Daemon_Dev.provisionprofile",

--- a/Source/santad/com.google.santa.daemon.systemextension.entitlements
+++ b/Source/santad/com.google.santa.daemon.systemextension.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.application-identifier</key>
-	<string>EQHXZ8M8AV.com.google.santa.daemon</string>
-	<key>com.apple.developer.team-identifier</key>
-	<string>EQHXZ8M8AV</string>
 	<key>com.apple.developer.endpoint-security.client</key>
 	<true/>
 </dict>

--- a/Testing/build_and_sign.sh
+++ b/Testing/build_and_sign.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+SANTAD_PATH=Santa.app/Contents/Library/SystemExtensions/com.google.santa.daemon.systemextension/Contents/MacOS/com.google.santa.daemon
+SANTA_BIN_PATH=Santa.app/Contents/MacOS
+SIGNING_IDENTITY="localhost"
+
+function main() {
+    sudo bazel build --ios_signing_cert_name=$SIGNING_IDENTITY --apple_generate_dsym -c opt --define=SANTA_BUILD_TYPE=ci --define=apple.propagate_embedded_extra_outputs=yes --macos_cpus=x86_64,arm64 //:release
+
+    echo "> Build complete, installing santa"
+    TMP_DIR=$(mktemp -d)
+    tar xvf $GIT_ROOT/bazel-bin/santa-*.tar.gz -C $TMP_DIR
+
+    for bin in $TMP_DIR/binaries/$SANTA_BIN_PATH/* $TMP_DIR/binaries/$SANTAD_PATH; do
+        sudo codesign --prefix=EQHXZ8M8AV --preserve-metadata=entitlements -fs $SIGNING_IDENTITY --timestamp --options library,kill,runtime $bin
+    done
+
+    echo "> Running install.sh"
+    (
+        cd $TMP_DIR
+        sudo ./conf/install.sh
+    )
+}
+
+main $@
+exit $?

--- a/Testing/com.google.santa.mobileconfig
+++ b/Testing/com.google.santa.mobileconfig
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.google.santa</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>BannedBlockMessage</key>
+                                <string>This application has been blocked from executing because it has been banned.</string>
+								<key>EnableForkAndExitLogging</key>
+								<true/>
+								<key>EnablePageZeroProtection</key>
+								<false/>
+								<key>EnableSystemExtension</key>
+								<true/>
+								<key>EventDetailText</key>
+								<string>Open in moroz...</string>
+								<key>EventDetailURL</key>
+                                <string>https://localhost:8080/v1/santa/ruledownload/%file_sha%</string>
+                                <key>MachineOwner</key>
+                                <string>SomeOwner</string>
+								<key>MachineID</key>
+								<string>00000000-0000-0000-0000-000000000000</string>
+                                <key>ClientAuthCertificateCN</key>
+                                <string>santa</string>
+								<key>SyncBaseURL</key>
+								<string>https://localhost:8080/v1/santa/</string>
+								<key>UnknownBlockMessage</key>
+								<string>This application has been blocked from executing&lt;br /&gt;because its trustworthiness cannot be determined.</string>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>f5177388-e5b0-11eb-b425-7831c1b9bca4</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>e395bf8e-e5b0-11eb-83e4-7831c1b9bca5</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Manages Santa's settings</string>
+	<key>PayloadDisplayName</key>
+	<string>Santa Configuration 2</string>
+	<key>PayloadIdentifier</key>
+	<string>com.google.santa</string>
+	<key>PayloadOrganization</key>
+	<string>Google LLC</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>278163C6-FC14-4AEB-9888-8283FA588435</string>
+	<key>PayloadVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Testing/global.toml
+++ b/Testing/global.toml
@@ -1,0 +1,14 @@
+client_mode = "MONITOR"
+batch_size = 100
+
+[[rules]]
+rule_type = "BINARY"
+policy = "BLACKLIST"
+sha256 = "432ad7907dbcfb2ddc0552a398b2c78539c1a230468d87f914f650e061756dbd"
+custom_msg = "deny bad test binary"
+
+[[rules]]
+rule_type = "CERTIFICATE"
+policy = "BLACKLIST"
+sha256 = "6a7767fb80ac25fd073db8302cb50bea36512808e045bbc3768659bf503d4d31"
+custom_msg = "deny bad test self-signed cert"

--- a/Testing/init_dev_certs.sh
+++ b/Testing/init_dev_certs.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+GIT_ROOT=$(git rev-parse --show-toplevel)
+CNF_PATH=$GIT_ROOT/Testing/openssl.cnf
+
+openssl genrsa -out ./santa.key 2048
+openssl rsa -in ./santa.key -out ./santa.key
+openssl req -new -key ./santa.key -out ./santa.csr -config $CNF_PATH
+openssl x509 -req -days 10 -in ./santa.csr -signkey ./santa.key -out ./santa.crt -extfile $CNF_PATH -extensions codesign
+openssl pkcs12 -export -out santa.p12 -inkey santa.key -in santa.crt -password pass:santa
+
+KEYCHAIN="/Library/Keychains/System.keychain"
+sudo security import ./santa.p12 -k $KEYCHAIN -A -P santa
+sudo security add-trusted-cert -d -r trustRoot -k $KEYCHAIN santa.crt

--- a/Testing/openssl.cnf
+++ b/Testing/openssl.cnf
@@ -1,0 +1,22 @@
+[ ca ]
+default_ca = CA_default
+
+[ req ]
+prompt = no
+distinguished_name    = req_distinguished_name
+
+[ req_distinguished_name ]
+commonName = localhost
+countryName = US
+organizationName = Google LLC
+OU=EQHXZ8M8AV
+name = santa
+
+[ codesign ]
+keyUsage = digitalSignature
+extendedKeyUsage = codeSigning
+
+[ v3_ca ]
+basicConstraints = critical,CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always

--- a/Testing/reset.sh
+++ b/Testing/reset.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+killall moroz
+security delete-identity -c "localhost"
+rm -rf /Applications/Santa.app
+systemextensionsctl reset

--- a/Testing/start_env.sh
+++ b/Testing/start_env.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -e
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+SANTA_BIN_PATH=Santa.app/Contents/MacOS
+SIGNING_IDENTITY="localhost"
+
+function setup_certs() {
+    echo "> Creating codesigning certs and keys"
+    $GIT_ROOT/Testing/init_dev_certs.sh
+}
+
+function run_moroz() {
+    echo "> Running moroz in the background"
+    go get github.com/groob/moroz/cmd/moroz
+    ~/go/bin/moroz -configs="$GIT_ROOT/Testing/global.toml" -tls-key santa.key -tls-cert santa.crt &
+}
+
+function install_profile() {
+    echo "> Installing mobileconfig"
+    # The `profiles` tool has been deprecated as of Big Sur. Ugly workaround instead:
+    sudo open /System/Library/PreferencePanes/Profiles.prefPane "$GIT_ROOT/Testing/com.google.santa.mobileconfig"
+}
+
+function build_install_santa() {
+    sudo systemextensionsctl developer on
+    echo "> Building and signing Santa"
+    $GIT_ROOT/Testing/build_and_sign.sh
+    systemextensionsctl list
+
+    # install.sh _should_ already start the system extension, but we want to
+    # explicitly call `--load-system-extension` again to actually log loading
+    # failures.
+    echo "> Install complete, attempting to explicitly start the santa systemextension"
+    /Applications/$SANTA_BIN_PATH/Santa --load-system-extension
+    systemextensionsctl list
+}
+
+function main() {
+    install_profile
+    setup_certs
+    run_moroz
+    build_install_santa
+}
+
+main $@
+exit $?


### PR DESCRIPTION
This PR includes several scripts for building and setting up an integration test environment that doesn't require the Santa provisionprofile. This sets up an environment such that a build of santad with `--define=SANTA_BUILD_TYPE=ci` can actually load. 

I also tested whether the entitlements file change for santad affects our internal provisionfile - the entitlements in Santa_Daemon_Dev.provisionprofile will take priority over the `entitlements` build rule.