### PR TITLE
Improve Santa's logs to be more descriptive.

### DIFF
--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -135,11 +135,14 @@ static NSString *const kPrinterProxyPostMonterey =
   NSError *fileInfoError;
   SNTFileInfo *binInfo = [[SNTFileInfo alloc] initWithPath:@(message.path) error:&fileInfoError];
   if (unlikely(!binInfo)) {
-    LOGE(@"Failed to read file %@: %@", @(message.path), fileInfoError.localizedDescription);
     if (config.failClosed && config.clientMode == SNTClientModeLockdown) {
+      LOGE(@"Failed to read file %@: %@ and denying action", @(message.path),
+           fileInfoError.localizedDescription);
       [self.eventProvider postAction:ACTION_RESPOND_DENY forMessage:message];
       [self.events incrementForFieldValues:@[ (NSString *)kDenyNoFileInfo ]];
     } else {
+      LOGE(@"Failed to read file %@: %@ but allowing action", @(message.path),
+           fileInfoError.localizedDescription);
       [self.eventProvider postAction:ACTION_RESPOND_ALLOW forMessage:message];
       [self.events incrementForFieldValues:@[ (NSString *)kAllowNoFileInfo ]];
     }


### PR DESCRIPTION
Instead of logging that it failed to load the file regardless it killed the process or allowed it afterwards, log whether it was denied or allowed.

Committer: Khaled Fouad <safrout@google.com>