### PR TITLE
GUI: Fix message queuing

### DIFF
--- a/Source/santa/SNTMessageWindowController.m
+++ b/Source/santa/SNTMessageWindowController.m
@@ -28,7 +28,8 @@
 }
 
 - (NSString *)messageHash {
-  return @"";
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
 }
 
 @end

--- a/Source/santa/SNTNotificationManager.m
+++ b/Source/santa/SNTNotificationManager.m
@@ -83,9 +83,7 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 
 - (BOOL)notificationAlreadyQueued:(SNTMessageWindowController *)pendingMsg {
   for (SNTMessageWindowController *msg in self.pendingNotifications) {
-    if ([msg messageHash] == [pendingMsg messageHash]) {
-      return YES;
-    }
+    if ([[msg messageHash] isEqual:[pendingMsg messageHash]]) return YES;
   }
   return NO;
 }
@@ -233,6 +231,14 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
   [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:un];
 }
 
+- (void)postRuleSyncNotificationWithCustomMessage:(NSString *)message {
+  NSUserNotification *un = [[NSUserNotification alloc] init];
+  un.title = @"Santa";
+  un.hasActionButton = NO;
+  un.informativeText = message ?: @"Requested application can now be run";
+  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:un];
+}
+
 - (void)postBlockNotification:(SNTStoredEvent *)event withCustomMessage:(NSString *)message {
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
@@ -243,14 +249,6 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
     [[SNTBinaryMessageWindowController alloc] initWithEvent:event andMessage:message];
 
   [self queueMessage:pendingMsg];
-}
-
-- (void)postRuleSyncNotificationWithCustomMessage:(NSString *)message {
-  NSUserNotification *un = [[NSUserNotification alloc] init];
-  un.title = @"Santa";
-  un.hasActionButton = NO;
-  un.informativeText = message ?: @"Requested application can now be run";
-  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:un];
 }
 
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message {


### PR DESCRIPTION
There are synchronization issues that remain but this change fixes the primary problem that we're not preventing duplicate notifications from being scheduled like we intend.

Part of #791