### PR TITLE
Project: Make versioning dynamic through bazel's --embed-label.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,5 @@
 load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
 load("//:helper.bzl", "run_command")
-load("//:version.bzl", "SANTA_VERSION")
 
 package(default_visibility = ["//:santa_package_group"])
 
@@ -11,13 +10,14 @@ exports_files(["LICENSE"])
 # The version label for mac_* rules.
 apple_bundle_version(
     name = "version",
-    build_label_pattern = "{build}",
-    build_version = SANTA_VERSION + ".{build}",
+    build_label_pattern = ".*\\.santa_{release}\\.{build}",
+    build_version = "{release}.{build}",
     capture_groups = {
-        "build": "\\d+",
+      "release": "\\d{4}\\.\\d+",
+      "build": "\\d+"
     },
     fallback_build_label = "1",
-    short_version_string = SANTA_VERSION,
+    short_version_string = "{release}",
 )
 
 # Used to detect release builds
@@ -107,7 +107,7 @@ genrule(
         "Conf/Package/postinstall",
         "Conf/Package/preinstall",
     ],
-    outs = ["santa-" + SANTA_VERSION + ".tar.gz"],
+    outs = ["santa-release.tar.gz"],
     cmd = select({
         "//conditions:default": """
         echo "ERROR: Trying to create a release tarball without optimization."

--- a/Source/santa/BUILD
+++ b/Source/santa/BUILD
@@ -66,7 +66,7 @@ macos_application(
     ],
     entitlements = "Santa.app.entitlements",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Dev.provisionprofile",

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -24,7 +24,7 @@ macos_command_line_application(
     name = "santabundleservice",
     bundle_id = "com.google.santa.bundleservice",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.15",
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":santabs_lib"],

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -66,7 +66,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Dev.provisionprofile",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -248,7 +248,7 @@ macos_bundle(
     ],
     infoplists = ["Info.plist"],
     linkopts = ["-execute"],
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
         "//conditions:default": "Santa_Daemon_Dev.provisionprofile",

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -117,7 +117,7 @@ macos_command_line_application(
     name = "santasyncservice",
     bundle_id = "com.google.santa.syncservice",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.15",
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":santass_lib"],

--- a/helper.bzl
+++ b/helper.bzl
@@ -22,7 +22,7 @@ def santa_unit_test(
         srcs = [],
         deps = [],
         size = "medium",
-        minimum_os_version = "10.9",
+        minimum_os_version = "10.15",
         resources = [],
         structured_resources = [],
         copts = [],

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,0 @@
-"""The version for all Santa components."""
-
-SANTA_VERSION = "2022.3"


### PR DESCRIPTION
The apple_rules allow versioning using an apple_bundle_version rule that extracts elements from an embedded label. We hadn't been able to use this until now because the kernel extension needed access to the version in a define.