### PR TITLE
Initial commit of an HTTP writer for SNTMetricSets

### DIFF
--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -19,6 +19,7 @@ objc_library(
         "//Source/common:SNTXPCMetricServiceInterface",
         "//Source/santametricservice/Formats:SNTMetricRawJSONFormat",
         "//Source/santametricservice/Writers:SNTMetricFileWriter",
+        "//Source/santametricservice/Writers:SNTMetricHTTPWriter",
         "@MOLCodesignChecker",
         "@MOLXPCConnection",
     ],
@@ -38,8 +39,8 @@ test_suite(
     name = "unit_tests",
     tests = [
         ":SNTMetricServiceTest",
-        "//Source/santametricservice/Formats:SNTMetricRawJSONFormatTest",
-        "//Source/santametricservice/Writers:SNTMetricFileWriterTest",
+        "//Source/santametricservice/Formats:format_tests",
+        "//Source/santametricservice/Writers:writer_tests",
     ],
 )
 

--- a/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
@@ -81,7 +81,7 @@
   if (![NSJSONSerialization isValidJSONObject:normalizedMetrics]) {
     if (err != nil) {
       *err = [[NSError alloc]
-        initWithDomain:@"SNTMetricRawJSONFileWriter"
+        initWithDomain:@"com.google.santa.metricservice.formatters.rawjson"
                   code:EINVAL
               userInfo:@{
                 NSLocalizedDescriptionKey : @"unable to convert metrics to JSON: invalid metrics"

--- a/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
@@ -81,7 +81,7 @@
   if (![NSJSONSerialization isValidJSONObject:normalizedMetrics]) {
     if (err != nil) {
       *err = [[NSError alloc]
-        initWithDomain:@"com.google.santa.metricservice.formatters.rawjson"
+        initWithDomain:@"com.google.santa.metricservice.formats.rawjson"
                   code:EINVAL
               userInfo:@{
                 NSLocalizedDescriptionKey : @"unable to convert metrics to JSON: invalid metrics"

--- a/Source/santametricservice/SNTMetricService.m
+++ b/Source/santametricservice/SNTMetricService.m
@@ -21,6 +21,7 @@
 #import "SNTMetricService.h"
 #import "Source/santametricservice/Formats/SNTMetricRawJSONFormat.h"
 #import "Source/santametricservice/Writers/SNTMetricFileWriter.h"
+#import "Source/santametricservice/Writers/SNTMetricHTTPWriter.h"
 
 @interface SNTMetricService ()
 @property MOLXPCConnection *notifierConnection;
@@ -38,7 +39,10 @@
   self = [super init];
   if (self) {
     rawJSONFormatter = [[SNTMetricRawJSONFormat alloc] init];
-    metricWriters = @{@"file" : [[SNTMetricFileWriter alloc] init]};
+    metricWriters = @{
+      @"file" : [[SNTMetricFileWriter alloc] init],
+      @"http" : [[SNTMetricHTTPWriter alloc] init],
+    };
 
     _queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
   }

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -5,6 +5,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTMetricSet.h"
 
+#import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
 #import <OCMock/OCMock.h>
 
 #import "Source/santametricservice/Formats/SNTMetricFormatTestHelper.h"
@@ -16,6 +17,9 @@ NSDictionary *validMetricsDict = nil;
 @property id mockConfigurator;
 @property NSString *tempDir;
 @property NSURL *jsonURL;
+@property id mockSession;
+@property id mockSessionDataTask;
+@property id mockMOLAuthenticatingURLSession;
 @end
 
 @implementation SNTMetricServiceTest
@@ -39,6 +43,15 @@ NSDictionary *validMetricsDict = nil;
 
 - (void)tearDown {
   [self.mockConfigurator stopMocking];
+  if (self.mockSessionDataTask != nil) {
+    [self.mockSessionDataTask stopMocking];
+  }
+  if (self.mockSession != nil) {
+    [self.mockSession stopMocking];
+  }
+  if (self.mockMOLAuthenticatingURLSession != nil) {
+    [self.mockMOLAuthenticatingURLSession stopMocking];
+  }
 
   // delete the temp dir
   [[NSFileManager defaultManager] removeItemAtPath:self.tempDir error:NULL];
@@ -111,5 +124,52 @@ NSDictionary *validMetricsDict = nil;
   [self convertJSONDateStringsToNSDateWithJson:parsedJSONData];
 
   XCTAssertEqualObjects(validMetricsDict, parsedJSONData, @"invalid JSON created");
+}
+
+- (void)testWritingJSON {
+  NSURL *url = [NSURL URLWithString:@"http://localhost:9444"];
+  OCMStub([self.mockConfigurator exportMetrics]).andReturn(YES);
+  OCMStub([self.mockConfigurator metricFormat]).andReturn(SNTMetricFormatTypeRawJSON);
+  OCMStub([self.mockConfigurator metricURL]).andReturn(url);
+
+  self.mockSession = OCMClassMock([NSURLSession class]);
+  self.mockSessionDataTask = OCMClassMock([NSURLSessionDataTask class]);
+  self.mockMOLAuthenticatingURLSession = OCMClassMock([MOLAuthenticatingURLSession class]);
+
+  OCMStub([self.mockMOLAuthenticatingURLSession alloc])
+    .andReturn(self.mockMOLAuthenticatingURLSession);
+  OCMStub([self.mockMOLAuthenticatingURLSession session]).andReturn(self.mockSession);
+
+  NSHTTPURLResponse *response =
+    [[NSHTTPURLResponse alloc] initWithURL:url
+                                statusCode:200
+                               HTTPVersion:@"HTTP/1.1"
+                              headerFields:@{@"content-type" : @"application/json"}];
+
+  __block void (^passedBlock)(NSData *, NSURLResponse *, NSError *);
+
+  XCTestExpectation *responseCallback =
+    [[XCTestExpectation alloc] initWithDescription:@"ensure writer passed JSON"];
+
+  // stub out session to call completion handler immediately.
+  void (^callCompletionHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    passedBlock(nil, response, nil);
+    [responseCallback fulfill];
+  };
+
+  OCMStub([(NSURLSessionDataTask *)self.mockSessionDataTask resume]).andDo(callCompletionHandler);
+
+  // stub out NSURLSession to assign our completion handler and return our mock
+  void (^getCompletionHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    [invocation getArgument:&passedBlock atIndex:3];
+  };
+
+  OCMStub([self.mockSession dataTaskWithRequest:[OCMArg any] completionHandler:[OCMArg any]])
+    .andDo(getCompletionHandler)
+    .andReturn(self.mockSessionDataTask);
+
+  SNTMetricService *service = [[SNTMetricService alloc] init];
+  [service exportForMonitoring:[SNTMetricFormatTestHelper createValidMetricsDictionary]];
+  [self waitForExpectations:@[ responseCallback ] timeout:10.0];
 }
 @end

--- a/Source/santametricservice/Writers/BUILD
+++ b/Source/santametricservice/Writers/BUILD
@@ -14,7 +14,6 @@ objc_library(
     srcs = [
         "SNTMetricFileWriter.h",
         "SNTMetricFileWriter.m",
-        "SNTMetricWriter.h",
     ],
     deps = [
         ":SNTMetricWriter",
@@ -29,5 +28,37 @@ santa_unit_test(
     ],
     deps = [
         ":SNTMetricFileWriter",
+    ],
+)
+
+objc_library(
+    name = "SNTMetricHTTPWriter",
+    srcs = [
+        "SNTMetricHTTPWriter.h",
+        "SNTMetricHTTPWriter.m",
+    ],
+    deps = [
+        ":SNTMetricWriter",
+        "//Source/common:SNTLogging",
+        "@MOLAuthenticatingURLSession",
+    ],
+)
+
+santa_unit_test(
+    name = "SNTMetricHTTPWriterTest",
+    srcs = [
+        "SNTMetricHTTPWriterTest.m",
+    ],
+    deps = [
+        ":SNTMetricHTTPWriter",
+        "@OCMock",
+    ],
+)
+
+test_suite(
+    name = "writer_tests",
+    tests = [
+        ":SNTMetricFileWriterTest",
+        ":SNTMetricHTTPWriterTest",
     ],
 )

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.h
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.h
@@ -1,0 +1,18 @@
+/// Copyright 2021 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import "Source/santametricservice/Writers/SNTMetricWriter.h"
+
+@interface SNTMetricHTTPWriter : NSObject <SNTMetricWriter>
+@end

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.h
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.h
@@ -14,5 +14,7 @@
 
 #import "Source/santametricservice/Writers/SNTMetricWriter.h"
 
+#import <Foundation/Foundation.h>
+
 @interface SNTMetricHTTPWriter : NSObject <SNTMetricWriter>
 @end

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -88,7 +88,7 @@
   }];
 
   if (_blockError != nil) {
-    // If the caller hasn't passed us an eror than we ignore it.
+    // If the caller hasn't passed us an error then we ignore it.
     if (error != nil) {
       *error = [_blockError copy];
     }

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -1,0 +1,101 @@
+/// Copyright 2021 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+#import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
+#include <dispatch/dispatch.h>
+
+#import "Source/common/SNTLogging.h"
+#import "Source/santametricservice/Writers/SNTMetricHTTPWriter.h"
+
+@implementation SNTMetricHTTPWriter {
+ @private
+  MOLAuthenticatingURLSession *_authSession;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _authSession = [[MOLAuthenticatingURLSession alloc] init];
+  }
+  return self;
+}
+
+/**
+ * Post serialzied metrics to the specified URL one object at a time.
+ **/
+- (BOOL)write:(NSArray<NSData *> *)metrics toURL:(NSURL *)url error:(NSError **)error {
+  __block NSError *_blockError = nil;
+
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+  request.HTTPMethod = @"POST";
+  [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+
+  _authSession.serverHostname = url.host;
+  NSURLSession *_session = _authSession.session;
+
+  dispatch_group_t requests = dispatch_group_create();
+
+  [metrics enumerateObjectsUsingBlock:^(id value, NSUInteger index, BOOL *stop) {
+    dispatch_group_enter(requests);
+
+    request.HTTPBody = (NSData *)value;
+    [[_session dataTaskWithRequest:request
+                 completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
+                                     NSError *_Nullable err) {
+                   if (err != nil) {
+                     _blockError = err;
+                     *stop = YES;
+                   } else if (response == nil) {
+                     *stop = YES;
+                   } else if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+
+                     // Check HTTP error codes and create errors for any non-200.
+                     if (httpResponse && httpResponse.statusCode != 200) {
+                       _blockError = [[NSError alloc]
+                         initWithDomain:@"com.google.santa.metricservice.writers.http"
+                                   code:httpResponse.statusCode
+                               userInfo:@{
+                                 NSLocalizedDescriptionKey : [NSString
+                                   stringWithFormat:@"received http status code %ld from %@",
+                                                    httpResponse.statusCode, url]
+                               }];
+                       *stop = YES;
+                     }
+                   }
+                   dispatch_group_leave(requests);
+                 }] resume];
+
+    // Wait up to 30 seconds for the request to complete.
+    if (dispatch_group_wait(requests, (int64_t)(30.0 * NSEC_PER_SEC)) != 0) {
+      NSString *errMsg =
+        [NSString stringWithFormat:@"HTTP request to %@ timedout after 30 seconds", url];
+
+      _blockError = [[NSError alloc] initWithDomain:@"com.google.santa.metricservice.writers.http"
+                                               code:ETIMEDOUT
+                                           userInfo:@{NSLocalizedDescriptionKey : errMsg}];
+    }
+  }];
+
+  if (_blockError != nil) {
+    // If the caller hasn't passed us an eror than we ignore it.
+    if (error != nil) {
+      *error = [_blockError copy];
+    }
+
+    return NO;
+  }
+
+  return YES;
+}
+@end

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -79,7 +79,7 @@
     // Wait up to 30 seconds for the request to complete.
     if (dispatch_group_wait(requests, (int64_t)(30.0 * NSEC_PER_SEC)) != 0) {
       NSString *errMsg =
-        [NSString stringWithFormat:@"HTTP request to %@ timedout after 30 seconds", url];
+        [NSString stringWithFormat:@"HTTP request to %@ timed out after 30 seconds", url];
 
       _blockError = [[NSError alloc] initWithDomain:@"com.google.santa.metricservice.writers.http"
                                                code:ETIMEDOUT

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
@@ -19,7 +19,7 @@
 - (void)setUp {
   self.mockSession = OCMClassMock([NSURLSession class]);
   self.mockSessionDataTask = OCMClassMock(
-    [NSURLSessionDataTask class]);  //)[OCMockObject niceMockForClass:[NSURLSessionDataTask class]];
+    [NSURLSessionDataTask class]);
   self.mockMOLAuthenticatingURLSession = OCMClassMock([MOLAuthenticatingURLSession class]);
 
   OCMStub([self.mockMOLAuthenticatingURLSession alloc])

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
@@ -1,0 +1,186 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
+#import <OCMock/OCMock.h>
+
+#import "Source/santametricservice/Writers/SNTMetricHTTPWriter.h"
+
+@interface SNTMetricHTTPWriterTest : XCTestCase
+@property id mockSession;
+@property id mockSessionDataTask;
+@property id mockMOLAuthenticatingURLSession;
+@property NSMutableArray<NSDictionary *> *mockResponses;
+@property SNTMetricHTTPWriter *httpWriter;
+@end
+
+@implementation SNTMetricHTTPWriterTest
+
+- (void)setUp {
+  self.mockSession = OCMClassMock([NSURLSession class]);
+  self.mockSessionDataTask = OCMClassMock(
+    [NSURLSessionDataTask class]);  //)[OCMockObject niceMockForClass:[NSURLSessionDataTask class]];
+  self.mockMOLAuthenticatingURLSession = OCMClassMock([MOLAuthenticatingURLSession class]);
+
+  OCMStub([self.mockMOLAuthenticatingURLSession alloc])
+    .andReturn(self.mockMOLAuthenticatingURLSession);
+  OCMStub([self.mockMOLAuthenticatingURLSession session]).andReturn(self.mockSession);
+
+  self.httpWriter = [[SNTMetricHTTPWriter alloc] init];
+  self.mockResponses = [[NSMutableArray alloc] init];
+
+  __block void (^completionHandler)(NSData *, NSURLResponse *, NSError *);
+
+  void (^getCompletionHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    [invocation getArgument:&completionHandler atIndex:3];
+  };
+
+  void (^callCompletionHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    NSDictionary *responseValue = self.mockResponses[0];
+    if (responseValue != nil) {
+      completionHandler(responseValue[@"data"], responseValue[@"response"],
+                        responseValue[@"error"]);
+      [self.mockResponses removeObjectAtIndex:0];
+    } else {
+      XCTFail(@"mockResponses set to zero");
+    }
+  };
+
+  OCMStub([(NSURLSessionDataTask *)self.mockSessionDataTask resume]).andDo(callCompletionHandler);
+
+  OCMStub([self.mockSession dataTaskWithRequest:[OCMArg any] completionHandler:[OCMArg any]])
+    .andDo(getCompletionHandler)
+    .andReturn(self.mockSessionDataTask);
+}
+
+- (void)tearDown {
+  [self.mockSessionDataTask stopMocking];
+  [self.mockSession stopMocking];
+  [self.mockMOLAuthenticatingURLSession stopMocking];
+}
+
+/// enqueues a mock HTTP response for testing.
+- (void)createMockResponseWithURL:(NSURL *)url
+                         withCode:(NSInteger)code
+                         withData:(NSData *)data
+                        withError:(NSError *)err {
+  NSHTTPURLResponse *response =
+    [[NSHTTPURLResponse alloc] initWithURL:url
+                                statusCode:code
+                               HTTPVersion:@"HTTP/1.1"
+                              headerFields:@{@"content-type" : @"application/json"}];
+
+  NSMutableDictionary *responseValue = [[NSMutableDictionary alloc] init];
+
+  responseValue[@"data"] = data;
+  responseValue[@"response"] = response;
+  responseValue[@"error"] = err;
+
+  [self.mockResponses addObject:responseValue];
+}
+
+- (void)testValidPostOfData {
+  NSURL *url = [[NSURL alloc] initWithString:@"http://localhost:8444/submit"];
+
+  [self createMockResponseWithURL:url withCode:200 withData:nil withError:nil];
+
+  SNTMetricHTTPWriter *httpWriter = [[SNTMetricHTTPWriter alloc] init];
+
+  NSData *JSONdata = [@"{\"foo\": \"bar\"}\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+
+  NSError *err;
+  BOOL result = [httpWriter write:@[ JSONdata ] toURL:url error:&err];
+  XCTAssertEqual(YES, result);
+  XCTAssertNil(err);
+}
+
+- (void)testEnsureHTTPErrorCodesResultInErrors {
+  NSURL *url = [NSURL URLWithString:@"http://localhost:10444"];
+
+  NSData *JSONdata = [@"{\"foo\": \"bar\"}\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *err;
+
+  for (NSInteger code = 400; code < 600; code += 100) {
+    [self createMockResponseWithURL:url withCode:code withData:nil withError:nil];
+
+    BOOL result = [self.httpWriter write:@[ JSONdata ] toURL:url error:&err];
+
+    XCTAssertEqual(NO, result, @"result of call to write did not fail as expected");
+    XCTAssertNotNil(err);
+    XCTAssertEqual(code, err.code);
+    XCTAssertEqual(@"com.google.santa.metricservice.writers.http", err.domain);
+
+    NSString *expectedErrMsg = [NSString
+      stringWithFormat:@"received http status code %ld from %@", code, url.absoluteString];
+    XCTAssertEqualObjects(expectedErrMsg, err.localizedDescription);
+    err = nil;
+  }
+}
+
+- (void)testEnsureErrorsFromTransportAreHandled {
+  NSURL *url = [NSURL URLWithString:@"http://localhost:9444"];
+  NSError *mockErr = [[NSError alloc] initWithDomain:@"com.google.santa.metricservice.writers.http"
+                                                code:505
+                                            userInfo:@{NSLocalizedDescriptionKey : @"test error"}];
+  NSError *err;
+
+  [self createMockResponseWithURL:url withCode:505 withData:nil withError:mockErr];
+
+  NSData *JSONdata = [@"{\"foo\": \"bar\"}\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+
+  BOOL result = [self.httpWriter write:@[ JSONdata ] toURL:url error:&err];
+
+  XCTAssertEqual(NO, result, @"result of call to write did not fail as expected");
+  XCTAssertEqual(mockErr.code, err.code);
+  XCTAssertEqualObjects(mockErr.domain, err.domain);
+  XCTAssertEqualObjects(@"test error", err.userInfo[NSLocalizedDescriptionKey]);
+}
+
+- (void)testEnsureMutlipleEntriesWriteMultipleTimes {
+  NSURL *url = [NSURL URLWithString:@"http://localhost:9444"];
+
+  // Ensure that non-200 status codes codes do not crash
+  [self createMockResponseWithURL:url withCode:200 withData:nil withError:nil];
+  [self createMockResponseWithURL:url withCode:200 withData:nil withError:nil];
+
+  NSData *JSONdata = [@"{\"foo\": \"bar\"}\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *err;
+  BOOL result = [self.httpWriter write:@[ JSONdata, JSONdata ] toURL:url error:&err];
+
+  XCTAssertEqual(YES, result);
+  XCTAssertNil(err);
+  XCTAssertEqual(0, self.mockResponses.count, @"incorrect number of requests was made");
+}
+
+- (void)testEnsurePassingNilOrNullErrorDoesNotCrash {
+  NSURL *url = [NSURL URLWithString:@"http://localhost:9444"];
+
+  // Queue up two responses for nil and NULL.
+  [self createMockResponseWithURL:url withCode:400 withData:nil withError:nil];
+  [self createMockResponseWithURL:url withCode:400 withData:nil withError:nil];
+
+  NSData *JSONdata = [@"{\"foo\": \"bar\"}\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+
+  BOOL result = [self.httpWriter write:@[ JSONdata ] toURL:url error:nil];
+  XCTAssertEqual(NO, result);
+
+  result = [self.httpWriter write:@[ JSONdata ] toURL:url error:NULL];
+  XCTAssertEqual(NO, result);
+
+  NSError *mockErr =
+    [[NSError alloc] initWithDomain:@"com.google.santa.metricservice.writers.http.test"
+                               code:505
+                           userInfo:@{NSLocalizedDescriptionKey : @"test error"}];
+
+  // Queue up two responses for nil and NULL.
+  [self createMockResponseWithURL:url withCode:500 withData:nil withError:mockErr];
+  [self createMockResponseWithURL:url withCode:500 withData:nil withError:mockErr];
+
+  result = [self.httpWriter write:@[ JSONdata ] toURL:url error:nil];
+  XCTAssertFalse(result);
+
+  result = [self.httpWriter write:@[ JSONdata ] toURL:url error:NULL];
+
+  XCTAssertFalse(result);
+}
+@end


### PR DESCRIPTION
This PR adds support for shipping serialized SNTMetricSets to an HTTP server via POSTs. The HTTP writer posts the serialized metrics one at a time, to ensure order. This comes with the assumption that 99% of the time we're going to be sending a single payload.

It's part of the work for metrics support in #563. 