### PR TITLE
Created a profiles package so provisioning profiles only need to be in one place.

### DIFF
--- a/Source/santa/BUILD
+++ b/Source/santa/BUILD
@@ -70,7 +70,7 @@ macos_application(
     minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
-        "//conditions:default": "Santa_Dev.provisionprofile",
+        "//conditions:default": "//profiles:santa_dev",
     }),
     version = "//:version",
     visibility = ["//:santa_package_group"],

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -32,7 +32,7 @@ macos_command_line_application(
     minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
-        "//conditions:default": "Santa_Dev.provisionprofile",
+        "//conditions:default": "//profiles:santa_dev",
     }),
     version = "//:version",
     visibility = ["//:santa_package_group"],

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -70,7 +70,7 @@ macos_command_line_application(
     minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
-        "//conditions:default": "Santa_Dev.provisionprofile",
+        "//conditions:default": "//profiles:santa_dev",
     }),
     version = "//:version",
     deps = [":santactl_lib"],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -251,7 +251,7 @@ macos_bundle(
     minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
-        "//conditions:default": "Santa_Daemon_Dev.provisionprofile",
+        "//conditions:default": "//profiles:daemon_dev",
     }),
     version = "//:version",
     visibility = ["//:santa_package_group"],

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -62,7 +62,7 @@ macos_command_line_application(
     minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
-        "//conditions:default": "Santa_Dev.provisionprofile",
+        "//conditions:default": "//profiles:santa_dev",
     }),
     version = "//:version",
     visibility = ["//:santa_package_group"],

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -151,7 +151,7 @@ macos_command_line_application(
     minimum_os_version = "10.15",
     provisioning_profile = select({
         "//:ci_build": None,
-        "//conditions:default": "Santa_Dev.provisionprofile",
+        "//conditions:default": "//profiles:santa_dev",
     }),
     version = "//:version",
     visibility = ["//:santa_package_group"],

--- a/profiles/BUILD
+++ b/profiles/BUILD
@@ -1,0 +1,16 @@
+package(
+    default_visibility = ["//:santa_package_group"],
+    features = ["-layering_check"],
+)
+
+licenses(["notice"])
+
+filegroup(
+  name="santa_dev",
+  srcs=["Santa_Dev.provisionprofile"]
+)
+
+filegroup(
+  name="daemon_dev",
+  srcs=["Santa_Daemon_Dev.provisionprofile"],
+)


### PR DESCRIPTION
This PR puts all of the provisioning profiles in a top level `profiles` package.

⚠️ This will break your build until you copy the `provisioningprofile`'s to the `/profiles` directory.