### PR TITLE
Fix up the SNTApplicationCoreMetricsTest

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -84,6 +84,7 @@ objc_library(
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTMetricSet",
+        "//Source/common:SNTSystemInfo",
     ],
 )
 

--- a/Source/santad/SNTApplicationCoreMetricsTest.m
+++ b/Source/santad/SNTApplicationCoreMetricsTest.m
@@ -15,6 +15,7 @@
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTMetricSet.h"
+#import "Source/common/SNTSystemInfo.h"
 #import "Source/santad/SNTApplicationCoreMetrics.h"
 #import "Source/santametricservice/Formats/SNTMetricFormatTestHelper.h"
 
@@ -80,11 +81,7 @@
 
   NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
 
-  NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-  NSString *shortOSVersion =
-    [NSString stringWithFormat:@"%ld.%ld.%ld", processInfo.operatingSystemVersion.majorVersion,
-                               processInfo.operatingSystemVersion.minorVersion,
-                               processInfo.operatingSystemVersion.patchVersion];
+  NSString *shortOSVersion = [SNTSystemInfo osVersion];
 
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
 


### PR DESCRIPTION
This ensures that the `SNTApplicationCoreMetricsTest` uses `SNTSystemInfo` to generate its test output.