### PR TITLE
Fix Flaky Execution Controller Tests

### DIFF
--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -157,7 +157,7 @@
   rule.type = SNTRuleTypeCertificate;
   OCMStub([self.mockRuleDatabase ruleForBinarySHA256:nil certificateSHA256:@"a" teamID:nil])
     .andReturn(rule);
-  
+
   OCMExpect([self.mockEventDatabase addStoredEvent:OCMOCK_ANY]);
 
   [self.sut validateBinaryWithMessage:[self getMessage]];

--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -157,10 +157,13 @@
   rule.type = SNTRuleTypeCertificate;
   OCMStub([self.mockRuleDatabase ruleForBinarySHA256:nil certificateSHA256:@"a" teamID:nil])
     .andReturn(rule);
+  
+  OCMExpect([self.mockEventDatabase addStoredEvent:OCMOCK_ANY]);
 
   [self.sut validateBinaryWithMessage:[self getMessage]];
 
   OCMVerify([self.mockDriverManager postAction:ACTION_RESPOND_DENY forMessage:[self getMessage]]);
+  OCMVerifyAllWithDelay(self.mockEventDatabase, 1);
 }
 
 - (void)testBinaryAllowCompilerRule {
@@ -224,9 +227,12 @@
   OCMStub([self.mockRuleDatabase ruleForBinarySHA256:@"a" certificateSHA256:nil teamID:nil])
     .andReturn(rule);
 
+  OCMExpect([self.mockEventDatabase addStoredEvent:OCMOCK_ANY]);
+
   [self.sut validateBinaryWithMessage:[self getMessage]];
 
   OCMVerify([self.mockDriverManager postAction:ACTION_RESPOND_DENY forMessage:[self getMessage]]);
+  OCMVerifyAllWithDelay(self.mockEventDatabase, 1);
 }
 
 - (void)testDefaultDecision {
@@ -234,17 +240,19 @@
   OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");
 
   OCMExpect([self.mockConfigurator clientMode]).andReturn(SNTClientModeMonitor);
+  OCMExpect([self.mockEventDatabase addStoredEvent:OCMOCK_ANY]);
+
   [self.sut validateBinaryWithMessage:[self getMessage]];
   OCMVerify([self.mockDriverManager postAction:ACTION_RESPOND_ALLOW forMessage:[self getMessage]]);
 
   OCMExpect([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
   [self.sut validateBinaryWithMessage:[self getMessage]];
   OCMVerify([self.mockDriverManager postAction:ACTION_RESPOND_DENY forMessage:[self getMessage]]);
+  OCMVerifyAllWithDelay(self.mockEventDatabase, 1);
 }
 
 - (void)testOutOfScope {
   OCMStub([self.mockFileInfo isMachO]).andReturn(NO);
-
   OCMStub([self.mockConfigurator clientMode]).andReturn(SNTClientModeLockdown);
   [self.sut validateBinaryWithMessage:[self getMessage]];
   OCMVerify([self.mockDriverManager postAction:ACTION_RESPOND_ALLOW forMessage:[self getMessage]]);
@@ -258,9 +266,10 @@
 - (void)testPageZero {
   OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
   OCMStub([self.mockFileInfo isMissingPageZero]).andReturn(YES);
-
+  OCMExpect([self.mockEventDatabase addStoredEvent:OCMOCK_ANY]);
   [self.sut validateBinaryWithMessage:[self getMessage]];
   OCMVerify([self.mockDriverManager postAction:ACTION_RESPOND_DENY forMessage:[self getMessage]]);
+  OCMVerifyAllWithDelay(self.mockEventDatabase, 1);
 }
 
 @end


### PR DESCRIPTION
This PR fixes the issue with some of the SNTExecutionController test flakiness. The underlying issue is that we dispatch an even to the SNTEventTable mock in the SNTExecutionController tests.

