### PR TITLE
Add "Team ID" to description on AllowedPathRegex

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -24,8 +24,8 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | ClientMode\*                      | Integer    | 1 = MONITOR, 2 = LOCKDOWN, defaults to MONITOR |
 | FailClosed                        | Bool       | If true and the ClientMode is LOCKDOWN: execution will be denied when there is an error reading or processing an executable file. |
 | FileChangesRegex\*                | String     | The regex of paths to log file changes. Regexes are specified in ICU format. |
-| AllowedPathRegex\*                | String     | A regex to allow if the binary or certificate scopes did not allow/block execution.  Regexes are specified in ICU format. |
-| BlockedPathRegex\*                | String     | A regex to block if the binary or certificate scopes did not allow/block an execution.  Regexes are specified in ICU format. |
+| AllowedPathRegex\*                | String     | A regex to allow if the binary, certificate, or Team ID scopes did not allow/block execution.  Regexes are specified in ICU format. |
+| BlockedPathRegex\*                | String     | A regex to block if the binary, certificate, or Team ID scopes did not allow/block an execution.  Regexes are specified in ICU format. |
 | EnableBadSignatureProtection      | Bool       | Enable bad signature protection, defaults to NO. If this flag is set to YES, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
 | EnablePageZeroProtection          | Bool       | Enable `__PAGEZERO` protection, defaults to YES. If this flag is set to YES, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
 | EnableSysxCache                   | Bool       | Enables a secondary cache that ensures better performance when multiple EndpointSecurity system extensions are installed. Defaults to YES in 2021.8, defaults to NO in earlier versions. |


### PR DESCRIPTION
This came up in the Mac Admins slack. Updating the docs to clarify that AllowedPathRegex also works with Team ID blocking.