### PR TITLE
Tests: ensure SNTPrefixTree test finishes executing at appropriate time

### DIFF
--- a/Source/common/SNTPrefixTreeTest.mm
+++ b/Source/common/SNTPrefixTreeTest.mm
@@ -50,7 +50,9 @@
   // Create a bunch of background noise.
   dispatch_async(dispatch_get_global_queue(0, 0), ^{
     for (uint64_t i = 0; i < UINT64_MAX; ++i) {
-      t->HasPrefix([UUIDs[i % count] UTF8String]);
+      dispatch_async(dispatch_get_global_queue(0, 0), ^{
+        t->HasPrefix([UUIDs[i % count] UTF8String]);
+      });
       if (stop) return;
     }
   });

--- a/Source/common/SNTPrefixTreeTest.mm
+++ b/Source/common/SNTPrefixTreeTest.mm
@@ -45,26 +45,27 @@
     [UUIDs addObject:[NSUUID UUID].UUIDString];
   }
 
+  __block BOOL stop = NO;
+
   // Create a bunch of background noise.
   dispatch_async(dispatch_get_global_queue(0, 0), ^{
-    dispatch_apply(UINT64_MAX, dispatch_get_global_queue(0, 0), ^(size_t i) {
+    for (uint64_t i = 0; i < UINT64_MAX; ++i) {
       t->HasPrefix([UUIDs[i % count] UTF8String]);
-    });
+      if (stop) return;
+    }
   });
 
   // Fill up the tree.
   dispatch_apply(count, dispatch_get_global_queue(0, 0), ^(size_t i) {
-    if (t->AddPrefix([UUIDs[i] UTF8String]) != kIOReturnSuccess) {
-      XCTFail();
-    }
+    XCTAssertEqual(t->AddPrefix([UUIDs[i] UTF8String]), kIOReturnSuccess);
   });
 
   // Make sure every leaf byte is found.
   dispatch_apply(count, dispatch_get_global_queue(0, 0), ^(size_t i) {
-    if (!t->HasPrefix([UUIDs[i] UTF8String])) {
-      XCTFail();
-    }
+    XCTAssertTrue(t->HasPrefix([UUIDs[i] UTF8String]));
   });
+
+  stop = YES;
 }
 
 @end


### PR DESCRIPTION
Also switch to using XCTAssert* instead of XCTFail