### PR TITLE
Disable layering check for Objective-C

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -3,7 +3,7 @@ load("@rules_proto_grpc//objc:defs.bzl", "objc_proto_library")
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["layering_check"],
+    features = ["-layering_check"],
 )
 
 licenses(["notice"])
@@ -11,6 +11,7 @@ licenses(["notice"])
 proto_library(
     name = "santa_proto",
     srcs = ["santa.proto"],
+    features = ["layering_check"],
     deps = [
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:timestamp_proto",

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["layering_check"],
+    features = ["-layering_check"],
 )
 
 objc_library(

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -3,7 +3,7 @@ load("//:helper.bzl", "santa_unit_test")
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["layering_check"],
+    features = ["-layering_check"],
 )
 
 licenses(["notice"])

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -3,7 +3,7 @@ load("//:helper.bzl", "santa_unit_test")
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["layering_check"],
+    features = ["-layering_check"],
 )
 
 licenses(["notice"])

--- a/Source/santametricservice/Formats/BUILD
+++ b/Source/santametricservice/Formats/BUILD
@@ -2,7 +2,7 @@ load("//:helper.bzl", "santa_unit_test")
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["layering_check"],
+    features = ["-layering_check"],
 )
 
 licenses(["notice"])

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])
 
 package(
     default_visibility = ["//:santa_package_group"],
-    features = ["layering_check"],
+    features = ["-layering_check"],
 )
 
 objc_library(


### PR DESCRIPTION
The Objective-C targets in these packages are currently not layering
check clean.  Disabling layering check ensures that they will continue
to build even when we enable layering check for Objective-C within
Google.

We also need to reenable layering_check on proto_library to avoid
internal breakges, due to 1. proto_library still implying cpp for some
code paths, and 2. disabling cpp layering check requires being on an
allowlist.