### PR TITLE
Added an XPC interface for the Metric Service

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -167,6 +167,15 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTXPCMetricServiceInterface",
+    srcs = ["SNTXPCMetricServiceInterface.m"],
+    hdrs = ["SNTXPCMetricServiceInterface.h"],
+    deps = [
+        "@MOLXPCConnection",
+    ],
+)
+
+objc_library(
     name = "SNTXPCControlInterface",
     srcs = ["SNTXPCControlInterface.m"],
     hdrs = ["SNTXPCControlInterface.h"],

--- a/Source/common/SNTXPCMetricServiceInterface.h
+++ b/Source/common/SNTXPCMetricServiceInterface.h
@@ -1,0 +1,50 @@
+/// Copyright 2021 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import <MOLXPCConnection/MOLXPCConnection.h>
+
+///  Protocol implemented by the metric service and utilized by santad
+///  exporting metrics to a monitoring system.
+@protocol SNTMetricServiceXPC
+
+///
+///  @param metrics The current metric/counter values serialized to an NSDictionary.
+///
+- (void)exportForMonitoring:(NSDictionary *)metrics;
+
+@end
+
+@interface SNTXPCMetricServiceInterface : NSObject
+
+///
+///  Returns an initialized NSXPCInterface for the SNTMetricServiceXPC protocol.
+///  Ensures any methods that accept custom classes as arguments are set-up
+///  before returning.
+///
++ (NSXPCInterface *)metricServiceInterface;
+
+///
+///  Returns the MachService ID for this service.
+///
++ (NSString *)serviceID;
+
+///
+///  Retrieve a pre-configured MOLXPCConnection for communicating with santametricservice.
+///  Connections just needs any handlers set and then can be resumed and used.
+///
++ (MOLXPCConnection *)configuredConnection;
+
+@end

--- a/Source/common/SNTXPCMetricServiceInterface.m
+++ b/Source/common/SNTXPCMetricServiceInterface.m
@@ -1,0 +1,42 @@
+/// Copyright 2021 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import "Source/common/SNTXPCMetricServiceInterface.h"
+
+
+@implementation SNTXPCMetricServiceInterface
+
++ (NSXPCInterface *)metricServiceInterface {
+  NSXPCInterface *r = [NSXPCInterface interfaceWithProtocol:@protocol(SNTMetricServiceXPC)];
+
+  [r setClasses:[NSSet setWithObjects:[NSDictionary class], nil]
+      forSelector:@selector(exportForMonitoring:)
+    argumentIndex:0
+          ofReply:NO];
+
+  return r;
+}
+
++ (NSString *)serviceID {
+  return @"com.google.santa.metricservice";
+}
+
++ (MOLXPCConnection *)configuredConnection {
+  MOLXPCConnection *c = [[MOLXPCConnection alloc] initClientWithName:[self serviceID]
+                                                          privileged:NO];
+  c.remoteInterface = [self metricServiceInterface];
+  return c;
+}
+
+@end


### PR DESCRIPTION
Added an XPC interface for the SNTMetric Service this follows the internal design doc.

The protocol for the service adds a single method `- (void)exportForMonitoring:(NSDictionary *)metrics;` The metrics dictionary is expected to be exported from the SNTMetricSet.

This is a first in a series of related PRs.