### PR TITLE
GUI: For App Store published apps, include team ID.

### DIFF
--- a/Source/santa/SNTBinaryMessageWindowController.m
+++ b/Source/santa/SNTBinaryMessageWindowController.m
@@ -139,7 +139,9 @@
 - (NSString *)publisherInfo {
   MOLCertificate *leafCert = [self.event.signingChain firstObject];
 
-  if (leafCert.commonName && leafCert.orgName) {
+  if ([leafCert.commonName isEqualToString:@"Apple Mac OS Application Signing"]) {
+    return [NSString stringWithFormat:@"App Store (Team ID: %@)", self.event.teamID];
+  } else if (leafCert.commonName && leafCert.orgName) {
     return [NSString stringWithFormat:@"%@ - %@", leafCert.orgName, leafCert.commonName];
   } else if (leafCert.commonName) {
     return leafCert.commonName;


### PR DESCRIPTION
With this change, the publisher field for an App Store published app will be `App Store (Team
ID: K36BKF7T3D` instead of `Apple Mac OS Application Signing`.

Fixes #758