### PR TITLE
Project: Fix coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./CoverageData/info.lcov
+          path-to-lcov: ./bazel-out/_coverage/_coverage_report.dat
           flag-name: Unit
 
   benchmark:

--- a/generate_cov.sh
+++ b/generate_cov.sh
@@ -1,39 +1,27 @@
 #!/bin/sh
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
-PROFILE_PATH="$GIT_ROOT/CoverageData"
-COV_FILE="$PROFILE_PATH/info.lcov"
-
-function build() {
-    tests=$(bazel query "tests(//:unit_tests)")
-    for t in $tests; do
-        profname=$(echo $t | shasum | awk '{print $1}')
-        bazel coverage \
-                --test_env="LLVM_PROFILE_FILE=$PROFILE_PATH/$profname.profraw" \
-                --experimental_use_llvm_covmap \
-                --spawn_strategy=standalone \
-                --cache_test_results=no \
-                --test_env=LCOV_MERGER=/usr/bin/true \
-                $t
-    done
-    xcrun llvm-profdata merge $PROFILE_PATH/*.profraw -output "$PROFILE_PATH/default.profdata"
-}
-
-function generate_lcov() {
-    object_files=$(find -L $(bazel info bazel-bin) -type f -exec file -L {} \; | grep "Mach-O" | sed 's,:.*,,' | grep -v 'testdata' | grep -v 'bazel-out')
-    bazel_base=$(bazel info execution_root)
-
-    true > $COV_FILE
-    for file in $object_files; do
-        xcrun llvm-cov export -instr-profile "$PROFILE_PATH/default.profdata" -format=lcov \
-            --ignore-filename-regex="/Applications/.*|external/.*" \
-          $file | sed "s,$bazel_base,$GIT_ROOT," >> $COV_FILE
-    done
-
-}
+BAZEL_EXEC_ROOT=$(bazel info execution_root)
+COV_FILE="$(bazel info output_path)/_coverage/_coverage_report.dat"
 
 function main() {
-    mkdir -p $PROFILE_PATH
-    build
-    generate_lcov
+  bazel coverage \
+    --experimental_use_llvm_covmap \
+    --instrument_test_targets \
+    --combined_report=lcov \
+    --spawn_strategy=standalone \
+    --test_env=LCOV_MERGER=/usr/bin/true \
+    //:unit_tests
+
+  # The generated file has most of the source files relative to bazel's
+  # execution_root path, so we strip that off as it prevents files being
+  # picked up by Coveralls.
+  sed -i '' "s,${BAZEL_EXEC_ROOT},${GIT_ROOT}," ${COV_FILE}
+
+  # We also want to filter out files that aren't ours but which sometimes get
+  # coverage data created anyway.
+  sed -i '' '/SF:\/Applications.*/,/end_of_record/d' ${COV_FILE}
+  sed -i '' '/SF:.*santa\/bazel-out.*/,/end_of_record/d' ${COV_FILE}
+
 }
 main


### PR DESCRIPTION
The latest `rules_apple` release makes coverage collection work a little better than before; with the right flags bazel will now generate a merged coverage report for us in a single pass.