### PR TITLE
Project: Add build version to CFBundleVersion

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,7 +11,12 @@ exports_files(["LICENSE"])
 # The version label for mac_* rules.
 apple_bundle_version(
     name = "version",
-    build_version = SANTA_VERSION,
+    build_label_pattern = "{build}",
+    build_version = SANTA_VERSION + ".{build}",
+    capture_groups = {
+        "build": "\\d+",
+    },
+    fallback_build_label = "1",
     short_version_string = SANTA_VERSION,
 )
 

--- a/Source/santactl/Commands/SNTCommandVersion.m
+++ b/Source/santactl/Commands/SNTCommandVersion.m
@@ -90,18 +90,25 @@ REGISTER_COMMAND_NAME(@"version")
   return @"not found";
 }
 
+- (NSString *)composeVersionsFromDict:(NSDictionary *)dict {
+  if (!dict[@"CFBundleVersion"]) return @"";
+  NSString *productVersion = dict[@"CFBundleShortVersionString"];
+  NSString *buildVersion = [[dict[@"CFBundleVersion"] componentsSeparatedByString:@"."] lastObject];
+  return [NSString stringWithFormat:@"%@ (build %@)", productVersion, buildVersion];
+}
+
 - (NSString *)santadVersion {
   SNTFileInfo *daemonInfo = [[SNTFileInfo alloc] initWithPath:@(kSantaDPath)];
-  return daemonInfo.bundleVersion ?: @"";
+  return [self composeVersionsFromDict:daemonInfo.infoPlist];
 }
 
 - (NSString *)santaAppVersion {
   SNTFileInfo *guiInfo = [[SNTFileInfo alloc] initWithPath:@(kSantaAppPath)];
-  return guiInfo.bundleVersion ?: @"";
+  return [self composeVersionsFromDict:guiInfo.infoPlist];
 }
 
 - (NSString *)santactlVersion {
-  return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] ?: @"";
+  return [self composeVersionsFromDict:[[NSBundle mainBundle] infoDictionary]];
 }
 
 @end

--- a/Source/santad/main.m
+++ b/Source/santad/main.m
@@ -122,12 +122,16 @@ int main(int argc, const char *argv[]) {
     NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
     NSProcessInfo *pi = [NSProcessInfo processInfo];
 
+    NSString *productVersion = infoDict[@"CFBundleShortVersionString"];
+    NSString *buildVersion =
+      [[infoDict[@"CFBundleVersion"] componentsSeparatedByString:@"."] lastObject];
+
     if ([pi.arguments containsObject:@"-v"]) {
-      printf("%s\n", [infoDict[@"CFBundleVersion"] UTF8String]);
+      printf("%s (build %s)\n", [productVersion UTF8String], [buildVersion UTF8String]);
       return 0;
     }
 
-    LOGI(@"Started, version %@", infoDict[@"CFBundleVersion"]);
+    LOGI(@"Started, version %@ (build %@)", productVersion, buildVersion);
 
     // Handle the case of macOS < 10.15 updating to >= 10.15.
     if ([[SNTConfigurator configurator] enableSystemExtension]) {


### PR DESCRIPTION
This adds the current build version as the final component of the CFBundleVersion (e.g. `2022.2.429612858`) and includes the build version in `santactl version` output:

```
santad          | 2022.2 (build 429612858)
santactl        | 2022.2 (build 429612858)
SantaGUI        | 2022.2 (build 429612858)
```

The CFBundleShortVersionString remains the "product" version to match GH releases. I did not add the build version to the kernel extension as the version formatting there is much more strict and we're likely removing it before the next release anyway.