### PR TITLE
Fix off-by one error in strlcpy.

### DIFF
--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -67,9 +67,7 @@
   if (message.es_message) {
     es_message_t *m = message.es_message;
     es_string_token_t path = m->process->executable->path;
-    size_t length = path.length;
-    if (length++ > PATH_MAX) length = PATH_MAX;
-    strlcpy(ppath, path.data, length);
+    strlcpy(ppath, path.data, sizeof(ppath));
   } else {
     proc_pidpath(message.pid, ppath, PATH_MAX);
   }


### PR DESCRIPTION
This fixes an off-by one introduced in #707, that came up when talking with @mlw. 