### PR TITLE
Update logo image of Santa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Santa [![CI](https://github.com/google/santa/actions/workflows/ci.yml/badge.svg)](https://github.com/google/santa/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/google/santa/badge.svg?branch=main)](https://coveralls.io/github/google/santa?branch=main)
 
 <p align="center">
-    <img src="./Source/santa/Resources/Images.xcassets/AppIcon.appiconset/santa-hat-icon-128.png" alt="Santa Icon" />
+    <img src="https://raw.githubusercontent.com/google/santa/main/Source/santa/Resources/Images.xcassets/AppIcon.appiconset/santa-hat-icon-128.png" alt="Santa Icon" />
 </p>
 
 Santa is a binary authorization system for macOS. It consists of a system 


### PR DESCRIPTION
Change the link to the raw.githubusercontent.com link so that it's still usable when synced internally.