### PR TITLE
santad: only store events if there is a sync server configured

### DIFF
--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -223,9 +223,12 @@ static NSString *const kPrinterProxyPostMonterey =
     se.quarantineTimestamp = binInfo.quarantineTimestamp;
     se.quarantineAgentBundleID = binInfo.quarantineAgentBundleID;
 
-    dispatch_async(_eventQueue, ^{
-      [self.eventTable addStoredEvent:se];
-    });
+    // Only store events if there is a sync server configured.
+    if ([SNTConfigurator configurator].syncBaseURL) {
+      dispatch_async(_eventQueue, ^{
+        [self.eventTable addStoredEvent:se];
+      });
+    }
 
     // If binary was blocked, do the needful
     if (action != ACTION_RESPOND_ALLOW && action != ACTION_RESPOND_ALLOW_COMPILER) {

--- a/Source/santad/SNTExecutionControllerTest.m
+++ b/Source/santad/SNTExecutionControllerTest.m
@@ -53,6 +53,8 @@
 
   self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
   OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  NSURL *url = [NSURL URLWithString:@"https://localhost/test"];
+  OCMStub([self.mockConfigurator syncBaseURL]).andReturn(url);
 
   self.mockDriverManager = OCMClassMock([SNTDriverManager class]);
 


### PR DESCRIPTION
Fixes #705 