### PR TITLE
preflight sync: stop the sync if we cannot communicate with the daemon

### DIFF
--- a/Source/santasyncservice/SNTSyncPreflight.m
+++ b/Source/santasyncservice/SNTSyncPreflight.m
@@ -75,7 +75,11 @@
     dispatch_group_leave(group);
   }];
 
-  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+  // Stop the sync if we are unable to communicate with daemon.
+  if (!dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC))) {
+    SLOGE(@"Unable to communicate with daemon.");
+    return NO;
+  }
 
   // If user requested it or we've never had a successful sync, try from a clean slate.
   if (syncClean) {


### PR DESCRIPTION
Chatting with @pmarkowsky...it doesn't make much sense to start the sync if we are unable to report key properties to the server such as rule count and client mode.

This pull will stop a preflight if it was unable to contact the daemon.