### PR TITLE
Refactored metric service tests to use a common helper

### DIFF
--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -29,6 +29,7 @@ santa_unit_test(
     srcs = ["SNTMetricServiceTest.m"],
     deps = [
         ":SNTMetricServiceLib",
+        "//Source/santametricservice/Formats:SNTMetricFormatTestHelper",
         "@OCMock",
     ],
 )

--- a/Source/santametricservice/Formats/BUILD
+++ b/Source/santametricservice/Formats/BUILD
@@ -11,6 +11,17 @@ objc_library(
 )
 
 objc_library(
+    name = "SNTMetricFormatTestHelper",
+    srcs = [
+        "SNTMetricFormatTestHelper.m",
+    ],
+    hdrs = ["SNTMetricFormatTestHelper.h"],
+    deps = [
+        "//Source/common:SNTMetricSet",
+    ],
+)
+
+objc_library(
     name = "SNTMetricRawJSONFormat",
     srcs = [
         "SNTMetricFormat.h",
@@ -30,8 +41,8 @@ santa_unit_test(
     ],
     structured_resources = glob(["testdata/**"]),
     deps = [
+        ":SNTMetricFormatTestHelper",
         ":SNTMetricRawJSONFormat",
-        "//Source/common:SNTMetricSet",
     ],
 )
 

--- a/Source/santametricservice/Formats/SNTMetricFormatTestHelper.h
+++ b/Source/santametricservice/Formats/SNTMetricFormatTestHelper.h
@@ -1,0 +1,19 @@
+/// Copyright 2021 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@interface SNTMetricFormatTestHelper : NSObject
++ (NSDictionary *)createValidMetricsDictionary;
+@end

--- a/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
+++ b/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
@@ -1,0 +1,94 @@
+/// Copyright 2021 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Source/common/SNTMetricSet.h"
+#import "Source/santametricservice/Formats/SNTMetricFormatTestHelper.h"
+
+@implementation SNTMetricFormatTestHelper
++ (NSDictionary *)convertDatesToFixedDateWithExportDict:(NSMutableDictionary *)exportDict {
+
+   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+   [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+   NSDate *fixedDate = [formatter dateFromString:@"2021-09-16T21:07:34.826Z"];
+
+   for (NSString *metricName in exportDict[@"metrics"]) {
+    NSMutableDictionary *metric = exportDict[@"metrics"][metricName];
+
+    for (NSString *field in metric[@"fields"]) {
+      NSMutableArray<NSMutableDictionary *> *values = metric[@"fields"][field];
+
+      [values enumerateObjectsUsingBlock:^(id object, NSUInteger index, BOOL *stop)  {
+          values[index][@"created"] = fixedDate;
+          values[index][@"last_updated"] = fixedDate;
+      }];
+    }
+  }
+
+  return exportDict;
+}
+
++ (NSDictionary *)createValidMetricsDictionary {
+  
+   SNTMetricSet *metricSet = [[SNTMetricSet alloc] initWithHostname:@"testHost"
+                                                          username:@"testUser"];
+
+  // Add constants
+  [metricSet addConstantStringWithName:@"/build/label"
+                              helpText:@"Software version running."
+                                 value:@"20210809.0.1"];
+  [metricSet addConstantBooleanWithName:@"/santa/using_endpoint_security_framework"
+                               helpText:@"Is santad using the endpoint security framework."
+                                  value:YES];
+  [metricSet addConstantIntegerWithName:@"/proc/birth_timestamp"
+                               helpText:@"Start time of this LogDumper instance, in microseconds "
+                                        @"since epoch"
+                                  value:(long long)(0x12345668910)];
+  // Add Metrics
+  SNTMetricCounter *c = [metricSet counterWithName:@"/santa/events"
+                                        fieldNames:@[ @"rule_type" ]
+                                          helpText:@"Count of events on the host"];
+
+  [c incrementForFieldValues:@[ @"binary" ]];
+  [c incrementBy:2 forFieldValues:@[ @"certificate" ]];
+
+  SNTMetricInt64Gauge *g = [metricSet int64GaugeWithName:@"/santa/rules"
+                                              fieldNames:@[ @"rule_type" ]
+                                                helpText:@"Number of rules."];
+
+  [g set:1 forFieldValues:@[ @"binary" ]];
+  [g set:3 forFieldValues:@[ @"certificate" ]];
+
+  // Add Metrics with callback
+  SNTMetricInt64Gauge *virtualMemoryGauge =
+    [metricSet int64GaugeWithName:@"/proc/memory/virtual_size"
+                       fieldNames:@[]
+                         helpText:@"The virtual memory size of this process."];
+
+  SNTMetricInt64Gauge *residentMemoryGauge =
+    [metricSet int64GaugeWithName:@"/proc/memory/resident_size"
+                       fieldNames:@[]
+                         helpText:@"The resident set siz of this process."];
+
+  [metricSet registerCallback:^(void) {
+    [virtualMemoryGauge set:987654321 forFieldValues:@[]];
+    [residentMemoryGauge set:123456789 forFieldValues:@[]];
+  }];
+
+  NSMutableDictionary *exportDict = [[metricSet export] mutableCopy];
+
+  return [SNTMetricFormatTestHelper convertDatesToFixedDateWithExportDict:exportDict];
+}
+@end

--- a/Source/santametricservice/Formats/SNTMetricRawJSONFormatTest.m
+++ b/Source/santametricservice/Formats/SNTMetricRawJSONFormatTest.m
@@ -1,125 +1,15 @@
 #import <XCTest/XCTest.h>
 
-#import "Source/common/SNTMetricSet.h"
+#import "Source/santametricservice/Formats/SNTMetricFormatTestHelper.h"
 #import "Source/santametricservice/Formats/SNTMetricRawJSONFormat.h"
-
-NSDictionary *validMetricsDict = nil;
 
 @interface SNTMetricRawJSONFormatTest : XCTestCase
 @end
 
 @implementation SNTMetricRawJSONFormatTest
 
-- (void)initializeValidMetricsDict {
-  NSDateFormatter *formatter = NSDateFormatter.new;
-  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
-  NSDate *fixedDate = [formatter dateFromString:@"2021-09-16T21:07:34.826Z"];
-
-  validMetricsDict = @{
-    @"root_labels" : @{@"hostname" : @"testHost", @"username" : @"testUser"},
-    @"metrics" : @{
-      @"/build/label" : @{
-        @"type" : @((int)SNTMetricTypeConstantString),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @"20210809.0.1"
-          } ]
-        }
-      },
-      @"/santa/events" : @{
-        @"type" : @((int)SNTMetricTypeCounter),
-        @"fields" : @{
-          @"rule_type" : @[
-            @{
-              @"value" : @"binary",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @1,
-            },
-            @{
-              @"value" : @"certificate",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @2,
-            },
-          ],
-        },
-      },
-      @"/santa/rules" : @{
-        @"type" : @((int)SNTMetricTypeGaugeInt64),
-        @"fields" : @{
-          @"rule_type" : @[
-            @{
-              @"value" : @"binary",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @1
-            },
-            @{
-              @"value" : @"certificate",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @3
-            }
-          ]
-        },
-      },
-      @"/santa/using_endpoint_security_framework" : @{
-        @"type" : @((int)SNTMetricTypeConstantBool),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @YES,
-          } ]
-        }
-      },
-      @"/proc/birth_timestamp" : @{
-        @"type" : @((int)SNTMetricTypeConstantInt64),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @1250999830800L,
-          } ]
-        },
-      },
-      @"/proc/memory/virtual_size" : @{
-        @"type" : @((int)SNTMetricTypeGaugeInt64),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @987654321,
-          } ]
-        }
-      },
-      @"/proc/memory/resident_size" : @{
-        @"type" : @((int)SNTMetricTypeGaugeInt64),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @123456789,
-          } ]
-        },
-      },
-    }
-  };
-}
-
-- (void)setUp {
-  [self initializeValidMetricsDict];
-}
-
 - (void)testMetricsConversionToJSON {
+  NSDictionary *validMetricsDict = [SNTMetricFormatTestHelper createValidMetricsDictionary];
   SNTMetricRawJSONFormat *formatter = [[SNTMetricRawJSONFormat alloc] init];
   NSError *err = nil;
   NSArray<NSData *> *output = [formatter convert:validMetricsDict error:&err];
@@ -151,6 +41,7 @@ NSDictionary *validMetricsDict = nil;
 
 - (void)testPassingANilOrNullErrorDoesNotCrash {
   SNTMetricRawJSONFormat *formatter = [[SNTMetricRawJSONFormat alloc] init];
+  NSDictionary *validMetricsDict = [SNTMetricFormatTestHelper createValidMetricsDictionary];
 
   NSArray<NSData *> *output = [formatter convert:validMetricsDict error:nil];
   output = [formatter convert:validMetricsDict error:NULL];

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -7,6 +7,7 @@
 
 #import <OCMock/OCMock.h>
 
+#import "Source/santametricservice/Formats/SNTMetricFormatTestHelper.h"
 #import "Source/santametricservice/SNTMetricService.h"
 
 NSDictionary *validMetricsDict = nil;
@@ -19,113 +20,7 @@ NSDictionary *validMetricsDict = nil;
 
 @implementation SNTMetricServiceTest
 
-- (void)initializeValidMetricsDict {
-  NSDateFormatter *formatter = NSDateFormatter.new;
-  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
-  NSDate *fixedDate = [formatter dateFromString:@"2021-09-16T21:07:34.826Z"];
-
-  validMetricsDict = @{
-    @"root_labels" : @{@"hostname" : @"testHost", @"username" : @"testUser"},
-    @"metrics" : @{
-      @"/build/label" : @{
-        @"type" : @((int)SNTMetricTypeConstantString),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @"20210809.0.1"
-          } ]
-        }
-      },
-      @"/santa/events" : @{
-        @"type" : @((int)SNTMetricTypeCounter),
-        @"fields" : @{
-          @"rule_type" : @[
-            @{
-              @"value" : @"binary",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @1,
-            },
-            @{
-              @"value" : @"certificate",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @2,
-            },
-          ],
-        },
-      },
-      @"/santa/rules" : @{
-        @"type" : @((int)SNTMetricTypeGaugeInt64),
-        @"fields" : @{
-          @"rule_type" : @[
-            @{
-              @"value" : @"binary",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @1
-            },
-            @{
-              @"value" : @"certificate",
-              @"created" : fixedDate,
-              @"last_updated" : fixedDate,
-              @"data" : @3
-            }
-          ]
-        },
-      },
-      @"/santa/using_endpoint_security_framework" : @{
-        @"type" : @((int)SNTMetricTypeConstantBool),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @YES,
-          } ]
-        }
-      },
-      @"/proc/birth_timestamp" : @{
-        @"type" : @((int)SNTMetricTypeConstantInt64),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @1250999830800L,
-          } ]
-        },
-      },
-      @"/proc/memory/virtual_size" : @{
-        @"type" : @((int)SNTMetricTypeGaugeInt64),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @987654321,
-          } ]
-        }
-      },
-      @"/proc/memory/resident_size" : @{
-        @"type" : @((int)SNTMetricTypeGaugeInt64),
-        @"fields" : @{
-          @"" : @[ @{
-            @"value" : @"",
-            @"created" : fixedDate,
-            @"last_updated" : fixedDate,
-            @"data" : @123456789,
-          } ]
-        },
-      },
-    }
-  };
-}
-
 - (void)setUp {
-  [self initializeValidMetricsDict];
   // create the configurator
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
@@ -194,6 +89,8 @@ NSDictionary *validMetricsDict = nil;
   OCMStub([self.mockConfigurator metricURL]).andReturn(self.jsonURL);
 
   SNTMetricService *ms = [[SNTMetricService alloc] init];
+  NSDictionary *validMetricsDict = [SNTMetricFormatTestHelper createValidMetricsDictionary];
+
   [ms exportForMonitoring:validMetricsDict];
 
   // Ensure that this has written 1 file that is well formed.


### PR DESCRIPTION
This refactors the SNTFormat tests to use the SNTMetricSet to generate the
testdata. This keeps the metric service and the SNTMetricSet in sync and
reduces repeated data.

Related to #563 