### PR TITLE
Detect existence of a provisionprofile and use that instead in build_and_sign.sh

### DIFF
--- a/Testing/build_and_sign.sh
+++ b/Testing/build_and_sign.sh
@@ -1,19 +1,41 @@
 #!/bin/sh
 set -e
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
+TMP_DIR=$(mktemp -d)
 
-KEYCHAIN="santa-dev-test.keychain"
-SANTAD_PATH=Santa.app/Contents/Library/SystemExtensions/com.google.santa.daemon.systemextension/Contents/MacOS/com.google.santa.daemon
-SANTAD_ENTITLEMENTS="$GIT_ROOT/Source/santad/com.google.santa.daemon.systemextension.entitlements"
-SANTA_BIN_PATH=Santa.app/Contents/MacOS
-SIGNING_IDENTITY="localhost"
+function cleanup() {
+    # Reset randomize_version if we used it
+    if [ -f "$TMP_DIR/version.bzl" ]; then
+        mv "$TMP_DIR/version.bzl" $VERSION_FILE
+    fi
+    rm -rf $TMP_DIR
+    rm -f $GIT_ROOT/bazel-bin/santa-*.tar.gz
+}
+trap cleanup EXIT
 
+function randomize_version() {
+    VERSION_FILE="$GIT_ROOT/version.bzl"
+    # Create a random version ID for the generated Santa version.
+    # The system extension won't replace itself if the version string isn't different than the one
+    # presently installed.
+    cp $VERSION_FILE $TMP_DIR
+    RANDOM_VERSION="$RANDOM.$RANDOM"
 
-function main() {
+    echo "Setting version to $RANDOM_VERSION"
+    echo "SANTA_VERSION = \"$RANDOM_VERSION\"" > $VERSION_FILE
+}
+
+function build_custom_signed() {
+    SANTAD_PATH=Santa.app/Contents/Library/SystemExtensions/com.google.santa.daemon.systemextension/Contents/MacOS/com.google.santa.daemon
+    SANTA_BIN_PATH=Santa.app/Contents/MacOS
+    KEYCHAIN="santa-dev-test.keychain"
+    SANTAD_ENTITLEMENTS="$GIT_ROOT/Source/santad/com.google.santa.daemon.systemextension.entitlements"
+    SIGNING_IDENTITY="localhost"
+
     bazel build --apple_generate_dsym -c opt --define=SANTA_BUILD_TYPE=ci --define=apple.propagate_embedded_extra_outputs=yes --macos_cpus=x86_64,arm64 //:release
 
     echo "> Build complete, installing santa"
-    TMP_DIR=$(mktemp -d)
     tar xvf $GIT_ROOT/bazel-bin/santa-*.tar.gz -C $TMP_DIR
     CS_ARGS="--prefix=EQHXZ8M8AV -fs $SIGNING_IDENTITY --timestamp --options library,kill,runtime"
 
@@ -22,12 +44,45 @@ function main() {
     done
 
     codesign ${CS_ARGS} --keychain $KEYCHAIN --entitlements $SANTAD_ENTITLEMENTS $TMP_DIR/binaries/$SANTAD_PATH
+}
 
+function build_provisionprofile_signed() {
+    bazel build --apple_generate_dsym -c opt --define=SANTA_BUILD_TYPE=release --define=apple.propagate_embedded_extra_outputs=yes --macos_cpus=x86_64,arm64 //:release
+    tar xvf $GIT_ROOT/bazel-bin/santa-*.tar.gz -C $TMP_DIR
+}
+
+function build() {
+    SANTA_DAEMON_PROVPROFILE=$GIT_ROOT/Source/santad/Santa_Daemon_Dev.provisionprofile
+    SANTA_PROVPROFILE=$GIT_ROOT/Source/santa/Santa_Dev.provisionprofile
+
+    if [[ -f $SANTA_DAEMON_PROVPROFILE && -f $SANTA_PROVPROFILE ]]; then
+        echo "Using provisionprofiles in $SANTA_DAEMON_PROVPROFILE and $SANTA_PROVPROFILE"
+        build_provisionprofile_signed
+    else
+        echo "No provisionprofiles detected, creating self-signed certs"
+        build_custom_signed
+    fi
+}
+
+function install() {
     echo "> Running install.sh"
     (
         cd $TMP_DIR
         sudo ./conf/install.sh
     )
+}
+
+function main() {
+    for i in "$@"; do
+        case $i in
+            --randomize_version)
+                randomize_version
+                ;;
+        esac
+    done
+
+    build
+    install
 }
 
 main $@

--- a/Testing/init_dev_certs.sh
+++ b/Testing/init_dev_certs.sh
@@ -2,14 +2,40 @@
 set -e
 GIT_ROOT=$(git rev-parse --show-toplevel)
 CNF_PATH=$GIT_ROOT/Testing/openssl.cnf
-
-openssl genrsa -out ./santa.key 2048
-openssl rsa -in ./santa.key -out ./santa.key
-openssl req -new -key ./santa.key -out ./santa.csr -config $CNF_PATH
-openssl x509 -req -days 10 -in ./santa.csr -signkey ./santa.key -out ./santa.crt -extfile $CNF_PATH -extensions codesign
-openssl pkcs12 -export -out santa.p12 -inkey santa.key -in santa.crt -password pass:santa
-
 KEYCHAIN="santa-dev-test.keychain"
-security create-keychain -p santa $KEYCHAIN
-security import ./santa.p12 -k $KEYCHAIN -A -P santa
-security add-trusted-cert -d -r trustRoot -k $KEYCHAIN santa.crt
+
+function init() {
+    openssl genrsa -out ./santa.key 2048
+    openssl rsa -in ./santa.key -out ./santa.key
+    openssl req -new -key ./santa.key -out ./santa.csr -config $CNF_PATH
+    openssl x509 -req -days 10 -in ./santa.csr -signkey ./santa.key -out ./santa.crt -extfile $CNF_PATH -extensions codesign
+    openssl pkcs12 -export -out santa.p12 -inkey santa.key -in santa.crt -password pass:santa
+
+    security create-keychain -p santa $KEYCHAIN
+    security import ./santa.p12 -k $KEYCHAIN -A -P santa
+    security add-trusted-cert -d -r trustRoot -k $KEYCHAIN santa.crt
+}
+
+function cleanup() {
+    security delete-keychain $KEYCHAIN
+    rm santa.key
+    rm santa.csr
+    rm santa.p12
+}
+
+function main() {
+    case $1 in
+        init)
+            init
+            ;;
+        cleanup)
+            cleanup
+            ;;
+        *)
+            echo "$0 [init|cleanup]"
+            ;;
+    esac
+}
+
+main $@
+exit $?

--- a/Testing/start_env.sh
+++ b/Testing/start_env.sh
@@ -8,7 +8,7 @@ SIGNING_IDENTITY="localhost"
 
 function setup_certs() {
     echo "> Creating codesigning certs and keys"
-    $GIT_ROOT/Testing/init_dev_certs.sh
+    $GIT_ROOT/Testing/init_dev_certs.sh init
 }
 
 function run_moroz() {


### PR DESCRIPTION
We only create a self-signed cert to sign with if there's no provisionprofile. 

Also add the option to randomize the version string in build_and_sign.sh. 
