### PR TITLE
Change SNTEventLog to be a singleton emit a singleton Logger object

### DIFF
--- a/Source/santad/Logs/SNTEventLog.h
+++ b/Source/santad/Logs/SNTEventLog.h
@@ -58,4 +58,8 @@
 // A UTC Date formatter.
 @property(readonly, nonatomic) NSDateFormatter *dateFormatter;
 @property(readonly, nonatomic) NSString *machineID;
+
+// Retrieve an initialized singleton SNTEventLog object.
+// Determines which type of SNTEventLog to use based on [SNTConfigurator eventLogType].
++ (instancetype)logger;
 @end

--- a/Source/santad/Logs/SNTEventLog.m
+++ b/Source/santad/Logs/SNTEventLog.m
@@ -23,6 +23,8 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTRule.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
+#import "Source/santad/Logs/SNTFileEventLog.h"
+#import "Source/santad/Logs/SNTSyslogEventLog.h"
 #import "Source/santad/SNTDatabaseController.h"
 
 @interface SNTEventLog ()
@@ -416,6 +418,26 @@
 #pragma clang diagnostic pop
 
   return [origURL path];  // this will be nil if there was an error
+}
+
++ (instancetype)logger {
+  static SNTEventLog *logger;
+  static dispatch_once_t onceToken;
+  SNTConfigurator *configurator = [SNTConfigurator configurator];
+  dispatch_once(&onceToken, ^{
+    switch ([configurator eventLogType]) {
+      case SNTEventLogTypeSyslog: {
+        logger = [[SNTSyslogEventLog alloc] init];
+        break;
+      }
+      case SNTEventLogTypeFilelog: {
+        logger = [[SNTFileEventLog alloc] init];
+        break;
+      }
+      default: logger = nil;
+    }
+  });
+  return logger;
 }
 
 @end

--- a/Source/santad/SNTCompilerController.h
+++ b/Source/santad/SNTCompilerController.h
@@ -23,8 +23,7 @@
 // Designated initializer takes a SNTEventLog instance so that we can
 // call saveDecisionDetails: to create a fake cached decision for transitive
 // rule creation requests that are still pending.
-- (instancetype)initWithEventProvider:(SNTDriverManager *)driverManager
-                             eventLog:(SNTEventLog *)eventLog;
+- (instancetype)initWithEventProvider:(SNTDriverManager *)driverManager;
 
 // Whenever an executable file is closed or renamed whitelist the resulting file.
 // We assume that we have already determined that the writing process was a compiler.

--- a/Source/santad/SNTCompilerController.m
+++ b/Source/santad/SNTCompilerController.m
@@ -27,17 +27,14 @@
 
 @interface SNTCompilerController ()
 @property id<SNTEventProvider> eventProvider;
-@property SNTEventLog *eventLog;
 @end
 
 @implementation SNTCompilerController
 
-- (instancetype)initWithEventProvider:(id<SNTEventProvider>)eventProvider
-                             eventLog:(SNTEventLog *)eventLog {
+- (instancetype)initWithEventProvider:(id<SNTEventProvider>)eventProvider {
   self = [super init];
   if (self) {
     _eventProvider = eventProvider;
-    _eventLog = eventLog;
   }
   return self;
 }
@@ -50,11 +47,11 @@
   cd.decision = SNTEventStateAllowPendingTransitive;
   cd.vnodeId = message.vnode_id;
   cd.sha256 = @"pending";
-  [self.eventLog cacheDecision:cd];
+  [[SNTEventLog logger] cacheDecision:cd];
 }
 
 - (void)removeFakeDecision:(santa_message_t)message {
-  [self.eventLog forgetCachedDecisionForVnodeId:message.vnode_id];
+  [[SNTEventLog logger] forgetCachedDecisionForVnodeId:message.vnode_id];
 }
 
 // Assume that this method is called only when we already know that the writing process is a
@@ -84,7 +81,7 @@
       if (![ruleTable addRules:@[ rule ] cleanSlate:NO error:&err]) {
         LOGE(@"unable to add new transitive rule to database: %@", err.localizedDescription);
       } else {
-        [self.eventLog
+        [[SNTEventLog logger]
           writeLog:[NSString
                      stringWithFormat:@"action=ALLOWLIST|pid=%d|pidversion=%d|path=%s|sha256=%@",
                                       message.pid, message.pidversion, target, fi.SHA256]];

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -28,6 +28,5 @@
 
 - (instancetype)initWithEventProvider:(SNTDriverManager *)driverManager
                     notificationQueue:(SNTNotificationQueue *)notQueue
-                           syncdQueue:(SNTSyncdQueue *)syncdQueue
-                             eventLog:(SNTEventLog *)eventLog;
+                           syncdQueue:(SNTSyncdQueue *)syncdQueue;
 @end

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -44,7 +44,6 @@ double watchdogRAMPeak = 0;
 @interface SNTDaemonControlController ()
 @property NSString *_syncXsrfToken;
 @property SNTPolicyProcessor *policyProcessor;
-@property SNTEventLog *eventLog;
 @property id<SNTEventProvider> eventProvider;
 @property SNTNotificationQueue *notQueue;
 @property SNTSyncdQueue *syncdQueue;
@@ -54,8 +53,7 @@ double watchdogRAMPeak = 0;
 
 - (instancetype)initWithEventProvider:(id<SNTEventProvider>)eventProvider
                     notificationQueue:(SNTNotificationQueue *)notQueue
-                           syncdQueue:(SNTSyncdQueue *)syncdQueue
-                             eventLog:(SNTEventLog *)eventLog {
+                           syncdQueue:(SNTSyncdQueue *)syncdQueue {
   self = [super init];
   if (self) {
     _policyProcessor =
@@ -63,7 +61,6 @@ double watchdogRAMPeak = 0;
     _eventProvider = eventProvider;
     _notQueue = notQueue;
     _syncdQueue = syncdQueue;
-    _eventLog = eventLog;
   }
   return self;
 }
@@ -303,7 +300,7 @@ double watchdogRAMPeak = 0;
   [eventTable addStoredEvent:event];
 
   // Log all of the generated bundle events.
-  [self.eventLog logBundleHashingEvents:events];
+  [[SNTEventLog logger] logBundleHashingEvents:events];
 
   WEAKIFY(self);
 

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -40,8 +40,7 @@
                             ruleTable:(SNTRuleTable *)ruleTable
                            eventTable:(SNTEventTable *)eventTable
                         notifierQueue:(SNTNotificationQueue *)notifierQueue
-                           syncdQueue:(SNTSyncdQueue *)syncdQueue
-                             eventLog:(SNTEventLog *)eventLog;
+                           syncdQueue:(SNTSyncdQueue *)syncdQueue;
 
 ///
 ///  Handles the logic of deciding whether to allow the binary to run or not, sends the response to

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -46,7 +46,6 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
 
 @interface SNTExecutionController ()
 @property id<SNTEventProvider> eventProvider;
-@property SNTEventLog *eventLog;
 @property SNTEventTable *eventTable;
 @property SNTNotificationQueue *notifierQueue;
 @property SNTPolicyProcessor *policyProcessor;
@@ -64,8 +63,7 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
                             ruleTable:(SNTRuleTable *)ruleTable
                            eventTable:(SNTEventTable *)eventTable
                         notifierQueue:(SNTNotificationQueue *)notifierQueue
-                           syncdQueue:(SNTSyncdQueue *)syncdQueue
-                             eventLog:(SNTEventLog *)eventLog {
+                           syncdQueue:(SNTSyncdQueue *)syncdQueue {
   self = [super init];
   if (self) {
     _eventProvider = eventProvider;
@@ -73,7 +71,6 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
     _eventTable = eventTable;
     _notifierQueue = notifierQueue;
     _syncdQueue = syncdQueue;
-    _eventLog = eventLog;
     _policyProcessor = [[SNTPolicyProcessor alloc] initWithRuleTable:_ruleTable];
 
     _eventQueue = dispatch_queue_create("com.google.santad.event_upload", DISPATCH_QUEUE_SERIAL);
@@ -128,7 +125,7 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
   // ACTION_NOTIFY_EXEC message related to the transitive rule is received.
   NSString *ttyPath;
   if (action == ACTION_RESPOND_ALLOW) {
-    [_eventLog cacheDecision:cd];
+    [[SNTEventLog logger] cacheDecision:cd];
   } else {
     ttyPath = [self ttyPathForPID:message.ppid];
   }
@@ -188,7 +185,7 @@ static size_t kLargeBinarySize = 30 * 1024 * 1024;
 
     // If binary was blocked, do the needful
     if (action != ACTION_RESPOND_ALLOW && action != ACTION_RESPOND_ALLOW_COMPILER) {
-      [_eventLog logDeniedExecution:cd withMessage:message];
+      [[SNTEventLog logger] logDeniedExecution:cd withMessage:message];
 
       if ([[SNTConfigurator configurator] enableBundles] && binInfo.bundle) {
         // If the binary is part of a bundle, find and hash all the related binaries in the bundle.

--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -69,8 +69,7 @@
                                                          ruleTable:self.mockRuleDatabase
                                                         eventTable:self.mockEventDatabase
                                                      notifierQueue:nil
-                                                        syncdQueue:nil
-                                                          eventLog:nil];
+                                                        syncdQueue:nil];
 }
 
 ///  Return a pre-configured santa_message_ t for testing with.


### PR DESCRIPTION
Presently, SNTEventLog is already managed as effectively a singleton by the nature of all of the logging mechanisms themselves within SNTApplication anyways. 

Making our logging layer a (stub-able) singleton simplifies this part of adding other EventProviders, and should make writing "did this attempt to log?" tests easier.