### PR TITLE
santad: Improve caching of static rules

### DIFF
--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -58,8 +58,9 @@
   self = [super init];
   if (self) {
     _identifier = dict[kRuleIdentifier];
-    if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length)
+    if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length) {
       _identifier = dict[kRuleSHA256];
+    }
     if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length) return nil;
 
     NSString *policyString = dict[kRulePolicy];

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -58,12 +58,11 @@
   self = [super init];
   if (self) {
     _identifier = dict[kRuleIdentifier];
-    if (!_identifier.length) _identifier = dict[kRuleSHA256];
-    if (!_identifier.length) {
-      return nil;
-    }
+    if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length) _identifier = dict[kRuleSHA256];
+    if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length) return nil;
 
     NSString *policyString = dict[kRulePolicy];
+    if (![policyString isKindOfClass:[NSString class]]) return nil;
     if ([policyString isEqual:kRulePolicyAllowlist] ||
         [policyString isEqual:kRulePolicyAllowlistDeprecated]) {
       _state = SNTRuleStateAllow;
@@ -83,6 +82,7 @@
     }
 
     NSString *ruleTypeString = dict[kRuleType];
+    if (![ruleTypeString isKindOfClass:[NSString class]]) return nil;
     if ([ruleTypeString isEqual:kRuleTypeBinary]) {
       _type = SNTRuleTypeBinary;
     } else if ([ruleTypeString isEqual:kRuleTypeCertificate]) {
@@ -94,7 +94,7 @@
     }
 
     NSString *customMsg = dict[kRuleCustomMsg];
-    if (customMsg.length) {
+    if ([customMsg isKindOfClass:[NSString class]] && customMsg.length) {
       _customMsg = customMsg;
     }
   }

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -58,7 +58,8 @@
   self = [super init];
   if (self) {
     _identifier = dict[kRuleIdentifier];
-    if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length) _identifier = dict[kRuleSHA256];
+    if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length)
+      _identifier = dict[kRuleSHA256];
     if (![_identifier isKindOfClass:[NSString class]] || !_identifier.length) return nil;
 
     NSString *policyString = dict[kRulePolicy];


### PR DESCRIPTION
In #846 I forgot that  is only a count of the entries so if the config changes but the number of rules remains the same we would never update the cache. This PR moves the processing of the raw config into the KVO handler code so it is not at all in the hot-path. It also does more checking of types in the rule dictionary processing code.