### PR TITLE
Update santactl fileinfo, sync, and status to show teamID info

### DIFF
--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -39,7 +39,7 @@
 ///  Database ops
 ///
 - (void)databaseRuleCounts:(void (^)(int64_t binary, int64_t certificate, int64_t compiler,
-                                     int64_t transitive))reply;
+                                     int64_t transitive, int64_t teamID))reply;
 - (void)databaseEventCount:(void (^)(int64_t count))reply;
 
 ///
@@ -57,6 +57,7 @@
 - (void)decisionForFilePath:(NSString *)filePath
                  fileSHA256:(NSString *)fileSHA256
           certificateSHA256:(NSString *)certificateSHA256
+                     teamID:(NSString *)teamID
                       reply:(void (^)(SNTEventState))reply;
 
 ///

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -203,6 +203,7 @@ REGISTER_COMMAND_NAME(@"rule")
   [[daemonConn remoteObjectProxy] decisionForFilePath:nil
                                            fileSHA256:fileSHA256
                                     certificateSHA256:certificateSHA256
+                                               teamID:teamID
                                                 reply:^(SNTEventState s) {
                                                   output = (SNTEventStateAllow & s)
                                                              ? @"Allowed".mutableCopy

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -94,17 +94,19 @@ REGISTER_COMMAND_NAME(@"status")
   }
 
   // Database counts
-  __block int64_t eventCount = -1, binaryRuleCount = -1, certRuleCount = -1;
+  __block int64_t eventCount = -1, binaryRuleCount = -1, certRuleCount = -1, teamIDRuleCount = -1;
   __block int64_t compilerRuleCount = -1, transitiveRuleCount = -1;
   dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] databaseRuleCounts:^(int64_t binary, int64_t certificate,
-                                                            int64_t compiler, int64_t transitive) {
-    binaryRuleCount = binary;
-    certRuleCount = certificate;
-    compilerRuleCount = compiler;
-    transitiveRuleCount = transitive;
-    dispatch_group_leave(group);
-  }];
+  [[self.daemonConn remoteObjectProxy]
+    databaseRuleCounts:^(int64_t binary, int64_t certificate, int64_t compiler, int64_t transitive,
+                         int64_t teamID) {
+      binaryRuleCount = binary;
+      certRuleCount = certificate;
+      teamIDRuleCount = teamID;
+      compilerRuleCount = compiler;
+      transitiveRuleCount = transitive;
+      dispatch_group_leave(group);
+    }];
   dispatch_group_enter(group);
   [[self.daemonConn remoteObjectProxy] databaseEventCount:^(int64_t count) {
     eventCount = count;
@@ -226,6 +228,7 @@ REGISTER_COMMAND_NAME(@"status")
     printf(">>> Database Info\n");
     printf("  %-25s | %lld\n", "Binary Rules", binaryRuleCount);
     printf("  %-25s | %lld\n", "Certificate Rules", certRuleCount);
+    printf("  %-25s | %lld\n", "TeamID Rules", teamIDRuleCount);
     printf("  %-25s | %lld\n", "Compiler Rules", compilerRuleCount);
     printf("  %-25s | %lld\n", "Transitive Rules", transitiveRuleCount);
     printf("  %-25s | %lld\n", "Events Pending Upload", eventCount);

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.h
@@ -37,6 +37,7 @@ extern NSString *const kBinaryRuleCount;
 extern NSString *const kCertificateRuleCount;
 extern NSString *const kCompilerRuleCount;
 extern NSString *const kTransitiveRuleCount;
+extern NSString *const kTeamIDRuleCount;
 extern NSString *const kFullSyncInterval;
 extern NSString *const kFCMToken;
 extern NSString *const kFCMFullSyncInterval;

--- a/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncConstants.m
@@ -37,6 +37,7 @@ NSString *const kBinaryRuleCount = @"binary_rule_count";
 NSString *const kCertificateRuleCount = @"certificate_rule_count";
 NSString *const kCompilerRuleCount = @"compiler_rule_count";
 NSString *const kTransitiveRuleCount = @"transitive_rule_count";
+NSString *const kTeamIDRuleCount = @"teamid_rule_count";
 NSString *const kFullSyncInterval = @"full_sync_interval";
 NSString *const kFCMToken = @"fcm_token";
 NSString *const kFCMFullSyncInterval = @"fcm_full_sync_interval";

--- a/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncPreflight.m
@@ -43,14 +43,16 @@
 
   dispatch_group_t group = dispatch_group_create();
   dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] databaseRuleCounts:^(int64_t binary, int64_t certificate,
-                                                            int64_t compiler, int64_t transitive) {
-    requestDict[kBinaryRuleCount] = @(binary);
-    requestDict[kCertificateRuleCount] = @(certificate);
-    requestDict[kCompilerRuleCount] = @(compiler);
-    requestDict[kTransitiveRuleCount] = @(transitive);
-    dispatch_group_leave(group);
-  }];
+  [[self.daemonConn remoteObjectProxy]
+    databaseRuleCounts:^(int64_t binary, int64_t certificate, int64_t compiler, int64_t transitive,
+                         int64_t teamID) {
+      requestDict[kBinaryRuleCount] = @(binary);
+      requestDict[kCertificateRuleCount] = @(certificate);
+      requestDict[kCompilerRuleCount] = @(compiler);
+      requestDict[kTransitiveRuleCount] = @(transitive);
+      requestDict[kTeamIDRuleCount] = @(teamID);
+      dispatch_group_leave(group);
+    }];
 
   dispatch_group_enter(group);
   [[self.daemonConn remoteObjectProxy] clientMode:^(SNTClientMode cm) {

--- a/Source/santactl/Commands/sync/SNTCommandSyncTest.m
+++ b/Source/santactl/Commands/sync/SNTCommandSyncTest.m
@@ -201,11 +201,12 @@
 - (void)testPreflightDatabaseCounts {
   SNTCommandSyncPreflight *sut = [[SNTCommandSyncPreflight alloc] initWithState:self.syncState];
 
-  int64_t bin = 5, cert = 8, compiler = 2, transitive = 19;
+  int64_t bin = 5, cert = 8, compiler = 2, transitive = 19, teamID = 3;
   OCMStub([self.daemonConnRop
     databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(bin), OCMOCK_VALUE(cert),
                                                     OCMOCK_VALUE(compiler),
-                                                    OCMOCK_VALUE(transitive), nil])]);
+                                                    OCMOCK_VALUE(transitive), OCMOCK_VALUE(teamID),
+                                                    nil])]);
 
   [self stubRequestBody:nil
                response:nil
@@ -216,6 +217,7 @@
             XCTAssertEqualObjects(requestDict[kCertificateRuleCount], @(8));
             XCTAssertEqualObjects(requestDict[kCompilerRuleCount], @(2));
             XCTAssertEqualObjects(requestDict[kTransitiveRuleCount], @(19));
+            XCTAssertEqualObjects(requestDict[kTeamIDRuleCount], @(3));
             return YES;
           }];
 

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -52,6 +52,11 @@
 - (NSUInteger)certificateRuleCount;
 
 ///
+/// @return Number of team ID rules in the database
+///
+- (NSUInteger)teamIDRuleCount;
+
+///
 ///  @return Rule for binary or certificate with given SHA-256. The binary rule will be returned
 ///          if it exists. If not, the certificate rule will be returned if it exists.
 ///

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -194,6 +194,14 @@ static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
   return count;
 }
 
+- (NSUInteger)teamIDRuleCount {
+  __block NSUInteger count = 0;
+  [self inDatabase:^(FMDatabase *db) {
+    count = [db longForQuery:@"SELECT COUNT(*) FROM rules WHERE type=3"];
+  }];
+  return count;
+}
+
 - (SNTRule *)ruleFromResultSet:(FMResultSet *)rs {
   return [[SNTRule alloc] initWithIdentifier:[rs stringForColumn:@"identifier"]
                                        state:[rs intForColumn:@"state"]

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -157,6 +157,7 @@
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"teamID");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID);
+  XCTAssertEqual([self.sut teamIDRuleCount], 1);
 
   r = [self.sut ruleForBinarySHA256:nil certificateSHA256:nil teamID:@"nonexistentTeamID"];
   XCTAssertNil(r);

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -91,10 +91,10 @@ double watchdogRAMPeak = 0;
 #pragma mark Database ops
 
 - (void)databaseRuleCounts:(void (^)(int64_t binary, int64_t certificate, int64_t compiler,
-                                     int64_t transitive))reply {
+                                     int64_t transitive, int64_t teamID))reply {
   SNTRuleTable *rdb = [SNTDatabaseController ruleTable];
   reply([rdb binaryRuleCount], [rdb certificateRuleCount], [rdb compilerRuleCount],
-        [rdb transitiveRuleCount]);
+        [rdb transitiveRuleCount], [rdb teamIDRuleCount]);
 }
 
 - (void)databaseRuleAddRules:(NSArray *)rules
@@ -148,10 +148,12 @@ double watchdogRAMPeak = 0;
 - (void)decisionForFilePath:(NSString *)filePath
                  fileSHA256:(NSString *)fileSHA256
           certificateSHA256:(NSString *)certificateSHA256
+                     teamID:(NSString *)teamID
                       reply:(void (^)(SNTEventState))reply {
   reply([self.policyProcessor decisionForFilePath:filePath
                                        fileSHA256:fileSHA256
-                                certificateSHA256:certificateSHA256]
+                                certificateSHA256:certificateSHA256
+                                           teamID:teamID]
           .decision);
 }
 

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -58,6 +58,7 @@
 ///
 - (nonnull SNTCachedDecision *)decisionForFilePath:(nonnull NSString *)filePath
                                         fileSHA256:(nullable NSString *)fileSHA256
-                                 certificateSHA256:(nullable NSString *)certificateSHA256;
+                                 certificateSHA256:(nullable NSString *)certificateSHA256
+                                            teamID:(nullable NSString *)teamID;
 
 @end

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -175,7 +175,8 @@
 // Used by `$ santactl fileinfo`.
 - (nonnull SNTCachedDecision *)decisionForFilePath:(nonnull NSString *)filePath
                                         fileSHA256:(nullable NSString *)fileSHA256
-                                 certificateSHA256:(nullable NSString *)certificateSHA256 {
+                                 certificateSHA256:(nullable NSString *)certificateSHA256
+                                            teamID:(nullable NSString *)teamID {
   SNTFileInfo *fileInfo;
   NSError *error;
   fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
@@ -183,7 +184,7 @@
   return [self decisionForFileInfo:fileInfo
                         fileSHA256:fileSHA256
                  certificateSHA256:certificateSHA256
-                            teamID:nil];
+                            teamID:teamID];
 }
 
 ///

--- a/docs/details/rules.md
+++ b/docs/details/rules.md
@@ -65,13 +65,11 @@ Santa ignores the chain and is only concerned with the leaf certificate's
 SHA-256 hash.
 
 ##### Apple Developer Team ID Rules
-The Apple Developer Program Team ID is a 10-character identifier  issued by Apple
+The Apple Developer Program Team ID is a 10-character identifier issued by Apple
 and tied to developer accounts/organizations. This is distinct from Certificates,
 as a single developer account can and frequently will request/rotate between 
-multiple different signing certificates and entitlements.
-
-This is an even more powerful rule with broader reach than individual certificate rules.
-
+multiple different signing certificates and entitlements. This is an even more 
+powerful rule with broader reach than individual certificate rules.
 
 ##### Rule Evaluation
 

--- a/docs/details/rules.md
+++ b/docs/details/rules.md
@@ -5,8 +5,8 @@ parent: Details
 # Rules
 
 Rules provide the primary evaluation mechanism for allowing and blocking
-binaries with Santa on macOS. There are two types of rules: binary and
-certificate.
+binaries with Santa on macOS. There are three types of rules: binary, 
+certificate, and TeamID.
 
 ##### Binary Rules
 
@@ -64,6 +64,15 @@ chain's intermediates or roots has no effect on binaries signing by a leaf.
 Santa ignores the chain and is only concerned with the leaf certificate's
 SHA-256 hash.
 
+##### Apple Developer Team ID Rules
+The Apple Developer Program Team ID is a 10-character identifier  issued by Apple
+and tied to developer accounts/organizations. This is distinct from Certificates,
+as a single developer account can and frequently will request/rotate between 
+multiple different signing certificates and entitlements.
+
+This is an even more powerful rule with broader reach than individual certificate rules.
+
+
 ##### Rule Evaluation
 
 When a process is trying to `execve()` `santad` retrieves information on the
@@ -71,7 +80,7 @@ binary, including a hash of the entire file and the signing chain (if any). The
 hash and signing leaf certificate are then passed through the
 [SNTPolicyProcessor](https://github.com/google/santa/blob/master/Source/santad/SNTPolicyProcessor.h).
 Rules are evaluated from most specific to least specific. First binary (either
-allow or block), then certificate (either allow or block). If no rules are found
+allow or block), then certificate (either allow or block), then team ID (either allow or block). If no rules are found
 that apply, scopes are then searched. See the [scopes.md](scopes.md) document
 for more information on scopes.
 
@@ -121,6 +130,34 @@ For checking the SHA-256 hash of `/usr/bin/yes` signing certificate:
 ```sh
 ⇒  sudo santactl rule --check --certificate --sha256 $(santactl fileinfo --cert-index 1 --key SHA-256 /usr/bin/yes)
 Allowed (Certificate)
+```
+
+##### Allowed with a Team ID rule
+
+```sh
+⇒ santactl fileinfo /Applications/Spotify.app --key Rule
+Allowed (TeamID)
+```
+
+For checking the Team ID of `/Applications/Microsoft\ Remote\ Desktop.app`
+
+```sh
+⇒  santactl fileinfo /Applications/Spotify.app --key "Team ID"
+2FNC3A47ZF
+```
+
+#### Blocked with a Team ID rule
+
+```sh
+⇒ santactl fileinfo /Applications/Microsoft\ Remote\ Desktop.app --key Rule
+Blocked (TeamID)
+```
+
+For checking the Team ID of `/Applications/Microsoft\ Remote\ Desktop.app`
+
+```sh
+⇒  santactl fileinfo /Applications/Microsoft\ Remote\ Desktop.app --key "Team ID"
+UBF8T346G9
 ```
 
 ##### Built-in rules


### PR DESCRIPTION
Some more QOL for working and managing team ID rules. Let me know if there's anywhere else I'm missing

Linked issue: https://github.com/google/santa/issues/634