### PR TITLE
preflight sync: fix dispatch_group_wait return polarity

### DIFF
--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -266,8 +266,8 @@ static void reachabilityHandler(SCNetworkReachabilityRef target, SCNetworkReacha
     return [self eventUploadWithSyncState:syncState];
   }
 
-  SLOGE(@"Preflight failed, will try again once %@ is reachable",
-        [[SNTConfigurator configurator] syncBaseURL].absoluteString);
+  LOGE(@"Preflight failed, will try again once %@ is reachable",
+       [[SNTConfigurator configurator] syncBaseURL].absoluteString);
   [self startReachability];
   return SNTSyncStatusTypePreflightFailed;
 }

--- a/Source/santasyncservice/SNTSyncPreflight.m
+++ b/Source/santasyncservice/SNTSyncPreflight.m
@@ -76,7 +76,7 @@
   }];
 
   // Stop the sync if we are unable to communicate with daemon.
-  if (!dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC))) {
+  if (dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC))) {
     SLOGE(@"Unable to communicate with daemon.");
     return NO;
   }


### PR DESCRIPTION
* dispatch_group_wait returns non-zero on error (i.e. timed out)
* also don't log reachability info to santactl 