### PR TITLE
santad: Log team ID in execution logs, where available

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -79,6 +79,7 @@ message Execution {
   optional string original_path = 11;
   repeated string args = 12;
   optional string machine_id = 13;
+  optional string team_id = 14;
 }
 
 message DiskAppeared {

--- a/Source/santad/Logs/SNTProtobufEventLog.m
+++ b/Source/santad/Logs/SNTProtobufEventLog.m
@@ -226,6 +226,7 @@
   exec.argsArray = [(__bridge NSArray *)message.args_array mutableCopy];
   exec.machineId =
     [[SNTConfigurator configurator] enableMachineIDDecoration] ? self.machineID : nil;
+  exec.teamId = cd.teamID;
 
   [self logWithSantaMessage:&message
                     wrapper:^(SNTPBSantaMessage *sm) {

--- a/Source/santad/Logs/SNTSyslogEventLog.m
+++ b/Source/santad/Logs/SNTSyslogEventLog.m
@@ -170,9 +170,13 @@
 
   [outLog appendFormat:@"|sha256=%@", cd.sha256];
 
-  if (cd.certSHA256) {
+  if (cd.certSHA256.length) {
     [outLog appendFormat:@"|cert_sha256=%@|cert_cn=%@", cd.certSHA256,
                          [self sanitizeString:cd.certCommonName]];
+  }
+
+  if (cd.teamID.length) {
+    [outLog appendFormat:@"|teamid=%@", cd.teamID];
   }
 
   if (cd.quarantineURL) {


### PR DESCRIPTION
Fixes #776