### PR TITLE
Fix: Typo in SNTDeviceManager tests & ensure tests run under CI

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -325,6 +325,7 @@ test_suite(
     tests = [
         ":SNTApplicationCoreMetricsTest",
         ":SNTApplicationTest",
+        ":SNTDeviceManagerTest",
         ":SNTEndpointSecurityManagerTest",
         ":SNTEventTableTest",
         ":SNTExecutionControllerTest",

--- a/Source/santad/EventProviders/SNTDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTDeviceManagerTest.mm
@@ -138,7 +138,7 @@
 
   __block NSString *gotmntonname, *gotmntfromname;
   __block NSArray<NSString *> *gotRemountedArgs;
-  deviceManager.deviceBlockCallbacks = ^(SNTDeviceEvent *event) {
+  deviceManager.deviceBlockCallback = ^(SNTDeviceEvent *event) {
     gotRemountedArgs = event.remountArgs;
     gotmntonname = event.mntonname;
     gotmntfromname = event.mntfromname;
@@ -172,7 +172,7 @@
 
   __block NSString *gotmntonname, *gotmntfromname;
   __block NSArray<NSString *> *gotRemountedArgs;
-  deviceManager.deviceBlockCallbacks = ^(SNTDeviceEvent *event) {
+  deviceManager.deviceBlockCallback = ^(SNTDeviceEvent *event) {
     gotRemountedArgs = event.remountArgs;
     gotmntonname = event.mntonname;
     gotmntfromname = event.mntfromname;


### PR DESCRIPTION
This fixes a typoe in the SNTDeviceManagerTests and adds the test to the santad test suite.