### PR TITLE
SNTConfigurator: remove mutability from sync state dict

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -28,7 +28,7 @@
 @property(readonly, nonatomic) NSDictionary *forcedConfigKeyTypes;
 
 /// Holds the configurations from a sync server and mobileconfig.
-@property NSMutableDictionary *syncState;
+@property NSDictionary *syncState;
 @property NSMutableDictionary *configState;
 
 /// Was --debug passed as an argument to this process?


### PR DESCRIPTION
The property doesn't need to be mutable, updating the type.