### PR TITLE
Remove code guarded by #ifdef kernel macros

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -3,7 +3,7 @@ load("@rules_proto_grpc//objc:defs.bzl", "objc_proto_library")
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["-layering_check"],
+    features = ["layering_check"],
 )
 
 licenses(["notice"])

--- a/Source/common/SNTCommon.h
+++ b/Source/common/SNTCommon.h
@@ -16,39 +16,15 @@
 /// Common defines between kernel <-> userspace
 ///
 
-#ifndef SANTA__COMMON__KERNELCOMMON_H
-#define SANTA__COMMON__KERNELCOMMON_H
+#ifndef SANTA__COMMON__COMMON_H
+#define SANTA__COMMON__COMMON_H
 
 #include <stdint.h>
 #include <sys/param.h>
 
-// Defines the name of the userclient class and the driver bundle ID.
-#define USERCLIENT_CLASS "com_google_SantaDriver"
-#define USERCLIENT_ID "com.google.santa-driver"
-
 // Branch prediction
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
-
-// List of methods supported by the driver.
-enum SantaDriverMethods {
-  kSantaUserClientOpen,
-  kSantaUserClientAllowBinary,
-  kSantaUserClientAllowCompiler,
-  kSantaUserClientDenyBinary,
-  kSantaUserClientAcknowledgeBinary,
-  kSantaUserClientClearCache,
-  kSantaUserClientRemoveCacheEntry,
-  kSantaUserClientCacheCount,
-  kSantaUserClientCheckCache,
-  kSantaUserClientCacheBucketCount,
-  kSantaUserClientFilemodPrefixFilterAdd,
-  kSantaUserClientFilemodPrefixFilterReset,
-
-  // Any methods supported by the driver should be added above this line to
-  // ensure this remains the count of methods.
-  kSantaUserClientNMethods,
-};
 
 typedef enum {
   QUEUETYPE_DECISION,
@@ -143,4 +119,4 @@ typedef struct {
   uint64_t start;
 } santa_bucket_count_t;
 
-#endif  // SANTA__COMMON__KERNELCOMMON_H
+#endif  // SANTA__COMMON__COMMON_H

--- a/Source/common/SNTCommon.h
+++ b/Source/common/SNTCommon.h
@@ -13,7 +13,7 @@
 ///    limitations under the License.
 
 ///
-/// Common defines between kernel <-> userspace
+/// Common defines between daemon <-> client
 ///
 
 #ifndef SANTA__COMMON__COMMON_H
@@ -25,11 +25,6 @@
 // Branch prediction
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
-
-typedef enum {
-  QUEUETYPE_DECISION,
-  QUEUETYPE_LOG,
-} santa_queuetype_t;
 
 // Enum defining actions that can be passed down the IODataQueue and in
 // response methods.
@@ -112,11 +107,5 @@ typedef struct {
   // NSArray of the arguments.
   void *args_array;
 } santa_message_t;
-
-// Used for the kSantaUserClientCacheBucketCount request.
-typedef struct {
-  uint16_t per_bucket[1024];
-  uint64_t start;
-} santa_bucket_count_t;
 
 #endif  // SANTA__COMMON__COMMON_H

--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -101,7 +101,6 @@ typedef NS_ENUM(NSInteger, SNTMetricFormatType) {
   SNTMetricFormatTypeMonarchJSON,
 };
 
-static const char *kKextPath = "/Library/Extensions/santa-driver.kext";
 static const char *kSantaDPath =
   "/Applications/Santa.app/Contents/Library/SystemExtensions/"
   "com.google.santa.daemon.systemextension/Contents/MacOS/com.google.santa.daemon";

--- a/Source/common/SNTLogging.h
+++ b/Source/common/SNTLogging.h
@@ -13,7 +13,7 @@
 ///    limitations under the License.
 
 ///
-/// Logging definitions, for both kernel and user space.
+/// Logging definitions
 ///
 
 #ifndef SANTA__COMMON__LOGGING_H

--- a/Source/common/SNTLogging.h
+++ b/Source/common/SNTLogging.h
@@ -19,21 +19,6 @@
 #ifndef SANTA__COMMON__LOGGING_H
 #define SANTA__COMMON__LOGGING_H
 
-#ifdef KERNEL
-
-#include <IOKit/IOLib.h>
-
-#ifdef DEBUG
-#define LOGD(format, ...) IOLog("D santa-driver: " format "\n", ##__VA_ARGS__);
-#else  // DEBUG
-#define LOGD(format, ...)
-#endif  // DEBUG
-#define LOGI(format, ...) IOLog("I santa-driver: " format "\n", ##__VA_ARGS__);
-#define LOGW(format, ...) IOLog("W santa-driver: " format "\n", ##__VA_ARGS__);
-#define LOGE(format, ...) IOLog("E santa-driver: " format "\n", ##__VA_ARGS__);
-
-#else  // KERNEL
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -67,7 +52,5 @@ void logMessage(LogLevel level, FILE *destination, NSString *format, ...)
 #ifdef __cplusplus
 }  // extern C
 #endif
-
-#endif  // KERNEL
 
 #endif  // SANTA__COMMON__LOGGING_H

--- a/Source/common/SNTPrefixTree.h
+++ b/Source/common/SNTPrefixTree.h
@@ -18,15 +18,11 @@
 #include <IOKit/IOReturn.h>
 #include <sys/param.h>
 
-#ifdef KERNEL
-#include <libkern/locks.h>
-#else
 // Support for unit testing.
 #include <pthread.h>
 #include <stdint.h>
 
 #include <mutex>
-#endif  // KERNEL
 
 ///
 ///  SantaPrefixTree is a simple prefix tree implementation.
@@ -88,16 +84,8 @@ class SNTPrefixTree {
   uint32_t max_nodes_;
   uint32_t node_count_;
 
-#ifdef KERNEL
-  lck_grp_t *spt_lock_grp_;
-  lck_grp_attr_t *spt_lock_grp_attr_;
-  lck_attr_t *spt_lock_attr_;
-  lck_rw_t *spt_lock_;
-  lck_mtx_t *spt_add_lock_;
-#else   // KERNEL
   pthread_rwlock_t spt_lock_;
   std::mutex *spt_add_lock_;
-#endif  // KERNEL
 };
 
 #endif /* SANTA__SANTA_DRIVER__SANTAPREFIXTREE_H */

--- a/Source/common/SantaCache.h
+++ b/Source/common/SantaCache.h
@@ -22,9 +22,6 @@
 
 #include "Source/common/SNTCommon.h"
 
-#ifdef KERNEL
-#include <IOKit/IOLib.h>
-#else  // KERNEL
 // Support for unit testing.
 #include <cstdio>
 #include <cstdlib>
@@ -41,7 +38,6 @@
 #define OSDecrementAtomic(addr) OSAtomicDecrement64((volatile int64_t *)addr)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif  // KERNEL
 
 /**
   A type to specialize to help SantaCache with its hashing.
@@ -375,8 +371,6 @@ class SantaCache {
   }
 };
 
-#ifndef KERNEL
 #pragma clang diagnostic pop
-#endif
 
 #endif  // SANTA__SANTA_DRIVER__SANTACACHE_H

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["-layering_check"],
+    features = ["layering_check"],
 )
 
 objc_library(


### PR DESCRIPTION
This should be the last remaining bits of the kernel extension in our codebase

Linked bug: https://github.com/google/santa/issues/738