### PR TITLE
Add model identifier to preflight request

### DIFF
--- a/Source/common/SNTSystemInfo.h
+++ b/Source/common/SNTSystemInfo.h
@@ -49,4 +49,9 @@
 ///
 + (NSString *)longHostname;
 
+///
+///  @return Model Identifier
+///
++ (NSString *)modelIdentifier;
+
 @end

--- a/Source/common/SNTSystemInfo.m
+++ b/Source/common/SNTSystemInfo.m
@@ -12,8 +12,8 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-#import <sys/utsname.h>
 #import "Source/common/SNTSystemInfo.h"
+#import <sys/utsname.h>
 
 @implementation SNTSystemInfo
 

--- a/Source/common/SNTSystemInfo.m
+++ b/Source/common/SNTSystemInfo.m
@@ -12,6 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
+#import <sys/utsname.h>
 #import "Source/common/SNTSystemInfo.h"
 
 @implementation SNTSystemInfo
@@ -58,6 +59,12 @@
   char hostname[MAXHOSTNAMELEN];
   gethostname(hostname, (int)sizeof(hostname));
   return @(hostname);
+}
+
++ (NSString *)modelIdentifier {
+  struct utsname systemInfo;
+  uname(&systemInfo);
+  return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
 }
 
 #pragma mark - Internal

--- a/Source/common/SNTSystemInfo.m
+++ b/Source/common/SNTSystemInfo.m
@@ -64,7 +64,7 @@
 + (NSString *)modelIdentifier {
   struct utsname systemInfo;
   uname(&systemInfo);
-  return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+  return @(systemInfo.machine);
 }
 
 #pragma mark - Internal

--- a/Source/common/SNTSystemInfo.m
+++ b/Source/common/SNTSystemInfo.m
@@ -13,7 +13,7 @@
 ///    limitations under the License.
 
 #import "Source/common/SNTSystemInfo.h"
-#import <sys/utsname.h>
+#include <sys/sysctl.h>
 
 @implementation SNTSystemInfo
 
@@ -62,9 +62,10 @@
 }
 
 + (NSString *)modelIdentifier {
-  struct utsname systemInfo;
-  uname(&systemInfo);
-  return @(systemInfo.machine);
+  char model[32];
+  size_t len = 32;
+  sysctlbyname("hw.model", model, &len, NULL, 0);
+  return @(model);
 }
 
 #pragma mark - Internal

--- a/Source/santasyncservice/SNTSyncConstants.h
+++ b/Source/santasyncservice/SNTSyncConstants.h
@@ -21,6 +21,7 @@ extern NSString *const kHostname;
 extern NSString *const kSantaVer;
 extern NSString *const kOSVer;
 extern NSString *const kOSBuild;
+extern NSString *const kModelIdentifier;
 extern NSString *const kPrimaryUser;
 extern NSString *const kRequestCleanSync;
 extern NSString *const kBatchSize;

--- a/Source/santasyncservice/SNTSyncConstants.m
+++ b/Source/santasyncservice/SNTSyncConstants.m
@@ -21,6 +21,7 @@ NSString *const kHostname = @"hostname";
 NSString *const kSantaVer = @"santa_version";
 NSString *const kOSVer = @"os_version";
 NSString *const kOSBuild = @"os_build";
+NSString *const kModelIdentifier = @"model_identifier";
 NSString *const kPrimaryUser = @"primary_user";
 NSString *const kRequestCleanSync = @"request_clean_sync";
 NSString *const kBatchSize = @"batch_size";

--- a/Source/santasyncservice/SNTSyncPreflight.m
+++ b/Source/santasyncservice/SNTSyncPreflight.m
@@ -37,6 +37,7 @@
   requestDict[kHostname] = [SNTSystemInfo longHostname];
   requestDict[kOSVer] = [SNTSystemInfo osVersion];
   requestDict[kOSBuild] = [SNTSystemInfo osBuild];
+  requestDict[kModelIdentifier] = [SNTSystemInfo modelIdentifier];
   requestDict[kSantaVer] = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
   requestDict[kPrimaryUser] = self.syncState.machineOwner;
   if (self.syncState.FCMToken) requestDict[kFCMToken] = self.syncState.FCMToken;


### PR DESCRIPTION
This is something that could help us identify some machines. I still haven't managed to properly test custom built Santa versions, so I can only guarantee that it compiles. Sorry.