### PR TITLE
Add config to allow uploading all events

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -417,6 +417,12 @@
 @property(readonly, nonatomic) BOOL enableCleanSyncEventUpload;
 
 ///
+///  If true, events will be uploaded for all executions, even those that are allowed.
+///  Use with caution, this generates a lot of events. Defaults to false.
+///
+@property(readonly, nonatomic) BOOL enableAllEventUpload;
+
+///
 ///  If true, forks and exits will be logged. Defaults to false.
 ///
 @property(readonly, nonatomic) BOOL enableForkAndExitLogging;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -112,6 +112,7 @@ static NSString *const kAllowedPathRegexKey = @"AllowedPathRegex";
 static NSString *const kAllowedPathRegexKeyDeprecated = @"WhitelistRegex";
 static NSString *const kBlockedPathRegexKey = @"BlockedPathRegex";
 static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
+static NSString *const kEnableAllEventUploadKey = @"EnableAllEventUpload";
 
 // TODO(markowsky): move these to sync server only.
 static NSString *const kMetricFormat = @"MetricFormat";
@@ -147,7 +148,8 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kRemountUSBModeKey : array,
       kFullSyncLastSuccess : date,
       kRuleSyncLastSuccess : date,
-      kSyncCleanRequired : number
+      kSyncCleanRequired : number,
+      kEnableAllEventUploadKey : number,
     };
     _forcedConfigKeyTypes = @{
       kClientModeKey : number,
@@ -208,6 +210,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kMetricExportInterval : number,
       kMetricExportTimeout : number,
       kMetricExtraLabels : dictionary,
+      kEnableAllEventUploadKey : number,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -392,6 +395,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 + (NSSet *)keyPathsForValuesAffectingEnableTransitiveRules {
+  return [self syncAndConfigStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingEnableAllEventUpload {
   return [self syncAndConfigStateSet];
 }
 
@@ -738,6 +745,17 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 - (BOOL)enableCleanSyncEventUpload {
   NSNumber *number = self.configState[kSyncEnableCleanSyncEventUpload];
   return number ? [number boolValue] : NO;
+}
+
+- (BOOL)enableAllEventUpload {
+  NSNumber *n = self.syncState[kEnableAllEventUploadKey];
+  if (n) return [n boolValue];
+
+  return [self.configState[kEnableAllEventUploadKey];
+}
+
+- (void)setEnableAllEventUpload:(BOOL)enabled {
+  [self updateSyncStateForKey:kEnableAllEventUploadKey value:@(enabled)];
 }
 
 - (BOOL)enableForkAndExitLogging {

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -51,6 +51,7 @@
 - (void)setRemountUSBMode:(NSArray *)remountUSBMode reply:(void (^)(void))reply;
 - (void)setEnableBundles:(BOOL)bundlesEnabled reply:(void (^)(void))reply;
 - (void)setEnableTransitiveRules:(BOOL)enabled reply:(void (^)(void))reply;
+- (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply;
 
 ///
 ///  Syncd Ops

--- a/Source/santad/SNTDaemonControlController.m
+++ b/Source/santad/SNTDaemonControlController.m
@@ -252,6 +252,15 @@ double watchdogRAMPeak = 0;
   reply();
 }
 
+- (void)enableAllEventUpload:(void (^)(BOOL))reply {
+  reply([SNTConfigurator configurator].enableAllEventUpload);
+}
+
+- (void)setEnableAllEventUpload:(BOOL)enabled reply:(void (^)(void))reply {
+  [[SNTConfigurator configurator] setEnableAllEventUpload:enabled];
+  reply();
+}
+
 #pragma mark Metrics Ops
 
 - (void)metrics:(void (^)(NSDictionary *))reply {

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -191,9 +191,11 @@ static NSString *const kPrinterProxyPostMonterey =
   [self incrementEventCounters:cd.decision];
 
   // Log to database if necessary.
-  if (cd.decision != SNTEventStateAllowBinary && cd.decision != SNTEventStateAllowCompiler &&
-      cd.decision != SNTEventStateAllowTransitive && cd.decision != SNTEventStateAllowCertificate &&
-      cd.decision != SNTEventStateAllowTeamID && cd.decision != SNTEventStateAllowScope) {
+  if ([[SNTCnfigurator configurator] enableAllEventUpload] ||
+      (cd.decision != SNTEventStateAllowBinary && cd.decision != SNTEventStateAllowCompiler &&
+       cd.decision != SNTEventStateAllowTransitive &&
+       cd.decision != SNTEventStateAllowCertificate && cd.decision != SNTEventStateAllowTeamID &&
+       cd.decision != SNTEventStateAllowScope)) {
     SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
     se.occurrenceDate = [[NSDate alloc] init];
     se.fileSHA256 = cd.sha256;

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -191,7 +191,7 @@ static NSString *const kPrinterProxyPostMonterey =
   [self incrementEventCounters:cd.decision];
 
   // Log to database if necessary.
-  if ([[SNTCnfigurator configurator] enableAllEventUpload] ||
+  if ([[SNTCnfigurator configurator].enableAllEventUpload] ||
       (cd.decision != SNTEventStateAllowBinary && cd.decision != SNTEventStateAllowCompiler &&
        cd.decision != SNTEventStateAllowTransitive &&
        cd.decision != SNTEventStateAllowCertificate && cd.decision != SNTEventStateAllowTeamID &&

--- a/Source/santasyncservice/SNTSyncConstants.h
+++ b/Source/santasyncservice/SNTSyncConstants.h
@@ -50,6 +50,7 @@ extern NSString *const kEnableBundlesDeprecated;
 extern NSString *const kEnableTransitiveRules;
 extern NSString *const kEnableTransitiveRulesDeprecated;
 extern NSString *const kEnableTransitiveRulesSuperDeprecated;
+extern NSString *const kEnableAllEventUpload;
 
 extern NSString *const kEvents;
 extern NSString *const kFileSHA256;

--- a/Source/santasyncservice/SNTSyncConstants.m
+++ b/Source/santasyncservice/SNTSyncConstants.m
@@ -51,6 +51,7 @@ NSString *const kEnableBundlesDeprecated = @"bundles_enabled";
 NSString *const kEnableTransitiveRules = @"enable_transitive_rules";
 NSString *const kEnableTransitiveRulesDeprecated = @"enabled_transitive_whitelisting";
 NSString *const kEnableTransitiveRulesSuperDeprecated = @"transitive_whitelisting_enabled";
+NSString *const kEnableAllEventUpload = @"enable_all_event_upload";
 
 NSString *const kEvents = @"events";
 NSString *const kFileSHA256 = @"file_sha256";

--- a/Source/santasyncservice/SNTSyncPreflight.m
+++ b/Source/santasyncservice/SNTSyncPreflight.m
@@ -106,6 +106,13 @@
                                                             dispatch_group_leave(group);
                                                           }];
 
+  dispatch_group_enter(group);
+  NSNumber *enableAllEventUpload = resp[kEnableAllEventUpload];
+  [[self.daemonConn remoteObjectProxy] setEnableAllEventUpload:[enableAllEventUpload boolValue]
+                                                         reply:^{
+                                                           dispatch_group_leave(group);
+                                                         }];
+
   self.syncState.eventBatchSize = [resp[kBatchSize] unsignedIntegerValue] ?: kDefaultEventBatchSize;
 
   // Don't let these go too low

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -64,6 +64,7 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | MetricExportInterval              | Integer    | Number of seconds to wait between exporting metrics. Defaults to 30.  |
 | MetricExportTimeout               | Integer    | Number of seconds to wait before a timeout occurs when exporting metrics. Defaults to 30.  |
 | MetricExtraLabels                 | Dictionary | A map of key value pairs to add to all metric root labels. (e.g. a=b,c=d) defaults to @{}). If a previously set key (e.g. host_name is set to "" then the key is remove from the metric root labels. Alternatively if a value is set for an existing key then the new value will override the old. |
+| EnableAllEventUpload              | Bool       | If YES, the client will upload all execution events to the sync server, including those that were explicitly allowed. |
 
 
 \*overridable by the sync server: run `santactl status` to check the current
@@ -210,6 +211,7 @@ ways to install configuration profiles:
 | fcm\_global\_rule\_sync\_deadline\* | Integer    | The max time to wait before performing a rule sync when a global rule sync FCM message is received. This allows syncing to be staggered for global events to avoid spikes in server load. Defaults to 600 secs (10 min). |
 | enable\_bundles\*                   | Bool       | If set to `True` the bundle scanning feature is enabled. Defaults to `False`. |
 | enable\_transitive\_rules           | Bool       | If set to `True` the transitive rule feature is enabled. Defaults to `False`. |
+| enable\_all\_event\_upload          | Bool       | If set to `True` the client will upload events for all executions, including those that are explicitly allowed. |
 | block\_usb\_mass\_storage           | Bool       | If set to 'True' blocking USB Mass storage feature is enabled. Defaults to `False`. | 
 | remount\_usb\_mode                  | Array      | Array of strings for arguments to pass to mount -o (any of "rdonly", "noexec", "nosuid", "nobrowse", "noowners", "nodev", "async", "-j"). when forcibly remounting devices. No default. |
 


### PR DESCRIPTION
This config can be enabled by profile or by the sync server and causes the client to upload all events, including those that are explicitly allowed.

Fixes #689