### PR TITLE
Fix:  SNTMetricSet reregistering metrics returns wrong metric

### DIFF
--- a/Source/common/SNTMetricSet.m
+++ b/Source/common/SNTMetricSet.m
@@ -521,8 +521,7 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
   SNTMetricCounter *c = [[SNTMetricCounter alloc] initWithName:name
                                                     fieldNames:fieldNames
                                                       helpText:helpText];
-  [self registerMetric:c];
-  return c;
+  return (SNTMetricCounter *)[self registerMetric:c];
 }
 
 - (SNTMetricInt64Gauge *)int64GaugeWithName:(NSString *)name
@@ -531,8 +530,7 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
   SNTMetricInt64Gauge *g = [[SNTMetricInt64Gauge alloc] initWithName:name
                                                           fieldNames:fieldNames
                                                             helpText:helpText];
-  [self registerMetric:g];
-  return g;
+  return (SNTMetricInt64Gauge *)[self registerMetric:g];
 }
 
 - (SNTMetricDoubleGauge *)doubleGaugeWithName:(NSString *)name
@@ -542,8 +540,7 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
                                                             fieldNames:fieldNames
                                                               helpText:helpText];
 
-  [self registerMetric:g];
-  return g;
+  return (SNTMetricDoubleGauge *)[self registerMetric:g];
 }
 
 - (SNTMetricStringGauge *)stringGaugeWithName:(NSString *)name
@@ -553,8 +550,7 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
                                                             fieldNames:fieldNames
                                                               helpText:helpText];
 
-  [self registerMetric:s];
-  return s;
+  return (SNTMetricStringGauge *)[self registerMetric:s];
 }
 
 - (SNTMetricBooleanGauge *)booleanGaugeWithName:(NSString *)name
@@ -564,8 +560,7 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
                                                               fieldNames:fieldNames
                                                                 helpText:helpText];
 
-  [self registerMetric:b];
-  return b;
+  return (SNTMetricBooleanGauge *)[self registerMetric:b];
 }
 
 - (void)addConstantStringWithName:(NSString *)name

--- a/Source/common/SNTMetricSetTest.m
+++ b/Source/common/SNTMetricSetTest.m
@@ -76,6 +76,19 @@
 
   XCTAssertEqualObjects([c export], expected);
 }
+
+- (void)testAddingMetricWithSameSchema {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] init];
+  SNTMetricCounter *a = [metricSet counterWithName:@"/santa/counter"
+                                        fieldNames:@[]
+                                          helpText:@"Test counter."];
+
+  SNTMetricCounter *b = [metricSet counterWithName:@"/santa/counter"
+                                        fieldNames:@[]
+                                          helpText:@"Test counter."];
+
+  XCTAssertEqual(a, b, @"Unexpected new counter returned.");
+}
 @end
 
 @implementation SNTMetricBooleanGaugeTest
@@ -114,6 +127,20 @@
   NSDictionary *output = [b export];
   XCTAssertEqualObjects(output, expected);
 }
+
+- (void)testAddingBooleanWithSameSchema {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] init];
+  SNTMetricBooleanGauge *a = [metricSet booleanGaugeWithName:@"/santa/daemon_connected"
+                                                  fieldNames:@[]
+                                                    helpText:@"Is the daemon connected."];
+
+  SNTMetricBooleanGauge *b = [metricSet booleanGaugeWithName:@"/santa/daemon_connected"
+                                                  fieldNames:@[]
+                                                    helpText:@"Is the daemon connected."];
+
+  XCTAssertEqual(a, b, @"Unexpected new boolean gauge returned.");
+}
+
 @end
 
 @implementation SNTMetricGaugeInt64Test
@@ -168,6 +195,20 @@
 
   XCTAssertEqualObjects([g export], expected);
 }
+
+- (void)testAddingMetricWithSameSchema {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] init];
+  SNTMetricInt64Gauge *a = [metricSet int64GaugeWithName:@"/santa/int64gauge"
+                                              fieldNames:@[]
+                                                helpText:@"Test gauge."];
+
+  SNTMetricInt64Gauge *b = [metricSet int64GaugeWithName:@"/santa/int64gauge"
+                                              fieldNames:@[]
+                                                helpText:@"Test gauge."];
+
+  XCTAssertEqual(a, b, @"Unexpected new gauge returned.");
+}
+
 @end
 
 @implementation SNTMetricDoubleGaugeTest
@@ -227,6 +268,19 @@
   };
   XCTAssertEqualObjects([g export], expected);
 }
+
+- (void)testAddingMetricWithSameSchema {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] init];
+  SNTMetricDoubleGauge *a = [metricSet doubleGaugeWithName:@"/santa/doublegauge"
+                                                fieldNames:@[]
+                                                  helpText:@"Test gauge."];
+
+  SNTMetricDoubleGauge *b = [metricSet doubleGaugeWithName:@"/santa/doublegauge"
+                                                fieldNames:@[]
+                                                  helpText:@"Test gauge."];
+
+  XCTAssertEqual(a, b, @"Unexpected new gauge returned.");
+}
 @end
 
 @implementation SNTMetricStringGaugeTest
@@ -240,6 +294,7 @@
   [s set:@"testValue" forFieldValues:@[]];
   XCTAssertEqualObjects([s getStringValueForFieldValues:@[]], @"testValue");
 }
+
 - (void)testExportNSDictionary {
   SNTMetricSet *metricSet = [[SNTMetricSet alloc] init];
   SNTMetricStringGauge *s = [metricSet stringGaugeWithName:@"/santa/mode"
@@ -264,6 +319,20 @@
 
   XCTAssertEqualObjects([s export], expected);
 }
+
+- (void)testAddingMetricWithSameSchema {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] init];
+  SNTMetricStringGauge *a = [metricSet stringGaugeWithName:@"/santa/stringgauge"
+                                                fieldNames:@[]
+                                                  helpText:@"Test gauge."];
+
+  SNTMetricStringGauge *b = [metricSet stringGaugeWithName:@"/santa/stringgauge"
+                                                fieldNames:@[]
+                                                  helpText:@"Test gauge."];
+
+  XCTAssertEqual(a, b, @"Unexpected new gauge returned.");
+}
+
 @end
 
 @implementation SNTMetricSetTest
@@ -550,7 +619,6 @@
 
   XCTAssertEqualObjects([metricSet export], expected);
 }
-
 @end
 
 @implementation SNTMetricSetHelperFunctionsTest


### PR DESCRIPTION
In a few cases I forgot to return the correct object from `[SNTMetricSet registerMetrics]`. Normally this isn't an issue as we're only registering metrics once. 

However for unit tests it breaks everything that uses the sharedInstance of the SNTMetricSet.