### PR TITLE
Remove use of entitlements field for the santad build rule

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -93,7 +93,6 @@ macos_bundle(
     infoplists = ["Info.plist"],
     linkopts = ["-execute"],
     minimum_os_version = "10.9",
-    entitlements = "com.google.santa.daemon.systemextension.entitlements",
     codesignopts = [
         "--timestamp",
         "--force",

--- a/Source/santad/com.google.santa.daemon.systemextension.entitlements
+++ b/Source/santad/com.google.santa.daemon.systemextension.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.application-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.google.santa.daemon</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>EQHXZ8M8AV</string>
 	<key>com.apple.developer.endpoint-security.client</key>
 	<true/>
 </dict>

--- a/Testing/build_and_sign.sh
+++ b/Testing/build_and_sign.sh
@@ -2,6 +2,7 @@
 set -e
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
+KEYCHAIN="santa-dev-test.keychain"
 SANTAD_PATH=Santa.app/Contents/Library/SystemExtensions/com.google.santa.daemon.systemextension/Contents/MacOS/com.google.santa.daemon
 SANTAD_ENTITLEMENTS="$GIT_ROOT/Source/santad/com.google.santa.daemon.systemextension.entitlements"
 SANTA_BIN_PATH=Santa.app/Contents/MacOS
@@ -9,7 +10,7 @@ SIGNING_IDENTITY="localhost"
 
 
 function main() {
-    sudo bazel build --ios_signing_cert_name=$SIGNING_IDENTITY --apple_generate_dsym -c opt --define=SANTA_BUILD_TYPE=ci --define=apple.propagate_embedded_extra_outputs=yes --macos_cpus=x86_64,arm64 //:release
+    bazel build --apple_generate_dsym -c opt --define=SANTA_BUILD_TYPE=ci --define=apple.propagate_embedded_extra_outputs=yes --macos_cpus=x86_64,arm64 //:release
 
     echo "> Build complete, installing santa"
     TMP_DIR=$(mktemp -d)
@@ -17,10 +18,10 @@ function main() {
     CS_ARGS="--prefix=EQHXZ8M8AV -fs $SIGNING_IDENTITY --timestamp --options library,kill,runtime"
 
     for bin in $TMP_DIR/binaries/$SANTA_BIN_PATH/*; do
-        sudo codesign --preserve-metadata=entitlements ${CS_ARGS} $bin
+        codesign --keychain $KEYCHAIN --preserve-metadata=entitlements ${CS_ARGS} $bin
     done
 
-    sudo codesign ${CS_ARGS} --entitlements $SANTAD_ENTITLEMENTS $TMP_DIR/binaries/$SANTAD_PATH
+    codesign ${CS_ARGS} --keychain $KEYCHAIN --entitlements $SANTAD_ENTITLEMENTS $TMP_DIR/binaries/$SANTAD_PATH
 
     echo "> Running install.sh"
     (

--- a/Testing/build_and_sign.sh
+++ b/Testing/build_and_sign.sh
@@ -3,8 +3,10 @@ set -e
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
 SANTAD_PATH=Santa.app/Contents/Library/SystemExtensions/com.google.santa.daemon.systemextension/Contents/MacOS/com.google.santa.daemon
+SANTAD_ENTITLEMENTS="$GIT_ROOT/Source/santad/com.google.santa.daemon.systemextension.entitlements"
 SANTA_BIN_PATH=Santa.app/Contents/MacOS
 SIGNING_IDENTITY="localhost"
+
 
 function main() {
     sudo bazel build --ios_signing_cert_name=$SIGNING_IDENTITY --apple_generate_dsym -c opt --define=SANTA_BUILD_TYPE=ci --define=apple.propagate_embedded_extra_outputs=yes --macos_cpus=x86_64,arm64 //:release
@@ -12,10 +14,13 @@ function main() {
     echo "> Build complete, installing santa"
     TMP_DIR=$(mktemp -d)
     tar xvf $GIT_ROOT/bazel-bin/santa-*.tar.gz -C $TMP_DIR
+    CS_ARGS="--prefix=EQHXZ8M8AV -fs $SIGNING_IDENTITY --timestamp --options library,kill,runtime"
 
-    for bin in $TMP_DIR/binaries/$SANTA_BIN_PATH/* $TMP_DIR/binaries/$SANTAD_PATH; do
-        sudo codesign --prefix=EQHXZ8M8AV --preserve-metadata=entitlements -fs $SIGNING_IDENTITY --timestamp --options library,kill,runtime $bin
+    for bin in $TMP_DIR/binaries/$SANTA_BIN_PATH/*; do
+        sudo codesign --preserve-metadata=entitlements ${CS_ARGS} $bin
     done
+
+    sudo codesign ${CS_ARGS} --entitlements $SANTAD_ENTITLEMENTS $TMP_DIR/binaries/$SANTAD_PATH
 
     echo "> Running install.sh"
     (

--- a/Testing/init_dev_certs.sh
+++ b/Testing/init_dev_certs.sh
@@ -9,7 +9,6 @@ openssl req -new -key ./santa.key -out ./santa.csr -config $CNF_PATH
 openssl x509 -req -days 10 -in ./santa.csr -signkey ./santa.key -out ./santa.crt -extfile $CNF_PATH -extensions codesign
 openssl pkcs12 -export -out santa.p12 -inkey santa.key -in santa.crt -password pass:santa
 
-#KEYCHAIN="/Library/Keychains/System.keychain"
 KEYCHAIN="santa-dev-test.keychain"
 security create-keychain -p santa $KEYCHAIN
 security import ./santa.p12 -k $KEYCHAIN -A -P santa

--- a/Testing/init_dev_certs.sh
+++ b/Testing/init_dev_certs.sh
@@ -9,6 +9,8 @@ openssl req -new -key ./santa.key -out ./santa.csr -config $CNF_PATH
 openssl x509 -req -days 10 -in ./santa.csr -signkey ./santa.key -out ./santa.crt -extfile $CNF_PATH -extensions codesign
 openssl pkcs12 -export -out santa.p12 -inkey santa.key -in santa.crt -password pass:santa
 
-KEYCHAIN="/Library/Keychains/System.keychain"
-sudo security import ./santa.p12 -k $KEYCHAIN -A -P santa
-sudo security add-trusted-cert -d -r trustRoot -k $KEYCHAIN santa.crt
+#KEYCHAIN="/Library/Keychains/System.keychain"
+KEYCHAIN="santa-dev-test.keychain"
+security create-keychain -p santa $KEYCHAIN
+security import ./santa.p12 -k $KEYCHAIN -A -P santa
+security add-trusted-cert -d -r trustRoot -k $KEYCHAIN santa.crt

--- a/Testing/reset.sh
+++ b/Testing/reset.sh
@@ -3,3 +3,4 @@ killall moroz
 security delete-identity -c "localhost"
 rm -rf /Applications/Santa.app
 systemextensionsctl reset
+security delete-keychain santa-dev-test.keychain


### PR DESCRIPTION
Revert entitlements change and update the codesign behavior of  `Testing/build_and_sign.sh` to match that of the internal kokoro `sign.sh`.

I misunderstood how our release workflow worked when testing for if https://github.com/google/santa/pull/602 broke anything - as it turns out, our .provisionfile isn't actually used in the release build and we instead use separate keys _and_ the entitlements file, where the actual `codesign` tool fills in TeamIdentifierPrefix. The entitlements arg for the build rule can't nicely fill this in, so remove it for now and instead mirror the kokoro sign.sh behavior within external build_and_sign.sh.