### PR TITLE
GUI: Update keys for EventDetailURL.

### DIFF
--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -119,10 +119,15 @@
   if (!formatStr.length) return nil;
 
   if (event.fileSHA256) {
-    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%file_sha%"
+    // This key is deprecated, use %file_identifier% or %bundle_or_file_identifier%
+    formatStr =
+      [formatStr stringByReplacingOccurrencesOfString:@"%file_sha%"
+                                           withString:event.fileBundleHash ?: event.fileSHA256];
+
+    formatStr = [formatStr stringByReplacingOccurrencesOfString:@"%file_identifier%"
                                                      withString:event.fileSHA256];
     formatStr =
-      [formatStr stringByReplacingOccurrencesOfString:@"%bundle_or_file_sha%"
+      [formatStr stringByReplacingOccurrencesOfString:@"%bundle_or_file_identifier%"
                                            withString:event.fileBundleHash ?: event.fileSHA256];
   }
   if (event.executingUser) {

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -78,15 +78,16 @@ take them to a web page with more information about that event.
 This property contains a kind of format string to be turned into the URL to send
 them to. The following sequences will be replaced in the final URL:
 
-| Key                     | Description                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------ |
-| %file_sha%              | SHA-256 of the file that was blocked                                           |
-| %bundle\_or\_file\_sha% | SHA-256 of the file that was blocked or the bundle containing it, if available |
-| %machine\_id%           | ID of the machine                                                              |
-| %username%              | The executing user                                                             |
-| %serial%                | System's serial number                                                         |
-| %uuid%                  | System's UUID                                                                  |
-| %hostname%              | System's full hostname                                                         |
+| Key                            | Description                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| %file_identifier%              | SHA-256 of the file that was blocked                                           |
+| %bundle\_or\_file\_identifier% | SHA-256 of the file that was blocked or the bundle containing it, if available |
+| %file_sha%                     | Deprecated, acts like bundle\_or\_file\_identifier                             |
+| %machine\_id%                  | ID of the machine                                                              |
+| %username%                     | The executing user                                                             |
+| %serial%                       | System's serial number                                                         |
+| %uuid%                         | System's UUID                                                                  |
+| %hostname%                     | System's full hostname                                                         |
 
 For example: `https://sync-server-hostname/%machine_id%/%file_sha%`
 


### PR DESCRIPTION
The previous change here (#797) was not backward compatible and would be difficult to roll out. This change restores the previously used key and adds 2 new ones for migration. The previous key is marked deprecated and will be removed in the future.