### PR TITLE
Deflake SNTApplicationTest by tracking subscriptions to specific event types

### DIFF
--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.h
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.h
@@ -44,7 +44,7 @@ typedef void (^ESCallback)(ESResponse *_Nonnull);
 
 // Singleton wrapper around all of the kernel-level EndpointSecurity framework functions.
 @interface MockEndpointSecurity : NSObject
-@property BOOL subscribed;
+@property NSMutableArray *_Nonnull subscriptions;
 - (void)reset;
 - (void)registerResponseCallback:(ESCallback _Nonnull)callback;
 - (void)triggerHandler:(es_message_t *_Nonnull)msg;

--- a/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManagerTest.mm
@@ -71,14 +71,7 @@ const NSString *const kBenignPath = @"/some/other/path";
 
   [mockES triggerHandler:m.message];
 
-  [self waitForExpectationsWithTimeout:30.0
-                               handler:^(NSError *error) {
-                                 if (error) {
-                                   XCTFail(@"Santa auth test timed out without receiving two "
-                                           @"events. Instead, had error: %@",
-                                           error);
-                                 }
-                               }];
+  [self waitForExpectations:@[ expectation ] timeout:60.0];
 
   for (ESResponse *resp in events) {
     XCTAssertEqual(
@@ -116,12 +109,7 @@ const NSString *const kBenignPath = @"/some/other/path";
 
     [mockES triggerHandler:m.message];
 
-    [self waitForExpectationsWithTimeout:30.0
-                                 handler:^(NSError *error) {
-                                   if (error) {
-                                     XCTFail(@"Santa auth test timed out with error: %@", error);
-                                   }
-                                 }];
+    [self waitForExpectations:@[ expectation ] timeout:60.0];
 
     XCTAssertEqual(got.result, [testCases objectForKey:testPath].intValue,
                    @"Incorrect handling of delete of %@", testPath);
@@ -152,12 +140,8 @@ const NSString *const kBenignPath = @"/some/other/path";
   }];
 
   [mockES triggerHandler:m.message];
-  [self waitForExpectationsWithTimeout:30.0
-                               handler:^(NSError *error) {
-                                 if (error) {
-                                   XCTFail(@"Santa auth test timed out with error: %@", error);
-                                 }
-                               }];
+
+  [self waitForExpectations:@[ expectation ] timeout:60.0];
 
   XCTAssertEqual(got.result, ES_AUTH_RESULT_ALLOW);
 }
@@ -199,12 +183,7 @@ const NSString *const kBenignPath = @"/some/other/path";
 
     [mockES triggerHandler:m.message];
 
-    [self waitForExpectationsWithTimeout:30.0
-                                 handler:^(NSError *error) {
-                                   if (error) {
-                                     XCTFail(@"Santa auth test timed out with error: %@", error);
-                                   }
-                                 }];
+    [self waitForExpectations:@[ expectation ] timeout:60.0];
 
     XCTAssertEqual(got.result, [testCases objectForKey:testPath].intValue,
                    @"Incorrect handling of rename of %@", testPath);
@@ -254,12 +233,8 @@ const NSString *const kBenignPath = @"/some/other/path";
 
     [mockES triggerHandler:m.message];
 
-    [self waitForExpectationsWithTimeout:30.0
-                                 handler:^(NSError *error) {
-                                   if (error) {
-                                     XCTFail(@"Santa auth test timed out with error: %@", error);
-                                   }
-                                 }];
+    [self waitForExpectations:@[ expectation ] timeout:60.0];
+
     XCTAssertEqual(got.result, [testCases objectForKey:testPath].intValue,
                    @"Incorrect handling of rename of %@", testPath);
 

--- a/Source/santad/SNTApplicationTest.m
+++ b/Source/santad/SNTApplicationTest.m
@@ -63,23 +63,14 @@
     [santaInit fulfill];
   });
 
-  [self waitForExpectationsWithTimeout:30.0
-                               handler:^(NSError *error) {
-                                 if (error) {
-                                   XCTFail(@"Santa's subscription to EndpointSecurity timed out "
-                                           @"with error: %@",
-                                           error);
-                                 }
-                               }];
+  [self waitForExpectations:@[ santaInit ] timeout:60.0];
 
   XCTestExpectation *expectation =
     [self expectationWithDescription:@"Wait for santa's Auth dispatch queue"];
   __block ESResponse *got = nil;
   [mockES registerResponseCallback:^(ESResponse *r) {
-    @synchronized(self) {
-      got = r;
-      [expectation fulfill];
-    }
+    got = r;
+    [expectation fulfill];
   }];
 
   NSString *binaryPath = [NSString pathWithComponents:@[ testPath, binaryName ]];
@@ -95,15 +86,7 @@
 
   [mockES triggerHandler:msg.message];
 
-  [self
-    waitForExpectationsWithTimeout:30.0
-                           handler:^(NSError *error) {
-                             if (error) {
-                               XCTFail(
-                                 @"Santa auth test on binary \"%@/%@\" timed out with error: %@",
-                                 testPath, binaryName, error);
-                             }
-                           }];
+  [self waitForExpectations:@[ expectation ] timeout:60.0];
 
   XCTAssertEqual(got.result, wantResult, @"received unexpected ES response on executing \"%@/%@\"",
                  testPath, binaryName);


### PR DESCRIPTION
EndpointSecurityTestUtil assumed only a single es_subscribe was needed to be called before serving all events. This resulted in listenForLogRequests and listenForDecisionRequests racing each other, which would result in auth events being dropped during tests if listenForLogRequests won the race.

This PR changes mock `es_subscribe` to note specific events we're ready for and switches us to `waitForExpectations` so that we can explicitly declare which expectations to wait for.