### PR TITLE
Use the message copy in the dispatch blocks

### DIFF
--- a/Source/santad/EventProviders/SNTDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTDeviceManager.mm
@@ -313,21 +313,21 @@ NS_ASSUME_NONNULL_BEGIN
   dispatch_semaphore_signal(processingSema);
   dispatch_semaphore_t deadlineExpiredSema = dispatch_semaphore_create(0);
 
-  if (m->action_type == ES_ACTION_TYPE_AUTH) {
+  if (mc->action_type == ES_ACTION_TYPE_AUTH) {
     dispatch_after(timeout, self.esAuthQueue, ^(void) {
       if (dispatch_semaphore_wait(processingSema, DISPATCH_TIME_NOW) != 0) {
         // Handler already responded, nothing to do.
         return;
       }
       LOGE(@"SNTDeviceManager: deadline reached: deny pid=%d ret=%d",
-           audit_token_to_pid(m->process->audit_token),
-           es_respond_auth_result(c, m, ES_AUTH_RESULT_DENY, false));
+           audit_token_to_pid(mc->process->audit_token),
+           es_respond_auth_result(c, mc, ES_AUTH_RESULT_DENY, false));
       dispatch_semaphore_signal(deadlineExpiredSema);
     });
   }
 
   dispatch_async(self.esAuthQueue, ^{
-    [self handleESMessage:m withClient:c];
+    [self handleESMessage:mc withClient:c];
     if (dispatch_semaphore_wait(processingSema, DISPATCH_TIME_NOW) != 0) {
       // Deadline expired, wait for deadline block to finish.
       dispatch_semaphore_wait(deadlineExpiredSema, DISPATCH_TIME_FOREVER);


### PR DESCRIPTION
The blocks were operating on the original message provided by ES instead of the copy that was made.