### PR TITLE
Add required labels for monarchjson

### DIFF
--- a/Source/santad/SNTApplicationCoreMetrics.m
+++ b/Source/santad/SNTApplicationCoreMetrics.m
@@ -85,9 +85,21 @@ static void RegisterMemoryAndCPUMetrics(SNTMetricSet *metricSet) {
 }
 
 static void RegisterHostnameAndUsernameLabels(SNTMetricSet *metricSet) {
-  [metricSet addRootLabel:@"host_name" value:[NSProcessInfo processInfo].hostName];
+  NSString *hostname = [NSProcessInfo processInfo].hostName;
+
+  [metricSet addRootLabel:@"host_name" value:hostname];
   [metricSet addRootLabel:@"username" value:NSUserName()];
   [metricSet addRootLabel:@"job_name" value:@"santad"];
+  [metricSet addRootLabel:@"service_name" value:@"santa"];
+  [metricSet addRootLabel:@"corp_site" value:@""];
+
+  if ([hostname hasSuffix:@".corp.google.com"]) {
+    NSArray<NSString *> *parts = [hostname componentsSeparatedByString:@"."];
+
+    if (parts.count >= 5) {
+      [metricSet addRootLabel:@"corp_site" value:parts[parts.count - 4]];
+    }
+  }
 }
 
 static void RegisterCommonSantaMetrics(SNTMetricSet *metricSet) {

--- a/Source/santad/SNTApplicationCoreMetricsTest.m
+++ b/Source/santad/SNTApplicationCoreMetricsTest.m
@@ -91,6 +91,15 @@
   }
 
   NSDate *fixedDate = [formatter dateFromString:@"2021-09-16T21:07:34.826Z"];
+  NSString *hostname = [NSProcessInfo processInfo].hostName;
+  NSString *expectedCorpSite = @"";
+
+  if ([[hostname lowercaseString] hasSuffix:@"corp.google.com"]) {
+    NSArray<NSString *> *parts = [hostname componentsSeparatedByString:@"."];
+    if (parts.count >= 5) {
+      expectedCorpSite = parts[parts.count - 4];
+    }
+  }
 
   NSDictionary *expected = @{
     @"metrics" : @{
@@ -188,8 +197,10 @@
       },
     },
     @"root_labels" : @{
-      @"host_name" : [NSProcessInfo processInfo].hostName,
+      @"host_name" : hostname,
       @"job_name" : @"santad",
+      @"service_name" : @"santa",
+      @"corp_site" : expectedCorpSite,
       @"username" : [NSProcessInfo processInfo].userName
     },
   };


### PR DESCRIPTION
This PR adds additional root labels  to the SNTApplicationCore metrics that are used by monarch.

Related-issue: #563