### PR TITLE
Add initial configuration options for barebones metric service

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -91,6 +91,12 @@ typedef NS_ENUM(NSInteger, SNTEventLogType) {
   SNTEventLogTypeFilelog,
 };
 
+typedef NS_ENUM(NSInteger, SNTMetricFormatType) {
+  SNTMetricFormatTypeUnknown,
+  SNTMetricFormatTypeRawJSON,
+  SNTMetricFormatTypeJSON,
+};
+
 static const char *kKextPath = "/Library/Extensions/santa-driver.kext";
 static const char *kSantaDPath =
   "/Applications/Santa.app/Contents/Library/SystemExtensions/"

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -382,7 +382,7 @@
 @property(readonly, nonatomic) SNTMetricFormatType metricFormat;
 
 ///
-/// URL describing where metrics are exported, defaults to "".
+/// URL describing where metrics are exported, defaults to nil.
 ///
 @property(readonly, nonatomic) NSURL *metricURL;
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -377,9 +377,9 @@
 @property(readonly, nonatomic) BOOL exportMetrics;
 
 ///
-/// String format for to export metrics as, defaults to "".
+/// Format to export Metrics as.
 ///
-@property(readonly, nonatomic) NSString *metricFormat;
+@property(readonly, nonatomic) SNTMetricFormatType metricFormat;
 
 ///
 /// URL describing where metrics are exported, defaults to "".

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -372,6 +372,11 @@
 @property(readonly, nonatomic) BOOL fcmEnabled;
 
 ///
+/// True if metricsExportFormat and metricsFile path are all set. Defaults to false.
+///
+@property(readonly, nonatomic) BOOL exportMetrics;
+
+///
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -372,9 +372,20 @@
 @property(readonly, nonatomic) BOOL fcmEnabled;
 
 ///
-/// True if metricsExportFormat and metricsFile path are all set. Defaults to false.
+/// True if metricsFormat and metricsURL are set. False otherwise.
 ///
 @property(readonly, nonatomic) BOOL exportMetrics;
+
+///
+/// String format for to export metrics as, defaults to "".
+///
+@property(readonly, nonatomic) NSString *metricFormat;
+
+///
+/// URL describing where metrics are exported, defaults to "".
+///
+@property(readonly, nonatomic) NSURL *metricURL;
+
 
 ///
 ///  Retrieve an initialized singleton configurator object using the default file path.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -102,7 +102,7 @@ static NSString *const kBlockedPathRegexKey = @"BlockedPathRegex";
 static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 
 // TODO(markowsky): move these to sync server only.
-static NSString *const kMetricsFormat = @"ExportMetricsFormat";
+static NSString *const kMetricsFormat = @"MetricsFormat";
 static NSString *const kMetricsFile = @"ExportMetricsFile";
 
 // The keys managed by a sync server.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -102,6 +102,8 @@ static NSString *const kBlockedPathRegexKey = @"BlockedPathRegex";
 static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 
 // TODO(markowsky): move these to sync server only.
+// Valid values for kMetricsFormat should be rawjson, and json. 
+// TODO(markowsky): add support for prometheus.
 static NSString *const kMetricsFormat = @"MetricsFormat";
 static NSString *const kMetricsURL = @"MetricsURL";
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -102,10 +102,8 @@ static NSString *const kBlockedPathRegexKey = @"BlockedPathRegex";
 static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 
 // TODO(markowsky): move these to sync server only.
-// Valid values for kMetricsFormat should be rawjson, and json. 
-// TODO(markowsky): add support for prometheus.
-static NSString *const kMetricsFormat = @"MetricsFormat";
-static NSString *const kMetricsURL = @"MetricsURL";
+static NSString *const kMetricFormat = @"MetricFormat";
+static NSString *const kMetricURL = @"MetricURL";
 
 // The keys managed by a sync server.
 static NSString *const kFullSyncLastSuccess = @"FullSyncLastSuccess";
@@ -177,8 +175,8 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kFCMProject : string,
       kFCMEntity : string,
       kFCMAPIKey : string,
-      kMetricsFormat : number,
-      kMetricsURL : string,
+      kMetricFormat : number,
+      kMetricURL : string,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -668,12 +666,12 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 /// otherwise.
 ///
 - (BOOL) exportMetrics {
-  return self.configState[kMetricsFormat] != SNTMetricFormatTypeUnknown &&
-    ![self.configState[kMetricsURL] isEqualToString:@""];
+  return self.configState[kMetricFormat] != SNTMetricFormatTypeUnknown &&
+    ![self.configState[kMetricURL] isEqualToString:@""];
 }
 
-- (SNTMetricFormatType)metricsFormat {
-  switch ([self.configState[kMetricsFormat] longLongValue]) {
+- (SNTMetricFormatType)metricFormat {
+  switch ([self.configState[kMetricFormat] longLongValue]) {
     case SNTMetricFormatTypeRawJSON:
       return SNTMetricFormatTypeRawJSON;
     case SNTMetricFormatTypeJSON:
@@ -683,8 +681,8 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   }
 }
 
-- (NSURL *)metricsURL {
-  return [NSURL URLWithString:self.configState[kMetricsURL]];
+- (NSURL *)metricURL {
+  return [NSURL URLWithString:self.configState[kMetricURL]];
 }
 
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -177,7 +177,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kFCMProject : string,
       kFCMEntity : string,
       kFCMAPIKey : string,
-      kMetricsFormat : string,
+      kMetricsFormat : number,
       kMetricsURL : string,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
@@ -668,18 +668,19 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 /// otherwise.
 ///
 - (BOOL) exportMetrics {
-  NSArray<NSString *> *metricKeys = @[kMetricsFormat, kMetricsURL];
-
-  for (NSString *key in metricKeys){
-    if ([self.configState[key] isEqualToString:@""]) {
-    	return NO;
-    }
-  }
-  return YES;
+  return self.configState[kMetricsFormat] != SNTMetricFormatTypeUnknown &&
+    ![self.configState[kMetricsURL] isEqualToString:@""];
 }
 
-- (NSString *)metricsFormat {
-  return self.configState[kMetricsFormat];
+- (SNTMetricFormatType)metricsFormat {
+  switch ([self.configState[kMetricsFormat] longLongValue]) {
+    case SNTMetricFormatTypeRawJSON:
+      return SNTMetricFormatTypeRawJSON;
+    case SNTMetricFormatTypeJSON:
+      return SNTMetricFormatTypeJSON;
+    default:
+      return SNTMetricFormatTypeUnknown;
+  }
 }
 
 - (NSURL *)metricsURL {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -103,7 +103,7 @@ static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 
 // TODO(markowsky): move these to sync server only.
 static NSString *const kMetricsFormat = @"MetricsFormat";
-static NSString *const kMetricsFile = @"ExportMetricsFile";
+static NSString *const kMetricsURL = @"MetricsURL";
 
 // The keys managed by a sync server.
 static NSString *const kFullSyncLastSuccess = @"FullSyncLastSuccess";

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1,4 +1,4 @@
-/// Copyright 2015 Google Inc. All rights reserved.
+/// Copyright 2021 Google Inc. All rights reserved.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -101,6 +101,10 @@ static NSString *const kAllowedPathRegexKeyDeprecated = @"WhitelistRegex";
 static NSString *const kBlockedPathRegexKey = @"BlockedPathRegex";
 static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 
+// TODO(markowsky): move these to sync server only.
+static NSString *const kMetricsFormat = @"ExportMetricsFormat";
+static NSString *const kMetricsFile = @"ExportMetricsFile";
+
 // The keys managed by a sync server.
 static NSString *const kFullSyncLastSuccess = @"FullSyncLastSuccess";
 static NSString *const kRuleSyncLastSuccess = @"RuleSyncLastSuccess";
@@ -171,6 +175,8 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kFCMProject : string,
       kFCMEntity : string,
       kFCMAPIKey : string,
+      kMetricsFormat : string,
+      kMetricsFile : string,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -652,6 +658,22 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (BOOL)fcmEnabled {
   return (self.fcmProject.length && self.fcmEntity.length && self.fcmAPIKey.length);
+}
+
+
+///
+/// Returns YES if all of the necessary options are set to export metrics, NO
+/// otherwise.
+///
+- (BOOL) exportMetrics {
+  NSArray<NSString *> *metricKeys = @[kMetricsFormat, kMetricsFile];
+
+  for (NSString *key in metricKeys){
+    if ([self.configState[key] isEqualToString:@""]) {
+    	return NO;
+    }
+  }
+  return YES;
 }
 
 #pragma mark Private

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -666,7 +666,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 /// otherwise.
 ///
 - (BOOL) exportMetrics {
-  NSArray<NSString *> *metricKeys = @[kMetricsFormat, kMetricsFile];
+  NSArray<NSString *> *metricKeys = @[kMetricsFormat, kMetricsURL];
 
   for (NSString *key in metricKeys){
     if ([self.configState[key] isEqualToString:@""]) {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -678,6 +678,15 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return YES;
 }
 
+- (NSString *)metricsFormat {
+  return self.configState[kMetricsFormat];
+}
+
+- (NSURL *)metricsURL {
+  return [NSURL URLWithString:self.configState[kMetricsURL]];
+}
+
+
 #pragma mark Private
 
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -178,7 +178,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kFCMEntity : string,
       kFCMAPIKey : string,
       kMetricsFormat : string,
-      kMetricsFile : string,
+      kMetricsURL : string,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -175,7 +175,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kFCMProject : string,
       kFCMEntity : string,
       kFCMAPIKey : string,
-      kMetricFormat : number,
+      kMetricFormat : string,
       kMetricURL : string,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
@@ -660,31 +660,31 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return (self.fcmProject.length && self.fcmEntity.length && self.fcmAPIKey.length);
 }
 
-
 ///
 /// Returns YES if all of the necessary options are set to export metrics, NO
 /// otherwise.
 ///
-- (BOOL) exportMetrics {
-  return self.configState[kMetricFormat] != SNTMetricFormatTypeUnknown &&
-    ![self.configState[kMetricURL] isEqualToString:@""];
+- (BOOL)exportMetrics {
+  return [self metricFormat] != SNTMetricFormatTypeUnknown &&
+         ![self.configState[kMetricURL] isEqualToString:@""];
 }
 
 - (SNTMetricFormatType)metricFormat {
-  switch ([self.configState[kMetricFormat] longLongValue]) {
-    case SNTMetricFormatTypeRawJSON:
-      return SNTMetricFormatTypeRawJSON;
-    case SNTMetricFormatTypeJSON:
-      return SNTMetricFormatTypeJSON;
-    default:
-      return SNTMetricFormatTypeUnknown;
+  NSString *normalized = [self.configState[kMetricFormat] lowercaseString];
+  normalized = [normalized stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+  if ([normalized isEqualToString:@"rawjson"]) {
+    return SNTMetricFormatTypeRawJSON;
+  } else if ([normalized isEqualToString:@"json"]) {
+    return SNTMetricFormatTypeJSON;
+  } else {
+    return SNTMetricFormatTypeUnknown;
   }
 }
 
 - (NSURL *)metricURL {
   return [NSURL URLWithString:self.configState[kMetricURL]];
 }
-
 
 #pragma mark Private
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -47,6 +47,8 @@ Additionally, there are options that can be controlled by both.
 | EventLogType                  | String     | Defines how event logs are stored. Options are 1) syslog: Sent to ASL or ULS (if built with the 10.12 SDK or later). 2) filelog: Sent to a file on disk. Use EventLogPath to specify a path. Defaults to filelog      |
 | EventLogPath                  | String     | If EventLogType is set to filelog, EventLogPath will provide the path to save logs. Defaults to /var/db/santa/santa.log. If you change this value ensure you also update com.google.santa.newsyslog.conf with the new path.        |
 | EnableMachineIDDecoration     | Bool       | If YES, this appends the MachineID to the end of each log line. Defaults to NO.       |
+| MetricsFormat                 | String     | Format to export monitoring metrics as. Supported formats (rawJSON, json). |
+| MetricsURL                    | String     | URL describing where monitoring metrics should be exported.  |
 
 *overridable by the sync server: run `santactl status` to check the current
 running config

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -47,8 +47,8 @@ Additionally, there are options that can be controlled by both.
 | EventLogType                  | String     | Defines how event logs are stored. Options are 1) syslog: Sent to ASL or ULS (if built with the 10.12 SDK or later). 2) filelog: Sent to a file on disk. Use EventLogPath to specify a path. Defaults to filelog      |
 | EventLogPath                  | String     | If EventLogType is set to filelog, EventLogPath will provide the path to save logs. Defaults to /var/db/santa/santa.log. If you change this value ensure you also update com.google.santa.newsyslog.conf with the new path.        |
 | EnableMachineIDDecoration     | Bool       | If YES, this appends the MachineID to the end of each log line. Defaults to NO.       |
-| MetricsFormat                 | String     | Format to export monitoring metrics as. Supported formats (rawJSON, json). |
-| MetricsURL                    | String     | URL describing where monitoring metrics should be exported.  |
+| MetricFormat                 | Integer     | Format to export metrics as 0 = None, 1 = Raw JSON blob, 2 = JSON one metric per line. Defaults to 0. |
+| MetricURL                    | String     | URL describing where monitoring metrics should be exported.  |
 
 *overridable by the sync server: run `santactl status` to check the current
 running config

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -47,7 +47,7 @@ Additionally, there are options that can be controlled by both.
 | EventLogType                  | String     | Defines how event logs are stored. Options are 1) syslog: Sent to ASL or ULS (if built with the 10.12 SDK or later). 2) filelog: Sent to a file on disk. Use EventLogPath to specify a path. Defaults to filelog      |
 | EventLogPath                  | String     | If EventLogType is set to filelog, EventLogPath will provide the path to save logs. Defaults to /var/db/santa/santa.log. If you change this value ensure you also update com.google.santa.newsyslog.conf with the new path.        |
 | EnableMachineIDDecoration     | Bool       | If YES, this appends the MachineID to the end of each log line. Defaults to NO.       |
-| MetricFormat                 | Integer     | Format to export metrics as 0 = None, 1 = Raw JSON blob, 2 = JSON one metric per line. Defaults to 0. |
+| MetricFormat                 | String     | Format to export metrics as, supported formats are "rawjson" for a single JSON blob and "json" for one metric per line. Defaults to "". |
 | MetricURL                    | String     | URL describing where monitoring metrics should be exported.  |
 
 *overridable by the sync server: run `santactl status` to check the current


### PR DESCRIPTION
This PR adds the initial configuration options for the bare bones.

Specifically it adds the following three things:

| Option | Meaning |
|---|---|
| **MetricFormat** |  a string describing how metrics should be formatted. Supported options ("raw json" for a single JSON object containing all metrics, "json" for JSON metrics one metric per line.  |
|  **MetricURL** | a string URL describing  where to export the formatted metrics. |
| **exportMetrics** | a helper function in SNTConfigurator that checks if all necessary keys are set and metrics should be exported. | 

Part of #563.