### PR TITLE
santad: enable sysx cache by default

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -621,7 +621,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (BOOL)enableSysxCache {
   NSNumber *number = self.configState[kEnableSysxCache];
-  return number ? [number boolValue] : NO;
+  return number ? [number boolValue] : YES;
 }
 
 - (BOOL)enableForkAndExitLogging {


### PR DESCRIPTION
We've had this enabled long enough now to know that it works correctly and helps performance considerably, so let's have it on by default.