### PR TITLE
Add team ID to synced events

### DIFF
--- a/Source/common/SNTStoredEvent.h
+++ b/Source/common/SNTStoredEvent.h
@@ -95,6 +95,12 @@
 ///
 @property NSArray *signingChain;
 
+
+///
+/// If the executed file was signed, this is the Team ID if present in the signature information.
+///
+@property NSString *teamID;
+
 ///
 ///  The user who executed the binary.
 ///

--- a/Source/common/SNTStoredEvent.m
+++ b/Source/common/SNTStoredEvent.m
@@ -49,6 +49,7 @@
   ENCODE(self.fileBundleVersionString, @"fileBundleVersionString");
 
   ENCODE(self.signingChain, @"signingChain");
+  ENCODE(self.teamID, @"teamID");
 
   ENCODE(self.executingUser, @"executingUser");
   ENCODE(self.occurrenceDate, @"occurrenceDate");
@@ -93,6 +94,7 @@
     _fileBundleVersionString = DECODE(NSString, @"fileBundleVersionString");
 
     _signingChain = DECODEARRAY(MOLCertificate, @"signingChain");
+    _teamID = DECODE(NSString, @"teamID");
 
     _executingUser = DECODE(NSString, @"executingUser");
     _occurrenceDate = DECODE(NSDate, @"occurrenceDate");

--- a/Source/santad/SNTExecutionController.m
+++ b/Source/santad/SNTExecutionController.m
@@ -207,6 +207,7 @@ static NSString *const kPrinterProxyPostMonterey =
     se.decision = cd.decision;
 
     se.signingChain = cd.certChain;
+    se.teamID = cd.teamID;
     se.pid = @(message.pid);
     se.ppid = @(message.ppid);
     se.parentName = @(message.pname);

--- a/Source/santasyncservice/SNTSyncConstants.h
+++ b/Source/santasyncservice/SNTSyncConstants.h
@@ -92,6 +92,7 @@ extern NSString *const kCertOrg;
 extern NSString *const kCertOU;
 extern NSString *const kCertValidFrom;
 extern NSString *const kCertValidUntil;
+extern NSString *const kTeamID;
 extern NSString *const kQuarantineDataURL;
 extern NSString *const kQuarantineRefererURL;
 extern NSString *const kQuarantineTimestamp;

--- a/Source/santasyncservice/SNTSyncConstants.m
+++ b/Source/santasyncservice/SNTSyncConstants.m
@@ -93,6 +93,7 @@ NSString *const kCertOrg = @"org";
 NSString *const kCertOU = @"ou";
 NSString *const kCertValidFrom = @"valid_from";
 NSString *const kCertValidUntil = @"valid_until";
+NSString *const kTeamID = @"team_id";
 NSString *const kQuarantineDataURL = @"quarantine_data_url";
 NSString *const kQuarantineRefererURL = @"quarantine_referer_url";
 NSString *const kQuarantineTimestamp = @"quarantine_timestamp";

--- a/Source/santasyncservice/SNTSyncEventUpload.m
+++ b/Source/santasyncservice/SNTSyncEventUpload.m
@@ -149,6 +149,7 @@
     [signingChain addObject:certDict];
   }
   newEvent[kSigningChain] = signingChain;
+  ADDKEY(newEvent, kTeamID, event.teamID);
 
   return newEvent;
 #undef ADDKEY

--- a/Source/santasyncservice/SNTSyncTest.m
+++ b/Source/santasyncservice/SNTSyncTest.m
@@ -340,6 +340,8 @@
         XCTAssertEqualObjects(cert[kCertValidFrom], @(1365806075));
         XCTAssertEqualObjects(cert[kCertValidUntil], @(1618266875));
 
+        XCTAssertNil(event[kTeamID]);
+
         event = events[1];
         XCTAssertEqualObjects(event[kFileName], @"hub");
         XCTAssertEqualObjects(event[kExecutingUser], @"foouser");

--- a/Source/santasyncservice/SNTSyncTest.m
+++ b/Source/santasyncservice/SNTSyncTest.m
@@ -340,7 +340,7 @@
         XCTAssertEqualObjects(cert[kCertValidFrom], @(1365806075));
         XCTAssertEqualObjects(cert[kCertValidUntil], @(1618266875));
 
-        XCTAssertNil(event[kTeamID]);
+        XCTAssertEqualObjects(event[kTeamID], @"012345678910");
 
         event = events[1];
         XCTAssertEqualObjects(event[kFileName], @"hub");

--- a/Source/santasyncservice/testdata/sync_eventupload_input_basic.plist
+++ b/Source/santasyncservice/testdata/sync_eventupload_input_basic.plist
@@ -91,6 +91,11 @@
 				<key>CF$UID</key>
 				<integer>6</integer>
 			</dict>
+			<key>teamID</key>
+			<dict>
+				<key>CF$UID</key>
+				<integer>39</integer>
+			</dict>
 		</dict>
 		<integer>14887</integer>
 		<string>ff98fa0c0a1095fedcbe4d388a9760e71399a5c3c017a847ffa545663b57929a</string>
@@ -393,6 +398,7 @@
 				</dict>
 			</array>
 		</dict>
+	        <string>012345678910</string>
 	</array>
 	<key>$top</key>
 	<dict>

--- a/docs/details/events.md
+++ b/docs/details/events.md
@@ -71,6 +71,7 @@ JSON blob. Here is an example of Firefox being blocked and sent for upload:
           "sha256": "b0b1730ecbc7ff4505142c49f1295e6eda6bcaed7e2c68c5be91b5a11001f024"
         }
       ],
+      "team_id": "43AQ936H96",
       "file_bundle_name": "Firefox",
       "executing_user": "bur",
       "ppid": 1,


### PR DESCRIPTION
The team ID cannot be extracted from the signing certificate information, when the binary comes from the App Store. With this PR, we are trying to include it in the event information.