### PR TITLE
Support rule downloading of Team ID rules

### DIFF
--- a/Source/santasyncservice/SNTSyncConstants.h
+++ b/Source/santasyncservice/SNTSyncConstants.h
@@ -96,6 +96,7 @@ extern NSString *const kEventUploadBundleBinaries;
 
 extern NSString *const kRules;
 extern NSString *const kRuleSHA256;
+extern NSString *const kRuleIdentifier;
 extern NSString *const kRulePolicy;
 extern NSString *const kRulePolicyAllowlist;
 extern NSString *const kRulePolicyAllowlistDeprecated;
@@ -109,6 +110,7 @@ extern NSString *const kRulePolicyRemove;
 extern NSString *const kRuleType;
 extern NSString *const kRuleTypeBinary;
 extern NSString *const kRuleTypeCertificate;
+extern NSString *const kRuleTypeTeamID;
 extern NSString *const kRuleCustomMsg;
 extern NSString *const kCursor;
 

--- a/Source/santasyncservice/SNTSyncConstants.m
+++ b/Source/santasyncservice/SNTSyncConstants.m
@@ -97,6 +97,7 @@ NSString *const kEventUploadBundleBinaries = @"event_upload_bundle_binaries";
 
 NSString *const kRules = @"rules";
 NSString *const kRuleSHA256 = @"sha256";
+NSString *const kRuleIdentifier = @"identifier";
 NSString *const kRulePolicy = @"policy";
 NSString *const kRulePolicyAllowlist = @"ALLOWLIST";
 NSString *const kRulePolicyAllowlistDeprecated = @"WHITELIST";
@@ -110,6 +111,7 @@ NSString *const kRulePolicyRemove = @"REMOVE";
 NSString *const kRuleType = @"rule_type";
 NSString *const kRuleTypeBinary = @"BINARY";
 NSString *const kRuleTypeCertificate = @"CERTIFICATE";
+NSString *const kRuleTypeTeamID = @"TEAMID";
 NSString *const kRuleCustomMsg = @"custom_msg";
 NSString *const kCursor = @"cursor";
 

--- a/Source/santasyncservice/SNTSyncRuleDownload.m
+++ b/Source/santasyncservice/SNTSyncRuleDownload.m
@@ -137,6 +137,9 @@
 
   SNTRule *newRule = [[SNTRule alloc] init];
   newRule.identifier = dict[kRuleSHA256];
+  if (newRule.identifier == nil) {
+    newRule.identifier = dict[kRuleIdentifier];
+  }
 
   NSString *policyString = dict[kRulePolicy];
   if ([policyString isEqual:kRulePolicyAllowlist] ||
@@ -162,6 +165,8 @@
     newRule.type = SNTRuleTypeBinary;
   } else if ([ruleTypeString isEqual:kRuleTypeCertificate]) {
     newRule.type = SNTRuleTypeCertificate;
+  } else if ([ruleTypeString isEqual:kRuleTypeTeamID]) {
+    newRule.type = SNTRuleTypeTeamID;
   } else {
     return nil;
   }

--- a/Source/santasyncservice/SNTSyncTest.m
+++ b/Source/santasyncservice/SNTSyncTest.m
@@ -422,6 +422,10 @@
                    state:SNTRuleStateBlock
                     type:SNTRuleTypeCertificate
                customMsg:@"Hi There"],
+    [[SNTRule alloc] initWithIdentifier:@"2FNC3A47ZF"
+                                  state:SNTRuleStateBlock
+                                   type:SNTRuleTypeTeamID
+                              customMsg:@"Banned team ID"],
   ];
 
   OCMVerify([self.daemonConnRop databaseRuleAddRules:rules cleanSlate:NO reply:OCMOCK_ANY]);

--- a/Source/santasyncservice/testdata/sync_ruledownload_batch2.json
+++ b/Source/santasyncservice/testdata/sync_ruledownload_batch2.json
@@ -1,1 +1,1 @@
-{"rules": [{"rule_type": "CERTIFICATE", "policy": "BLACKLIST", "sha256": "7846698e47ef41be80b83fb9e2b98fa6dc46c9188b068bff323c302955a00142", "custom_msg": "Hi There"}]}
+{"rules": [{"rule_type": "CERTIFICATE", "policy": "BLACKLIST", "sha256": "7846698e47ef41be80b83fb9e2b98fa6dc46c9188b068bff323c302955a00142", "custom_msg": "Hi There"},{"rule_type":"TEAMID", "policy":"BLOCKLIST", "identifier": "2FNC3A47ZF", "custom_msg": "Banned team ID"}]}


### PR DESCRIPTION
As part of this, allow "identifier" instead of "sha256" as the key for identifying a rule in the sync protoocol. 

Linked Issue: https://github.com/google/santa/issues/634