### PR TITLE
Fix up endTimestamp to be Monarch compliant

### DIFF
--- a/Source/santametricservice/Formats/BUILD
+++ b/Source/santametricservice/Formats/BUILD
@@ -76,6 +76,7 @@ santa_unit_test(
     deps = [
         ":SNTMetricFormatTestHelper",
         ":SNTMetricMonarchJSONFormat",
+        "@OCMock",
     ],
 )
 

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
@@ -113,7 +113,7 @@ const NSString *kKey = @"key";
       }
 
       monarchDataEntry[kStartTimestamp] = [self->_dateFormatter stringFromDate:entry[@"created"]];
-      // monarch wants all the end timestamp to be updated, even if the value does not change.
+      // Monarch wants all the end timestamp to be updated, even if the value does not change.
       monarchDataEntry[kEndTimestamp] = [self->_dateFormatter stringFromDate:endTimestamp];
 
       if (!metric[@"type"]) {

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
@@ -163,7 +163,7 @@ const NSString *kKey = @"key";
 
 - (NSDictionary *)formatMetric:(NSString *)name
                     withMetric:(NSDictionary *)metric
-              withEndTimestamp:(NSDate *)endTimestamp {
+               andEndtimestamp:(NSDate *)endTimestamp {
   NSMutableDictionary *monarchMetric = [[NSMutableDictionary alloc] init];
 
   monarchMetric[kMetricName] = name;
@@ -193,7 +193,7 @@ const NSString *kKey = @"key";
   for (NSString *metricName in metrics[@"metrics"]) {
     [monarchMetrics addObject:[self formatMetric:metricName
                                       withMetric:metrics[@"metrics"][metricName]
-                                withEndTimestamp:endTimestamp]];
+                                 andEndtimestamp:endTimestamp]];
   }
 
   NSMutableArray<NSDictionary *> *rootLabels = [[NSMutableArray alloc] init];

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
@@ -158,11 +158,12 @@ const NSString *kKey = @"key";
 }
 
 /**
- * formatMetric translates the SNTMetricSet metric entries into those consumable by Monarch.
+ * formatMetric translates the SNTMetricSet metric entries into those consumable
+ * by Monarch.
  **/
 
 - (NSDictionary *)formatMetric:(NSString *)name
-                    withMetric:(NSDictionary *)metric
+                     withValue:(NSDictionary *)metric
                andEndtimestamp:(NSDate *)endTimestamp {
   NSMutableDictionary *monarchMetric = [[NSMutableDictionary alloc] init];
 
@@ -192,7 +193,7 @@ const NSString *kKey = @"key";
 
   for (NSString *metricName in metrics[@"metrics"]) {
     [monarchMetrics addObject:[self formatMetric:metricName
-                                      withMetric:metrics[@"metrics"][metricName]
+                                       withValue:metrics[@"metrics"][metricName]
                                  andEndtimestamp:endTimestamp]];
   }
 

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
@@ -12,11 +12,8 @@
 
 - (void)testMetricsConversionToJSON {
   id classMock = OCMClassMock([NSDate class]);
-  NSDateFormatter *testDateFormatter = NSDateFormatter.new;
-  [testDateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
-  NSDate *mockedEndTimestamp = [testDateFormatter dateFromString:@"2021-09-16 21:08:10+0000"];
-
-  OCMStub([classMock date]).andReturn(mockedEndTimestamp);
+  OCMStub([classMock date])
+    .andReturn([NSDate dateWithTimeIntervalSince1970:1631826490]);  // 2021-09-16 21:08:10Z
 
   NSDictionary *validMetricsDict = [SNTMetricFormatTestHelper createValidMetricsDictionary];
   SNTMetricMonarchJSONFormat *formatter = [[SNTMetricMonarchJSONFormat alloc] init];

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
@@ -6,6 +6,17 @@
 @interface SNTMetricMonarchJSONFormatTest : XCTestCase
 @end
 
+// Stub out NSDate's date method
+@implementation NSDate (custom)
+
++ (instancetype)date {
+  NSDateFormatter *formatter = NSDateFormatter.new;
+  [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
+  return [formatter dateFromString:@"2021-09-16 21:08:10+0000"];
+}
+
+@end
+
 @implementation SNTMetricMonarchJSONFormatTest
 
 - (void)testMetricsConversionToJSON {

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
@@ -1,25 +1,23 @@
 #import <XCTest/XCTest.h>
 
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
 #import "Source/santametricservice/Formats/SNTMetricFormatTestHelper.h"
 #import "Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.h"
 
 @interface SNTMetricMonarchJSONFormatTest : XCTestCase
 @end
 
-// Stub out NSDate's date method
-@implementation NSDate (custom)
-
-+ (instancetype)date {
-  NSDateFormatter *formatter = NSDateFormatter.new;
-  [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
-  return [formatter dateFromString:@"2021-09-16 21:08:10+0000"];
-}
-
-@end
-
 @implementation SNTMetricMonarchJSONFormatTest
 
 - (void)testMetricsConversionToJSON {
+  id classMock = OCMClassMock([NSDate class]);
+  NSDateFormatter *testDateFormatter = NSDateFormatter.new;
+  [testDateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
+  NSDate *mockedEndTimestamp = [testDateFormatter dateFromString:@"2021-09-16 21:08:10+0000"];
+
+  OCMStub([classMock date]).andReturn(mockedEndTimestamp);
+
   NSDictionary *validMetricsDict = [SNTMetricFormatTestHelper createValidMetricsDictionary];
   SNTMetricMonarchJSONFormat *formatter = [[SNTMetricMonarchJSONFormat alloc] init];
   NSError *err = nil;

--- a/Source/santametricservice/Formats/testdata/json/monarch.json
+++ b/Source/santametricservice/Formats/testdata/json/monarch.json
@@ -26,7 +26,7 @@
           "data" : [
             {
               "int64Value" : 1,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "field" : [
                 {
                   "name" : "rule_type",
@@ -37,7 +37,7 @@
             },
             {
               "int64Value" : 3,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "field" : [
                 {
                   "name" : "rule_type",
@@ -54,7 +54,7 @@
           "data" : [
             {
               "int64Value" : 123456789,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "startTimestamp" : "2021-09-16T21:07:34.826Z"
             }
           ],
@@ -73,7 +73,7 @@
           "data" : [
             {
               "int64Value" : 1,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "field" : [
                 {
                   "name" : "rule_type",
@@ -84,7 +84,7 @@
             },
             {
               "int64Value" : 2,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "field" : [
                 {
                   "name" : "rule_type",
@@ -104,7 +104,7 @@
           "data" : [
             {
               "boolValue" : true,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "startTimestamp" : "2021-09-16T21:07:34.826Z"
             }
           ]
@@ -116,7 +116,7 @@
           "data" : [
             {
               "int64Value" : 1250999830800,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "startTimestamp" : "2021-09-16T21:07:34.826Z"
             }
           ]
@@ -127,7 +127,7 @@
           "data" : [
             {
               "int64Value" : 987654321,
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "startTimestamp" : "2021-09-16T21:07:34.826Z"
             }
           ],
@@ -141,7 +141,7 @@
           "data" : [
             {
               "stringValue" : "20210809.0.1",
-              "endTimestamp" : "2021-09-16T21:07:34.826Z",
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
               "startTimestamp" : "2021-09-16T21:07:34.826Z"
             }
           ]

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -22,17 +22,6 @@ NSDictionary *validMetricsDict = nil;
 @property id mockMOLAuthenticatingURLSession;
 @end
 
-// Stub out NSDate's date method
-@implementation NSDate (custom)
-
-+ (instancetype)date {
-  NSDateFormatter *formatter = NSDateFormatter.new;
-  [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
-  return [formatter dateFromString:@"2021-09-16 21:08:10+0000"];
-}
-
-@end
-
 @implementation SNTMetricServiceTest
 
 - (void)setUp {
@@ -175,6 +164,13 @@ NSDictionary *validMetricsDict = nil;
 }
 
 - (void)testWritingMonarchJSONToAFile {
+  id classMock = OCMClassMock([NSDate class]);
+  NSDateFormatter *testDateFormatter = NSDateFormatter.new;
+  [testDateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
+  NSDate *mockedEndTimestamp = [testDateFormatter dateFromString:@"2021-09-16 21:08:10+0000"];
+
+  OCMStub([classMock date]).andReturn(mockedEndTimestamp);
+
   OCMStub([self.mockConfigurator exportMetrics]).andReturn(YES);
   OCMStub([self.mockConfigurator metricFormat]).andReturn(SNTMetricFormatTypeMonarchJSON);
   OCMStub([self.mockConfigurator metricURL]).andReturn(self.jsonURL);

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -22,6 +22,17 @@ NSDictionary *validMetricsDict = nil;
 @property id mockMOLAuthenticatingURLSession;
 @end
 
+// Stub out NSDate's date method
+@implementation NSDate (custom)
+
++ (instancetype)date {
+  NSDateFormatter *formatter = NSDateFormatter.new;
+  [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
+  return [formatter dateFromString:@"2021-09-16 21:08:10+0000"];
+}
+
+@end
+
 @implementation SNTMetricServiceTest
 
 - (void)setUp {

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -165,11 +165,8 @@ NSDictionary *validMetricsDict = nil;
 
 - (void)testWritingMonarchJSONToAFile {
   id classMock = OCMClassMock([NSDate class]);
-  NSDateFormatter *testDateFormatter = NSDateFormatter.new;
-  [testDateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZZZ"];
-  NSDate *mockedEndTimestamp = [testDateFormatter dateFromString:@"2021-09-16 21:08:10+0000"];
-
-  OCMStub([classMock date]).andReturn(mockedEndTimestamp);
+  OCMStub([classMock date])
+    .andReturn([NSDate dateWithTimeIntervalSince1970:1631826490]);  // 2021-09-16 21:08:10Z
 
   OCMStub([self.mockConfigurator exportMetrics]).andReturn(YES);
   OCMStub([self.mockConfigurator metricFormat]).andReturn(SNTMetricFormatTypeMonarchJSON);


### PR DESCRIPTION
This PR fixes an issue with our Monarch JSON that causes some metrics to be wonky.

Specifically our `endTimestamp` field needs to be the time of the export not the `last_updated` time. 