### PR TITLE
Sync state plist | only allow santad read+write permissions

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -959,7 +959,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   syncState[kAllowedPathRegexKey] = [syncState[kAllowedPathRegexKey] pattern];
   syncState[kBlockedPathRegexKey] = [syncState[kBlockedPathRegexKey] pattern];
   [syncState writeToFile:kSyncStateFilePath atomically:YES];
-  [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0644}
+  [[NSFileManager defaultManager] setAttributes:@{NSFilePosixPermissions : @0600}
                                    ofItemAtPath:kSyncStateFilePath
                                           error:NULL];
 }


### PR DESCRIPTION
Nit change here.

An insider or attacker can read the /var/db/santa/sync-state.plist file to determine allowlisted (or denylisted) locations that bypass Santa restrictions.

Example snippet:
```
❯ sudo cat /var/db/santa/sync-state.plist

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>AllowedPathRegex</key>
	<string>^/Users/[\w-]+/(?:workspace|go/bin|go/src|/opt/homebrew/|/usr/local/(?:Caskroom|Cellar|Homebrew|bin)/.*</string>
	<key>BlockedPathRegex</key>
	<string>^/var/.*/AppTranslocation/.*</string>
</dict>
</plist>
```

Access to this file should require sudo to write/read it.