### PR TITLE
GUI: Add silent mode configuration option.

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -256,6 +256,16 @@
 #pragma mark - GUI Settings
 
 ///
+///  When silent mode is enabled, Santa will never show notifications for
+///  blocked processes.
+///
+///  This can be a very confusing experience for users, use with caution.
+///
+///  Defaults to NO.
+///
+@property(readonly, nonatomic) BOOL enableSilentMode;
+
+///
 /// The text to display when opening Santa.app.
 /// If unset, the default text will be displayed.
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -66,7 +66,8 @@ static NSString *const kMachineOwnerPlistKeyKey = @"MachineOwnerKey";
 static NSString *const kMachineIDPlistFileKey = @"MachineIDPlist";
 static NSString *const kMachineIDPlistKeyKey = @"MachineIDKey";
 
-static NSString *const kAboutText = @"AboutText";
+static NSString *const kEnableSilentModeKey = @"EnableSilentMode";
+static NSString *const kAboutTextKey = @"AboutText";
 static NSString *const kMoreInfoURLKey = @"MoreInfoURL";
 static NSString *const kEventDetailURLKey = @"EventDetailURL";
 static NSString *const kEventDetailTextKey = @"EventDetailText";
@@ -172,7 +173,8 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kRemountUSBModeKey : array,
       kEnablePageZeroProtectionKey : number,
       kEnableBadSignatureProtectionKey : number,
-      kAboutText : string,
+      kEnableSilentModeKey : string,
+      kAboutTextKey : string,
       kMoreInfoURLKey : string,
       kEventDetailURLKey : string,
       kEventDetailTextKey : string,
@@ -300,6 +302,10 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 + (NSSet *)keyPathsForValuesAffectingEnablePageZeroProtection {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingEnableSilentMode {
   return [self configStateSet];
 }
 
@@ -611,8 +617,13 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   return number ? [number boolValue] : NO;
 }
 
+- (BOOL)enableSilentMode {
+  NSNumber *number = self.configState[kEnableSilentModeKey];
+  return number ? [number boolValue] : NO;
+}
+
 - (NSString *)aboutText {
-  return self.configState[kAboutText];
+  return self.configState[kAboutTextKey];
 }
 
 - (NSURL *)moreInfoURL {

--- a/Source/santa/SNTNotificationManager.m
+++ b/Source/santa/SNTNotificationManager.m
@@ -208,6 +208,8 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 #pragma mark SNTNotifierXPC protocol methods
 
 - (void)postClientModeNotification:(SNTClientMode)clientmode {
+  if ([SNTConfigurator configurator].enableSilentMode) return;
+
   UNUserNotificationCenter *un = [UNUserNotificationCenter currentNotificationCenter];
 
   UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
@@ -246,6 +248,8 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 }
 
 - (void)postRuleSyncNotificationWithCustomMessage:(NSString *)message {
+  if ([SNTConfigurator configurator].enableSilentMode) return;
+
   UNUserNotificationCenter *un = [UNUserNotificationCenter currentNotificationCenter];
 
   UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
@@ -262,6 +266,8 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 }
 
 - (void)postBlockNotification:(SNTStoredEvent *)event withCustomMessage:(NSString *)message {
+  if ([SNTConfigurator configurator].enableSilentMode) return;
+
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;
@@ -274,6 +280,8 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 }
 
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message {
+  if ([SNTConfigurator configurator].enableSilentMode) return;
+
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;

--- a/docs/deployment/com.google.santa.example.mobileconfig
+++ b/docs/deployment/com.google.santa.example.mobileconfig
@@ -20,6 +20,8 @@
 								<integer>1</integer>
 								<key>EnablePageZeroProtection</key>
 								<false/>
+								<key>EnableSilentMode</key>
+								<false/>
 								<key>EventDetailText</key>
 								<string>Open sync server</string>
 								<key>EventDetailURL</key>

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -30,6 +30,7 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | EnableBadSignatureProtection      | Bool       | Enable bad signature protection, defaults to NO. If this flag is set to YES, binaries with a bad signing chain will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
 | EnablePageZeroProtection          | Bool       | Enable `__PAGEZERO` protection, defaults to YES. If this flag is set to YES, 32-bit binaries that are missing the `__PAGEZERO` segment will be blocked even in MONITOR mode, **unless** the binary is allowed by an explicit rule. |
 | EnableSysxCache                   | Bool       | Enables a secondary cache that ensures better performance when multiple EndpointSecurity system extensions are installed. Defaults to YES in 2021.8, defaults to NO in earlier versions. |
+| EnableSilentMode                  | Bool       | If true, Santa will not post any GUI notifications. This can be a very confusing experience for users, use with caution. Defaults to NO. |
 | AboutText                         | String     | The text to display when the user opens Santa.app. If unset, the default text will be displayed. |
 | MoreInfoURL                       | String     | The URL to open when the user clicks "More Info..." when opening Santa.app.  If unset, the button will not be displayed. |
 | EventDetailURL                    | String     | See the [EventDetailURL](#eventdetailurl) section below. |


### PR DESCRIPTION
When enabled, this option disables *all* GUI notifications from Santa. This is intended for kiosk-style machines where it is not expected for users to _ever_ execute unknown binaries.

Fixes #862