### PR TITLE
Fix: remediate a crash in santametricservice

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -439,6 +439,11 @@
 @property(readonly, nonatomic) NSUInteger metricExportInterval;
 
 ///
+/// Duration in seconds for metrics export timeout. Defaults to 30;
+///
+@property(readonly, nonatomic) NSUInteger metricExportTimeout;
+
+///
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -110,6 +110,7 @@ static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 static NSString *const kMetricFormat = @"MetricFormat";
 static NSString *const kMetricURL = @"MetricURL";
 static NSString *const kMetricExportInterval = @"MetricExportInterval";
+static NSString *const kMetricExportTimeout = @"MetricExportTimeout";
 static NSString *const kMetricExtraLabels = @"MetricExtraLabels";
 
 // The keys managed by a sync server.
@@ -193,6 +194,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kMetricFormat : string,
       kMetricURL : string,
       kMetricExportInterval : number,
+      kMetricExportTimeout : number,
       kMetricExtraLabels : dictionary,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
@@ -758,6 +760,19 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   }
   return [configuredInterval unsignedIntegerValue];
 }
+
+// Returns a default value of 30 (for 30 seconds).
+- (NSUInteger)metricExportTimeout {
+  NSNumber *configuredInterval = self.configState[kMetricExportTimeout];
+
+  if (configuredInterval == nil) {
+    return 30;
+  }
+  return [configuredInterval unsignedIntegerValue];
+}
+
+
+
 
 - (NSDictionary *)extraMetricLabels {
   return self.configState[kMetricExtraLabels];

--- a/Source/santametricservice/Writers/BUILD
+++ b/Source/santametricservice/Writers/BUILD
@@ -39,6 +39,7 @@ objc_library(
     ],
     deps = [
         ":SNTMetricWriter",
+        "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
         "@MOLAuthenticatingURLSession",
     ],

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -14,6 +14,7 @@
 #import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
 #include <dispatch/dispatch.h>
 
+#import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/santametricservice/Writers/SNTMetricHTTPWriter.h"
 
@@ -79,11 +80,15 @@
 
     [task resume];
 
-    // Wait up to 30 seconds for the request to complete.
-    if (dispatch_group_wait(requests, (int64_t)(30.0 * NSEC_PER_SEC)) != 0) {
+    SNTConfigurator *config = [SNTConfigurator configurator];
+    int64_t timeout = (int64_t)config.metricExportTimeout;
+
+    // Wait up to timeout seconds for the request to complete.
+    if (dispatch_group_wait(requests, (timeout * NSEC_PER_SEC)) != 0) {
       [task cancel];
       NSString *errMsg =
-        [NSString stringWithFormat:@"HTTP request to %@ timed out after 30 seconds", url];
+        [NSString stringWithFormat:@"HTTP request to %@ timed out after %lu seconds", url,
+                                   (unsigned long)timeout];
 
       _blockError = [[NSError alloc] initWithDomain:@"com.google.santa.metricservice.writers.http"
                                                code:ETIMEDOUT

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -56,7 +56,8 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | EnableMachineIDDecoration     | Bool       | If YES, this appends the MachineID to the end of each log line. Defaults to NO.       |
 | MetricFormat                  | String     | Format to export metrics as, supported formats are "rawjson" for a single JSON blob and "monarchjson" for a format consumable by Google's Monarch tooling. Defaults to "". |
 | MetricURL                     | String     | URL describing where monitoring metrics should be exported.  |
-| MetricExportInterval          | Integer    | Number of seconds to wait between exporting metrics. Defaults to 30.  
+| MetricExportInterval          | Integer    | Number of seconds to wait between exporting metrics. Defaults to 30.  |
+| MetricExportTimeout           | Integer    | Number of seconds to wait before a timeout occurs when exporting metrics. Defaults to 30.  |
 | MetricExtraLabels             | Dictionary | A map of key value pairs to add to all metric root labels. (e.g. a=b,c=d) defaults to @{}). If a previously set key (e.g. host_name is set to "" then the key is remove from the metric root labels. Alternatively if a value is set for an existing key then the new value will override the old. |
 
 


### PR DESCRIPTION
This PR fixes a crash in santametricservice by making sure to cancel the `NSURLSessionDataTask` when a timeout has been detected. 

The issue was manifesting as a segfault where the stack variable that was captured inside the block was no longer valid.

Additionally this adds a configuration option `MetricExportTimeout` that's used to make this simpler to test and also user tunable.