### PR TITLE
Make SNTCommonEnums a textual header

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -85,7 +85,7 @@ objc_library(
 
 objc_library(
     name = "SNTCommonEnums",
-    hdrs = ["SNTCommonEnums.h"],
+    textual_hdrs = ["SNTCommonEnums.h"],
 )
 
 objc_library(


### PR DESCRIPTION
This change fixes -wunused-variable warnings. The header is not valid by itself and should be declared as a textual header rather than as a header.