### PR TITLE
Fix: santactl metrics command behavior

### DIFF
--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -246,11 +246,6 @@ double watchdogRAMPeak = 0;
 #pragma mark Metrics Ops
 
 - (void)metrics:(void (^)(NSDictionary *))reply {
-  // If metrics are not enabled send nil back
-  if (![[SNTConfigurator configurator] exportMetrics]) {
-    reply(nil);
-  }
-
   SNTMetricSet *metricSet = [SNTMetricSet sharedInstance];
   reply([metricSet export]);
 }


### PR DESCRIPTION
 Removed the check for export metrics in santad. Metrics are always collected but only exported to a monitoring system when all of the necessary config options are set. Since they're always collected `santactl metrics` should always return metrics data.

Related issues: #563