### PR TITLE
Add AboutText option for the Santa.app

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -186,6 +186,12 @@
 #pragma mark - GUI Settings
 
 ///
+/// The text to display when opening Santa.app.
+/// If unset, the default text will be displayed.
+///
+@property(readonly, nonatomic) NSString *aboutText;
+
+///
 ///  The URL to open when the user clicks "More Info..." when opening Santa.app.
 ///  If unset, the button will not be displayed.
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -59,6 +59,7 @@ static NSString *const kMachineOwnerPlistKeyKey = @"MachineOwnerKey";
 static NSString *const kMachineIDPlistFileKey = @"MachineIDPlist";
 static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
+static NSString *const kAboutText = @"AboutText";
 static NSString *const kMoreInfoURLKey = @"MoreInfoURL";
 static NSString *const kEventDetailURLKey = @"EventDetailURL";
 static NSString *const kEventDetailTextKey = @"EventDetailText";
@@ -144,6 +145,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kBlockedPathRegexKeyDeprecated : re,
       kEnablePageZeroProtectionKey : number,
       kEnableBadSignatureProtectionKey : number,
+      kAboutText : string,
       kMoreInfoURLKey : string,
       kEventDetailURLKey : string,
       kEventDetailTextKey : string,
@@ -492,6 +494,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 - (BOOL)enableBadSignatureProtection {
   NSNumber *number = self.configState[kEnableBadSignatureProtectionKey];
   return number ? [number boolValue] : NO;
+}
+
+- (NSString *)aboutText {
+    return self.configState[kAboutText];
 }
 
 - (NSURL *)moreInfoURL {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -497,7 +497,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 - (NSString *)aboutText {
-    return self.configState[kAboutText];
+  return self.configState[kAboutText];
 }
 
 - (NSURL *)moreInfoURL {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -260,6 +260,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self configStateSet];
 }
 
++ (NSSet *)keyPathsForValuesAffectingAboutText {
+  return [self configStateSet];
+}
+
 + (NSSet *)keyPathsForValuesAffectingMoreInfoURL {
   return [self configStateSet];
 }

--- a/Source/santa/Resources/AboutWindow.xib
+++ b/Source/santa/Resources/AboutWindow.xib
@@ -7,6 +7,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SNTAboutWindowController">
             <connections>
+                <outlet property="aboutTextField" destination="uh6-q0-RzL" id="oGn-hV-wwc"/>
                 <outlet property="moreInfoButton" destination="SRu-Kf-vu5" id="Vj2-9Q-05d"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>

--- a/Source/santa/SNTAboutWindowController.h
+++ b/Source/santa/SNTAboutWindowController.h
@@ -16,6 +16,7 @@
 
 @interface SNTAboutWindowController : NSWindowController
 
+@property IBOutlet NSTextField *aboutTextField;
 @property IBOutlet NSButton *moreInfoButton;
 
 - (IBAction)openMoreInfoURL:(id)sender;

--- a/Source/santa/SNTAboutWindowController.m
+++ b/Source/santa/SNTAboutWindowController.m
@@ -24,7 +24,12 @@
 
 - (void)loadWindow {
   [super loadWindow];
-  if (![[SNTConfigurator configurator] moreInfoURL]) {
+  SNTConfigurator *config = [SNTConfigurator configurator];
+  NSString *aboutText = [config aboutText];
+  if (aboutText) {
+    [self.aboutTextField setStringValue:aboutText];
+  }
+  if (![config moreInfoURL]) {
     [self.moreInfoButton removeFromSuperview];
   }
 }

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -25,6 +25,7 @@ Additionally, there are options that can be controlled by both.
 | BlockedPathRegex*             | String     | A regex to block if the binary or certificate scopes did not allow/block an execution.  Regexes are specified in ICU format. |
 | EnableBadSignatureProtection  | Bool       | Enable bad signature protection, defaults to NO. If this flag is set to YES, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
 | EnablePageZeroProtection      | Bool       | Enable `__PAGEZERO` protection, defaults to YES. If this flag is set to YES, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
+| AboutText                     | String     | The text to display when the user opening Santa.app. If unset, the default text will be displayed. |
 | MoreInfoURL                   | String     | The URL to open when the user clicks "More Info..." when opening Santa.app.  If unset, the button will not be displayed. |
 | EventDetailURL                | String     | See the [EventDetailURL](#eventdetailurl) section below. |
 | EventDetailText               | String     | Related to the above property, this string represents the text to show on the button. |

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -25,7 +25,7 @@ Additionally, there are options that can be controlled by both.
 | BlockedPathRegex*             | String     | A regex to block if the binary or certificate scopes did not allow/block an execution.  Regexes are specified in ICU format. |
 | EnableBadSignatureProtection  | Bool       | Enable bad signature protection, defaults to NO. If this flag is set to YES, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
 | EnablePageZeroProtection      | Bool       | Enable `__PAGEZERO` protection, defaults to YES. If this flag is set to YES, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
-| AboutText                     | String     | The text to display when the user opening Santa.app. If unset, the default text will be displayed. |
+| AboutText                     | String     | The text to display when the user opens Santa.app. If unset, the default text will be displayed. |
 | MoreInfoURL                   | String     | The URL to open when the user clicks "More Info..." when opening Santa.app.  If unset, the button will not be displayed. |
 | EventDetailURL                | String     | See the [EventDetailURL](#eventdetailurl) section below. |
 | EventDetailText               | String     | Related to the above property, this string represents the text to show on the button. |


### PR DESCRIPTION
Some users would like to be able to customize the text being displayed in the Santa.app about window. This is a little bit related to the #660 issue.

Only embarrassing problem: I do not know how to setup dev provisioning profiles and certificates for this project, so I wasn't able to test this at all…

I would need a little help, if you are interested in this small feature.