### PR TITLE
rule download: return early on daemon timeout

### DIFF
--- a/Source/santasyncservice/SNTSyncRuleDownload.m
+++ b/Source/santasyncservice/SNTSyncRuleDownload.m
@@ -46,7 +46,7 @@
                                                         dispatch_semaphore_signal(sema);
                                                       }];
   if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 300 * NSEC_PER_SEC))) {
-    LOGE(@"Failed to add rule(s) to database: timeout connecting to daemon");
+    LOGE(@"Failed to add rule(s) to database: timeout sending rules to daemon");
     return NO;
   }
 

--- a/Source/santasyncservice/SNTSyncRuleDownload.m
+++ b/Source/santasyncservice/SNTSyncRuleDownload.m
@@ -45,7 +45,10 @@
                                                         error = e;
                                                         dispatch_semaphore_signal(sema);
                                                       }];
-  dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 300 * NSEC_PER_SEC));
+  if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 300 * NSEC_PER_SEC))) {
+    LOGE(@"Failed to add rule(s) to database: timeout connecting to daemon");
+    return NO;
+  }
 
   if (error) {
     LOGE(@"Failed to add rule(s) to database: %@", error.localizedDescription);


### PR DESCRIPTION
* This fixes a potential bug where the postflight could run even though the rules didn't apply.