### PR TITLE
santad: remove start and stop options from the sync service queue

### DIFF
--- a/Source/santad/SNTSyncdQueue.h
+++ b/Source/santad/SNTSyncdQueue.h
@@ -25,7 +25,5 @@
 
 - (void)addEvents:(NSArray<SNTStoredEvent *> *)events isFromBundle:(BOOL)isFromBundle;
 - (void)addBundleEvent:(SNTStoredEvent *)event reply:(void (^)(SNTBundleEventAction))reply;
-- (void)startSyncingEvents;
-- (void)stopSyncingEvents;
 
 @end


### PR DESCRIPTION
The `startSyncingEvents` and `stopSyncingEvents` were used in SNTDaemonControlController's `-[setSyncdListener:]` method. This allowed upload requests to wait up to 2 seconds for the now legacy syncd connection to become active. The idea was to smooth out any jitter with the connection. The calls to start and stop event uploading were mistakenly removed in https://github.com/google/santa/pull/775, resulting in no santad initiated uploads from taking place. It also means bundle events would never be uploaded.

This pull request removes these start and stop options. In reality the jitter mitigation didn't accomplish much. If the syncservice were to crash or hang it will take longer than a few seconds for the connection to be re-established. In that case we would be dropping the event anyways. We are okay with this, the main event is still saved to the events.db and will be uploaded on the next full sync.