### PR TITLE
Add sync server list

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -38,7 +38,7 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | BannedBlockMessage                | String     | This is the message shown to the user when a binary is blocked because of a rule if that rule doesn't provide a custom message. If this is not configured a reasonable  default is provided. |
 | ModeNotificationMonitor           | String     | The notification text to display when the client goes into Monitor mode. Defaults to "Switching into Monitor mode". |
 | ModeNotificationLockdown          | String     | The notification text to display when the client goes into Lockdown mode. Defaults to "Switching into Lockdown mode". |
-| SyncBaseURL                       | String     | The base URL of the sync server.         |
+| <a name="sync-base-url"></a>SyncBaseURL                       | String     | The base URL of the sync server.         |
 | SyncProxyConfiguration            | Dictionary | The proxy configuration to use when syncing. See the [Apple Documentation](https://developer.apple.com/documentation/cfnetwork/global_proxy_settings_constants) for details on the keys that can be used in this dictionary. |
 | SyncEnableCleanSyncEventUpload    | Bool       | If true, events will be uploaded to the sync server even if a clean sync is requested. Defaults to false. |
 | ClientAuthCertificateFile         | String     | If set, this contains the location of a PKCS#12 certificate to be used for sync authentication. |

--- a/docs/deployment/getting-started.md
+++ b/docs/deployment/getting-started.md
@@ -10,8 +10,7 @@ This page shows you the process to get started with your deployment of Santa.
 
 **Note:** You can combine each of the profiles listed in the following steps into a single profile containing the different payloads: configuration, TCC, system extension, and notifications.
 
-1. (Optional) Set up a [sync server](../introduction/syncing-overview.md). Without a sync server, [`santactl`](../binaries/santactl.md) can configure rules locally.
-<!--TODO Add in list of sync servers to another page in docs from ReadMe & expand here with a link to new page/section  -->
+1. (Optional) Set up a [sync server](../introduction/syncing-overview.md). For a list of open-source sync servers, see [Sync Servers](sync-servers.md). Without a sync server, [`santactl`](../binaries/santactl.md) can configure rules locally.
 
 1. Create and install your Santa configuration profile to customize your deployment of Santa. See [Configuration](configuration.md) for a reference list of the available options and an [example profile](https://github.com/google/santa/blob/main/docs/deployment/com.google.santa.example.mobileconfig).
 

--- a/docs/deployment/sync-servers.md
+++ b/docs/deployment/sync-servers.md
@@ -6,7 +6,7 @@ nav_order: 3
 
 # Sync Servers
 
-The [`santactl`](../binaries/santactl.md) command-line client includes a flag to synchronize with a management server, which uploads events that have occurred on the machine and downloads new rules. 
+Santa's [SyncBaseURL](configuration.md#sync-base-url) configuration flag allows you to synchronize with a management server, which uploads events that have occurred on the machine and downloads new rules. 
 
 There are several open-source servers you can sync with:
 

--- a/docs/deployment/sync-servers.md
+++ b/docs/deployment/sync-servers.md
@@ -1,0 +1,18 @@
+---
+title: Sync Servers
+parent: Deployment
+nav_order: 3
+---
+
+# Sync Servers
+
+The [`santactl`](../binaries/santactl.md) command-line client includes a flag to synchronize with a management server, which uploads events that have occurred on the machine and downloads new rules. 
+
+There are several open-source servers you can sync with:
+
+* [Moroz](https://github.com/groob/moroz): A simple golang server that serves hard-coded rules from configuration files.
+* [Rudolph](https://github.com/airbnb/rudolph): An AWS-based serverless sync service primarily built on API GW, DynamoDB, and Lambda components to reduce operational burden. Rudolph is designed to be fast, easy-to-use, and cost-efficient.
+* [Zentral](https://github.com/zentralopensource/zentral/wiki): A centralized service that pulls data from multiple sources and deploys configurations to multiple services.
+* [Zercurity](https://github.com/zercurity/zercurity): A dockerized service for managing and monitoring applications across a large fleet using Santa + Osquery.
+
+Alternatively, `santactl` can configure rules locally without a sync server.

--- a/docs/deployment/sync-servers.md
+++ b/docs/deployment/sync-servers.md
@@ -16,3 +16,5 @@ There are several open-source servers you can sync with:
 * [Zercurity](https://github.com/zercurity/zercurity): A dockerized service for managing and monitoring applications across a large fleet using Santa + Osquery.
 
 Alternatively, `santactl` can configure rules locally without a sync server.
+
+See the [Syncing Overview](../introduction/syncing-overview.md) page for an explanation of how syncing works in Santa.

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 parent: Deployment
-nav_order: 3
+nav_order: 4
 ---
 
 # Troubleshooting

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ The following pages give an overview of how Santa accomplishes authorization at 
 
 * [Getting Started](deployment/getting-started.md): A quick guide to setting up your deployment.
 * [Configuration](deployment/configuration.md): The local and sync server configuration options, along with example needed mobileconfig files.
+* [Sync Servers](deployment/sync-servers.md): A list of open-source sync servers.
 * [Troubleshooting](deployment/troubleshooting.md): How to troubleshoot issues with your Santa deployment.
 
 ### Concepts


### PR DESCRIPTION
Fixes #836 

Quick add of the open source sync server list to the docs. Have added this to its own page with references to the Sync overview page. And an update to the Getting Started page & home page to reference this also.