### PR TITLE
Project: Explicitly set calendar on ISO8601 dates

### DIFF
--- a/Source/santad/Logs/SNTEventLog.m
+++ b/Source/santad/Logs/SNTEventLog.m
@@ -52,6 +52,7 @@
 
     _dateFormatter = [[NSDateFormatter alloc] init];
     _dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    _dateFormatter.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601];
     _dateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
 
     // Grab the system UUID on init

--- a/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
+++ b/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
@@ -29,8 +29,9 @@
     formatter = isoFormatter;
   } else {
     NSDateFormatter *localFormatter = [[NSDateFormatter alloc] init];
-    [localFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
-    [localFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+    localFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    localFormatter.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601];
+    localFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
     formatter = localFormatter;
   }
 

--- a/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricRawJSONFormat.m
@@ -24,7 +24,8 @@
   if (self) {
     _dateFormatter = [[NSDateFormatter alloc] init];
     _dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    _dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+    _dateFormatter.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601];
+    _dateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
   }
   return self;
 }

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -51,8 +51,10 @@ NSDictionary *validMetricsDict = nil;
 - (NSDate *)createNSDateFromDateString:(NSString *)dateString {
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
 
-  [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+  formatter = [[NSDateFormatter alloc] init];
+  formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+  formatter.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601];
+  formatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
 
   return [formatter dateFromString:dateString];
 }


### PR DESCRIPTION
I left the `NSDateFormatter`'s from `santactl status` and `santactl fileinfo` as they were as the dates they produce are user-facing.