### PR TITLE
Add provisioningprofile for santactl so that it's properly signed

### DIFF
--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -89,6 +89,10 @@ macos_command_line_application(
         "--force",
         "--options library,kill,runtime",
     ],
+    provisioning_profile = select({
+        "//:ci_build": None,
+        "//conditions:default": "Santa_Dev.provisionprofile",
+    }),
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":santactl_lib"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "0a2c39c0209087e39818c16908c545d744a2e0ca", # tag = "0.31.3",
+    commit = "a2deaf0e557edaad295533d1b21aa88ce1f0227d", # Latest commit that fixes https://github.com/google/santa/issues/595
 )
 
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")


### PR DESCRIPTION
With https://github.com/bazelbuild/rules_apple/pull/1236 merged, we can now use the `provisioning_profile` rule on santactl instead of needing to sign over it with the correct certs. 

This will allow santactl with an included .provisionprofile to actually run without failing the MOLXPC checks (fixes https://github.com/google/santa/issues/595). 