### PR TITLE
Santa: Post distributed notification when showing block UI

### DIFF
--- a/Source/santa/BUILD
+++ b/Source/santa/BUILD
@@ -49,6 +49,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTStrengthify",
+        "//Source/common:SNTSyncConstants",
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCNotifierInterface",
         "@MOLCertificate",

--- a/Source/santa/BUILD
+++ b/Source/santa/BUILD
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application")
+load("//:helper.bzl", "santa_unit_test")
 
 licenses(["notice"])
 
@@ -89,4 +90,18 @@ macos_application(
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":SantaGUI_lib"],
+)
+
+santa_unit_test(
+    name = "SNTNotificationManagerTest",
+    srcs = [
+        "SNTNotificationManagerTest.m",
+    ],
+    sdk_frameworks = [
+        "Cocoa",
+    ],
+    deps = [
+        ":SantaGUI_lib",
+        "@OCMock",
+    ],
 )

--- a/Source/santa/SNTNotificationManager.m
+++ b/Source/santa/SNTNotificationManager.m
@@ -128,18 +128,18 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
   SNTBinaryMessageWindowController *wc = (SNTBinaryMessageWindowController *)pendingMsg;
   NSDistributedNotificationCenter *dc = [NSDistributedNotificationCenter defaultCenter];
   NSMutableDictionary *userInfo = [@{
-      kFileSHA256: wc.event.fileSHA256 ?: @"",
-      kFilePath: wc.event.filePath ?: @"",
-      kFileBundleName: wc.event.fileBundleName ?: @"",
-      kFileBundleID: wc.event.fileBundleID ?: @"",
-      kFileBundleVersion: wc.event.fileBundleVersion ?: @"",
-      kFileBundleShortVersionString: wc.event.fileBundleVersionString ?: @"",
-      kTeamID: wc.event.teamID ?: @"",
-      kExecutingUser: wc.event.executingUser ?: @"",
-      kExecutionTime: @([wc.event.occurrenceDate timeIntervalSince1970]) ?: @0,
-      kPID: wc.event.pid ?: @0,
-      kPPID: wc.event.ppid ?: @0,
-      kParentName: wc.event.parentName ?: @"",
+    kFileSHA256 : wc.event.fileSHA256 ?: @"",
+    kFilePath : wc.event.filePath ?: @"",
+    kFileBundleName : wc.event.fileBundleName ?: @"",
+    kFileBundleID : wc.event.fileBundleID ?: @"",
+    kFileBundleVersion : wc.event.fileBundleVersion ?: @"",
+    kFileBundleShortVersionString : wc.event.fileBundleVersionString ?: @"",
+    kTeamID : wc.event.teamID ?: @"",
+    kExecutingUser : wc.event.executingUser ?: @"",
+    kExecutionTime : @([wc.event.occurrenceDate timeIntervalSince1970]) ?: @0,
+    kPID : wc.event.pid ?: @0,
+    kPPID : wc.event.ppid ?: @0,
+    kParentName : wc.event.parentName ?: @"",
   } mutableCopy];
 
   MOLCertificate *leafCert = [wc.event.signingChain firstObject];

--- a/Source/santa/SNTNotificationManager.m
+++ b/Source/santa/SNTNotificationManager.m
@@ -121,6 +121,13 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
   }
 }
 
+// For blocked execution notifications, post an NSDistributedNotificationCenter
+// notification with the important details from the stored event. Distributed
+// notifications are system-wide broadcasts that can be sent by apps and observed
+// from separate processes. This allows users of Santa to write tools that
+// perform actions when we block execution, such as trigger management tools or
+// display an enterprise-specific UI (which is particularly useful when combined
+// with the EnableSilentMode configuration option, to disable Santa's standard UI).
 - (void)postDistributedNotification:(SNTMessageWindowController *)pendingMsg {
   if (![pendingMsg isKindOfClass:[SNTBinaryMessageWindowController class]]) {
     return;

--- a/Source/santa/SNTNotificationManagerTest.m
+++ b/Source/santa/SNTNotificationManagerTest.m
@@ -1,0 +1,76 @@
+/// Copyright 2022 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+// #import <MOLCertificate/MOLCertificate.h>
+// #import <MOLCodesignChecker/MOLCodesignChecker.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/santa/SNTNotificationManager.h"
+
+#import "Source/common/SNTStoredEvent.h"
+
+@class SNTBinaryMessageWindowController;
+
+@interface SNTNotificationManager (Testing)
+- (void)hashBundleBinariesForEvent:(SNTStoredEvent *)event
+                    withController:(SNTBinaryMessageWindowController *)controller;
+@end
+
+@interface SNTNotificationManagerTest : XCTestCase
+@end
+
+@implementation SNTNotificationManagerTest
+
+- (void)setUp {
+  [super setUp];
+  fclose(stdout);
+}
+
+- (void)testPostBlockNotificationSendsDistributedNotification {
+  SNTStoredEvent *ev = [[SNTStoredEvent alloc] init];
+  ev.fileSHA256 = @"the-sha256";
+  ev.filePath = @"/Applications/Safari.app/Contents/MacOS/Safari";
+  ev.fileBundleName = @"Safari";
+  ev.fileBundlePath = @"/Applications/Safari.app";
+  ev.fileBundleID = @"com.apple.Safari";
+  ev.fileBundleVersion = @"18614.1.14.1.15";
+  ev.fileBundleVersionString = @"16.0";
+  ev.executingUser = @"rah";
+  ev.occurrenceDate = [NSDate dateWithTimeIntervalSince1970:1660221048];
+  ev.decision = SNTEventStateBlockBinary;
+  ev.pid = @84156;
+  ev.ppid = @1;
+  ev.parentName = @"launchd";
+
+  SNTNotificationManager *sut = OCMPartialMock([[SNTNotificationManager alloc] init]);
+  OCMStub([sut hashBundleBinariesForEvent:OCMOCK_ANY withController:OCMOCK_ANY]).andDo(nil);
+
+  id dncMock = OCMClassMock([NSDistributedNotificationCenter class]);
+  OCMStub([dncMock defaultCenter]).andReturn(dncMock);
+
+  [sut postBlockNotification:ev withCustomMessage:@""];
+
+  OCMVerify([dncMock postNotificationName:@"com.google.santa.notification.blockedeexecution"
+                                   object:@"com.google.santa"
+                                 userInfo:[OCMArg checkWithBlock:^BOOL(NSDictionary *userInfo) {
+                                   XCTAssertEqualObjects(userInfo[@"file_sha256"], @"the-sha256");
+                                   XCTAssertEqualObjects(userInfo[@"pid"], @84156);
+                                   XCTAssertEqualObjects(userInfo[@"ppid"], @1);
+                                   XCTAssertEqualObjects(userInfo[@"execution_time"], @1660221048);
+                                   return YES;
+                                 }]]);
+}
+
+@end


### PR DESCRIPTION
This allows users to supplement or replace the Santa UI, as well as trigger post-block tools if needed.

Fixes #869