### PR TITLE
Add a workflow for checking links in Markdown files

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -1,0 +1,13 @@
+name: Check Markdown links
+
+on: 
+  pull_request:
+    paths:
+      - "**.md"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
This adds a workflow to check for dead links in Markdown files when a PR is submitted.

It replaces #627 