### PR TITLE
Conf: Delete and clean-up ASL conf, enable signaling on newsyslog.conf.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -99,7 +99,6 @@ genrule(
         "Conf/com.google.santa.metricservice.plist",
         "Conf/com.google.santad.plist",
         "Conf/com.google.santa.plist",
-        "Conf/com.google.santa.asl.conf",
         "Conf/com.google.santa.newsyslog.conf",
         "Conf/Package/Distribution.xml",
         "Conf/Package/notarization_tool.sh",

--- a/Conf/com.google.santa.asl.conf
+++ b/Conf/com.google.santa.asl.conf
@@ -1,6 +1,0 @@
-# Copy this file to /etc/asl to log all messages from santa-driver to the log file
-> /var/db/santa/santa.log format="[$((Time)(ISO8601Z.3))] $Message" mode=0644 rotate=seq compress file_max=25M all_max=100M uid=0 gid=0
-? [= Sender kernel] [S= Message santa-driver:] claim
-? [= Sender kernel] [S= Message santa-driver:] file /var/db/santa/santa.log
-? [= Facility com.google.santa] claim
-? [= Facility com.google.santa] file /var/db/santa/santa.log

--- a/Conf/com.google.santa.newsyslog.conf
+++ b/Conf/com.google.santa.newsyslog.conf
@@ -1,2 +1,2 @@
 # logfilename             [owner:group]       mode   count size(KiB) when   flags [/pid_file] # [sig_num]
-/var/db/santa/santa.log   root:wheel          644    10    25000     *      NZ
+/var/db/santa/santa.log   root:wheel          644    10    25000     *      Z

--- a/Conf/install.sh
+++ b/Conf/install.sh
@@ -46,6 +46,7 @@ GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 /bin/rm /usr/sbin/santactl >/dev/null 2>&1
 /bin/rm -rf /Applications/Santa.app 2>&1
 /bin/rm -rf /Library/Extensions/santa-driver.kext 2>&1
+/bin/rm /etc/asl/com.google.santa.asl.conf
 
 # Copy new files.
 /bin/mkdir -p /var/db/santa
@@ -63,7 +64,6 @@ GUI_USER=$(/usr/bin/stat -f '%u' /dev/console)
 /bin/cp ${CONF}/com.google.santa.bundleservice.plist /Library/LaunchDaemons
 /bin/cp ${CONF}/com.google.santa.metricservice.plist /Library/LaunchDaemons
 /bin/cp ${CONF}/com.google.santad.plist /Library/LaunchDaemons
-/bin/cp ${CONF}/com.google.santa.asl.conf /etc/asl/
 /bin/cp ${CONF}/com.google.santa.newsyslog.conf /etc/newsyslog.d/
 
 # Reload syslogd to pick up ASL configuration change.


### PR DESCRIPTION
The ASL config is a remnant from when Santa did all logging via ASL before Apple deprecated ASL and replaced it with ULS, which doesn't allow redirecting messages to a file. The old config wasn't causing any problems except that it was handling battling newsyslog for rotation and had different parameters.

The signal change in the newsyslog.conf causes newsyslog to fallback on sending a (harmless) SIGHUP to syslogd, which has no effect on Santa except it also triggers a 10s sleep inside newsyslog between renaming the old file and beginning the compression, which is plenty of time for santad to notice the rename and start writing new logs to the newer file.