### PR TITLE
Tests: Fix some flaky tests

### DIFF
--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -87,16 +87,6 @@
   return (santa_vnode_id_t){.fsid = 1234, .fileid = 5678};
 }
 
-- (void)tearDown {
-  [self.mockFileInfo stopMocking];
-  [self.mockCodesignChecker stopMocking];
-  [self.mockDriverManager stopMocking];
-  [self.mockRuleDatabase stopMocking];
-  [self.mockEventDatabase stopMocking];
-
-  [super tearDown];
-}
-
 - (void)testBinaryAllowRule {
   OCMStub([self.mockFileInfo isMachO]).andReturn(YES);
   OCMStub([self.mockFileInfo SHA256]).andReturn(@"a");

--- a/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
@@ -23,7 +23,8 @@
   self = [super init];
   if (self) {
     _dateFormatter = [[NSDateFormatter alloc] init];
-    [_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+    _dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    _dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
   }
   return self;
 }

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
@@ -52,12 +52,6 @@
     .andReturn(self.mockSessionDataTask);
 }
 
-- (void)tearDown {
-  [self.mockSessionDataTask stopMocking];
-  [self.mockSession stopMocking];
-  [self.mockMOLAuthenticatingURLSession stopMocking];
-}
-
 /// enqueues a mock HTTP response for testing.
 - (void)createMockResponseWithURL:(NSURL *)url
                          withCode:(NSInteger)code


### PR DESCRIPTION
1. OCMock objects don't need stopMocking to be called - it's only necessary to call that in cases where the original object behavior must be restored before the end of the test. Otherwise the mock automatically restores during deallocation.
2. SNTMetricRawJSONFormat still used a plain NSDateFormatter and so was applying timezone calculations. In tests we've switched to using NSISO8601DateFormatter but this requires 10.13 and our deployment target is still 10.9 so I've stuck to applying the UTC timezone to the formatter instead.