### PR TITLE
Ensure KVO works for USB config options

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -475,7 +475,6 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self syncAndConfigStateSet];
 }
 
-
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -475,6 +475,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self syncAndConfigStateSet];
 }
 
++ (NSSet *)keyPathsForValuesAffectingUSBBlockMessage {
+  return [self syncAndConfigStateSet];
+}
+
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -468,7 +468,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 + (NSSet *)keyPathsForValuesAffectingRemountUSBMode {
-  return [self syncAndConfigStateSet];
+  return [self configStateSet];
 }
 
 + (NSSet *)keyPathsForValuesAffectingRemountUSBBlockMessage {

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -475,7 +475,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self syncAndConfigStateSet];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingUSBBlockMessage {
++ (NSSet *)keyPathsForValuesAffectingUsbBlockMessage {
   return [self syncAndConfigStateSet];
 }
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -464,10 +464,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 + (NSSet *)keyPathsForValuesAffectingBannedUSBBlockMessage {
-  return [self syncAndConfigStateSet];
+  return [self configStateSet];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingRemountUSBBlockMode {
++ (NSSet *)keyPathsForValuesAffectingRemountUSBMode {
   return [self syncAndConfigStateSet];
 }
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -459,6 +459,23 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return [self configStateSet];
 }
 
++ (NSSet *)keyPathsForValuesAffectingBlockUSBMount {
+  return [self syncAndConfigStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingBannedUSBBlockMessage {
+  return [self syncAndConfigStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingRemountUSBBlockMode {
+  return [self syncAndConfigStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingRemountUSBBlockMessage {
+  return [self syncAndConfigStateSet];
+}
+
+
 #pragma mark Public Interface
 
 - (SNTClientMode)clientMode {


### PR DESCRIPTION
This PR adds methods to SNTConfigurator to ensure KVO works for those options through out Santa.