### PR TITLE
Project: Add bazel commands extractor for VSCode integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ tulsigen-*
 *.p12
 *.keychain
 *.swp
+compile_commands.json
+.cache/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,6 +20,18 @@ load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependen
 
 apple_support_dependencies()
 
+# Hedron Bazel Compile Commands Extractor
+# Allows integrating with clangd
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+git_repository(
+    name = "hedron_compile_commands",
+    commit = "e085566bf35e020402a2e32258360b16446fbad8",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+    shallow_since = "1638167585 -0800",
+)
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+hedron_compile_commands_setup()
+
 # Macops MOL* dependencies
 
 git_repository(

--- a/external
+++ b/external
@@ -1,0 +1,1 @@
+bazel-out/../../../external


### PR DESCRIPTION
We need to follow-up with docs on using it, with a TL;DR of:

1. Run `bazel run @hedron_compile_commands//:refresh_all`
2. Install (if needed) VSCode and the clangd extension (`code --install-extension llvm-vs-code-extensions.vscode-clangd`)
3. In VSCode settings enable "Clangd: Check Updates" and add the following to "Clangd: Arguments":
    - `--header-insertion=never`
    -  `--compile-commands-dir=${workspaceFolder}/`
4. Reload VScode and open your checked-out santa folder. Wait a while for it to finish indexing, progress will be shown in the bottom left of the window.