### PR TITLE
Fix additional strlcpy issue, simplify call paths

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityManager.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManager.h
@@ -30,10 +30,6 @@
 // The populated buffer will be NUL terminated.
 + (BOOL)populateBufferFromESFile:(es_file_t *)file buffer:(char *)buffer size:(size_t)size;
 
-// Returns YES if the path was truncated.
-// The populated buffer will be NUL terminated.
-+ (BOOL)populateBufferFromString:(const char *)string buffer:(char *)buffer size:(size_t)size;
-
 @property(nonatomic, copy) void (^decisionCallback)(santa_message_t);
 @property(nonatomic, copy) void (^logCallback)(santa_message_t);
 @property(readonly, nonatomic) es_client_t *client;

--- a/Source/santad/EventProviders/SNTEndpointSecurityManager.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityManager.h
@@ -19,15 +19,20 @@
 
 #include <EndpointSecurity/EndpointSecurity.h>
 
-// Gleaned from https://opensource.apple.com/source/xnu/xnu-4903.241.1/bsd/sys/proc_internal.h
-const pid_t PID_MAX = 99999;
-
 @interface SNTEndpointSecurityManager : NSObject <SNTEventProvider>
 - (santa_vnode_id_t)vnodeIDForFile:(es_file_t *)file;
 
 - (BOOL)isCompilerPID:(pid_t)pid;
 - (void)setIsCompilerPID:(pid_t)pid;
 - (void)setNotCompilerPID:(pid_t)pid;
+
+// Returns YES if the path was truncated.
+// The populated buffer will be NUL terminated.
++ (BOOL)populateBufferFromESFile:(es_file_t *)file buffer:(char *)buffer size:(size_t)size;
+
+// Returns YES if the path was truncated.
+// The populated buffer will be NUL terminated.
++ (BOOL)populateBufferFromString:(const char *)string buffer:(char *)buffer size:(size_t)size;
 
 @property(nonatomic, copy) void (^decisionCallback)(santa_message_t);
 @property(nonatomic, copy) void (^logCallback)(santa_message_t);

--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -21,6 +21,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
+#import "Source/santad/EventProviders/SNTEndpointSecurityManager.h"
 
 @implementation SNTSyslogEventLog
 
@@ -66,10 +67,11 @@
   char ppath[PATH_MAX] = "(null)";
   if (message.es_message) {
     es_message_t *m = message.es_message;
-    es_string_token_t path = m->process->executable->path;
-    strlcpy(ppath, path.data, sizeof(ppath));
+    [SNTEndpointSecurityManager populateBufferFromESFile:m->process->executable
+                                                  buffer:ppath
+                                                    size:sizeof(ppath)];
   } else {
-    proc_pidpath(message.pid, ppath, PATH_MAX);
+    proc_pidpath(message.pid, ppath, sizeof(ppath));
   }
 
   [outStr


### PR DESCRIPTION
This PR streamlines the call paths the utilize `strlcpy`, removing an unnecessary `length` parameter and making use of an existing helper function. This also fixes an off-by-one issue in an existing call to `strlcpy`.