### PR TITLE
Fix ES Mock Client Subscription issues

### DIFF
--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.h
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.h
@@ -73,11 +73,6 @@ API_UNAVAILABLE(ios, tvos, watchos)
 es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
                       es_muted_paths_t * _Nonnull * _Nullable muted_paths);
 
-API_AVAILABLE(macos(12.0))
-API_UNAVAILABLE(ios, tvos, watchos)
-es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
-                      es_muted_paths_t * _Nonnull * _Nullable muted_paths);
-
 API_AVAILABLE(macos(10.15))
 API_UNAVAILABLE(ios, tvos, watchos)
 es_respond_result_t es_respond_auth_result(es_client_t *_Nonnull client,

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.h
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.h
@@ -78,10 +78,6 @@ API_UNAVAILABLE(ios, tvos, watchos)
 es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
                       es_muted_paths_t * _Nonnull * _Nullable muted_paths);
 
-API_AVAILABLE(macos(12.0)) 
-API_UNAVAILABLE(ios, tvos, watchos)
-void es_release_muted_paths(es_muted_paths_t * _Nonnull muted_paths);
-
 API_AVAILABLE(macos(10.15))
 API_UNAVAILABLE(ios, tvos, watchos)
 es_respond_result_t es_respond_auth_result(es_client_t *_Nonnull client,

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.h
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.h
@@ -21,7 +21,8 @@ es_string_token_t MakeStringToken(const NSString *_Nonnull s);
 
 es_file_t MakeESFile(const char *_Nonnull path);
 es_process_t MakeESProcess(es_file_t *_Nonnull esFile);
-es_message_t MakeESMessage(es_event_type_t eventType, es_process_t *_Nonnull instigator, struct timespec ts);
+es_message_t MakeESMessage(es_event_type_t eventType, es_process_t *_Nonnull instigator,
+                           struct timespec ts);
 CF_EXTERN_C_END
 
 @class ESMessage;
@@ -68,10 +69,16 @@ API_UNAVAILABLE(ios, tvos, watchos)
 es_new_client_result_t es_new_client(es_client_t *_Nullable *_Nonnull client,
                                      es_handler_block_t _Nonnull handler);
 
+#if defined(MAC_OS_VERSION_12_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_12_0
 API_AVAILABLE(macos(12.0))
 API_UNAVAILABLE(ios, tvos, watchos)
-es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
-                      es_muted_paths_t * _Nonnull * _Nullable muted_paths);
+es_return_t es_muted_paths_events(es_client_t *_Nonnull client,
+                                  es_muted_paths_t *_Nonnull *_Nullable muted_paths);
+
+API_AVAILABLE(macos(12.0))
+API_UNAVAILABLE(ios, tvos, watchos)
+void es_release_muted_paths(es_muted_paths_t *_Nonnull muted_paths);
+#endif
 
 API_AVAILABLE(macos(10.15))
 API_UNAVAILABLE(ios, tvos, watchos)

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.h
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.h
@@ -68,6 +68,20 @@ API_UNAVAILABLE(ios, tvos, watchos)
 es_new_client_result_t es_new_client(es_client_t *_Nullable *_Nonnull client,
                                      es_handler_block_t _Nonnull handler);
 
+API_AVAILABLE(macos(12.0))
+API_UNAVAILABLE(ios, tvos, watchos)
+es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
+                      es_muted_paths_t * _Nonnull * _Nullable muted_paths);
+
+API_AVAILABLE(macos(12.0))
+API_UNAVAILABLE(ios, tvos, watchos)
+es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
+                      es_muted_paths_t * _Nonnull * _Nullable muted_paths);
+
+API_AVAILABLE(macos(12.0)) 
+API_UNAVAILABLE(ios, tvos, watchos)
+void es_release_muted_paths(es_muted_paths_t * _Nonnull muted_paths);
+
 API_AVAILABLE(macos(10.15))
 API_UNAVAILABLE(ios, tvos, watchos)
 es_respond_result_t es_respond_auth_result(es_client_t *_Nonnull client,

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
@@ -207,7 +207,7 @@ CF_EXTERN_C_END
 }
 
 - (BOOL)removeClient:(es_client_t *_Nonnull)client {
-  MockESClient *clientToRemove = nil;
+  MockESClient *clientToRemove;
   for (MockESClient *c in self.clients) {
     if (client == (__bridge es_client_t *)c) {
       clientToRemove = c;

--- a/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
+++ b/Source/santad/EventProviders/EndpointSecurityTestUtil.mm
@@ -45,7 +45,8 @@ es_process_t MakeESProcess(es_file_t *esFile) {
   return esProc;
 }
 
-es_message_t MakeESMessage(es_event_type_t eventType, es_process_t *instigator, struct timespec ts) {
+es_message_t MakeESMessage(es_event_type_t eventType, es_process_t *instigator,
+                           struct timespec ts) {
   es_message_t esMsg = {};
 
   esMsg.time = ts;
@@ -205,21 +206,21 @@ CF_EXTERN_C_END
   [self.clients addObject:mockClient];
 }
 
-- (BOOL)removeClient:(es_client_t *_Nonnull) client {
+- (BOOL)removeClient:(es_client_t *_Nonnull)client {
   MockESClient *clientToRemove = nil;
   for (MockESClient *c in self.clients) {
-      if (client == (__bridge es_client_t *)c) {
-        clientToRemove = c;
-        break;
-      }
+    if (client == (__bridge es_client_t *)c) {
+      clientToRemove = c;
+      break;
     }
+  }
 
   if (!clientToRemove) {
     NSLog(@"Attempted to remove unknown mock es client.");
     return NO;
   }
 
-  [self.clients removeObject: clientToRemove];
+  [self.clients removeObject:clientToRemove];
   return YES;
 }
 
@@ -299,28 +300,29 @@ es_new_client_result_t es_new_client(es_client_t *_Nullable *_Nonnull client,
   return ES_NEW_CLIENT_RESULT_SUCCESS;
 };
 
+#if defined(MAC_OS_VERSION_12_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_12_0
 API_AVAILABLE(macos(12.0))
 API_UNAVAILABLE(ios, tvos, watchos)
-es_return_t es_muted_paths_events(es_client_t * _Nonnull client, 
-                      es_muted_paths_t * _Nonnull * _Nullable muted_paths) {
-  
+es_return_t es_muted_paths_events(es_client_t *_Nonnull client,
+                                  es_muted_paths_t *_Nonnull *_Nullable muted_paths) {
   es_muted_paths_t *tmp = (es_muted_paths_t *)malloc(sizeof(es_muted_paths_t));
 
   tmp->count = 0;
-  *muted_paths = (es_muted_paths_t * _Nullable)tmp;
+  *muted_paths = (es_muted_paths_t *_Nullable)tmp;
 
   return ES_RETURN_SUCCESS;
 };
 
-API_AVAILABLE(macos(12.0)) 
+API_AVAILABLE(macos(12.0))
 API_UNAVAILABLE(ios, tvos, watchos)
-void es_release_muted_paths(es_muted_paths_t * _Nonnull muted_paths) {
+void es_release_muted_paths(es_muted_paths_t *_Nonnull muted_paths) {
   free(muted_paths);
 }
+#endif
 
 API_AVAILABLE(macos(10.15))
 API_UNAVAILABLE(ios, tvos, watchos) es_return_t es_delete_client(es_client_t *_Nullable client) {
-  if (![[MockEndpointSecurity mockEndpointSecurity] removeClient: client]) {
+  if (![[MockEndpointSecurity mockEndpointSecurity] removeClient:client]) {
     return ES_RETURN_ERROR;
   }
   return ES_RETURN_SUCCESS;


### PR DESCRIPTION
This fixes an issue with the ES mock where it was deleting all clients on an unsubscribe.