### PR TITLE
Machine id proto

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -251,9 +251,6 @@ message Execution {
   // The original path on disk of the target executable
   // Applies when executables are translocated
   optional string original_path = 15;
-
-  // Machine ID of the host emitting this log
-  optional string machine_id = 16;
 }
 
 // Information about a fork event
@@ -435,11 +432,15 @@ message SantaMessage {
   // Can allow client to relate events across time
   optional string uuid = 1;
 
+  // Machine ID of the host emitting this log
+  // Only valid when EnableMachineIDDecoration configuration option is set
+  optional string machine_id = 2;
+
   // Timestamp when the event occurred
-  optional google.protobuf.Timestamp event_time = 2;
+  optional google.protobuf.Timestamp event_time = 3;
 
   // Timestamp when Santa finished processing the event
-  optional google.protobuf.Timestamp processed_time = 3;
+  optional google.protobuf.Timestamp processed_time = 4;
 
   // Event type being described by this message
   oneof event {

--- a/Source/gui/SNTNotificationManagerTest.m
+++ b/Source/gui/SNTNotificationManagerTest.m
@@ -12,8 +12,6 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-// #import <MOLCertificate/MOLCertificate.h>
-// #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -334,6 +334,7 @@ objc_library(
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
         ":SNTDecisionCache",
+        "//Source/common:SNTConfigurator",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -64,6 +64,7 @@ class BasicString : public Serializer {
 
  private:
   std::string CreateDefaultString(size_t reserved_size = 512);
+  std::vector<uint8_t> FinalizeString(std::string &str);
 
   std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi_;
   bool prefix_time_name_;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -171,8 +171,13 @@ std::string BasicString::CreateDefaultString(size_t reserved_size) {
   return str;
 }
 
-inline std::vector<uint8_t> FinalizeString(std::string &str) {
+std::vector<uint8_t> BasicString::FinalizeString(std::string &str) {
+  if (EnabledMachineID()) {
+    str.append("|machineid=");
+    str.append(MachineID());
+  }
   str.append("\n");
+
   std::vector<uint8_t> vec(str.length());
   std::copy(str.begin(), str.end(), vec.begin());
   return vec;
@@ -278,11 +283,6 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExec &msg) {
 
       str.append(SanitizableString(esapi_->ExecArg(&esm.event.exec, i)).Sanitized());
     }
-  }
-
-  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
-    str.append("|machineid=");
-    str.append([NonNull([[SNTConfigurator configurator] machineID]) UTF8String]);
   }
 
   return FinalizeString(str);

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -114,7 +114,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::string got = BasicStringSerializeMessage(&esMsg);
   std::string want = "action=WRITE|path=close_file"
                      "|pid=12|ppid=56|process=foo|processpath=foo"
-                     "|uid=-2|user=nobody|gid=-1|group=nogroup\n";
+                     "|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -127,6 +127,11 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA, &proc);
   esMsg.event.exchangedata.file1 = &file1;
   esMsg.event.exchangedata.file2 = &file2;
+
+  // Arbitrarily overwriting mock to test not adding machine id in this event
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  OCMStub([self.mockConfigurator enableMachineIDDecoration]).andReturn(NO);
 
   std::string got = BasicStringSerializeMessage(&esMsg);
   std::string want = "action=EXCHANGE|path=exchange_1|newpath=exchange_2"
@@ -170,7 +175,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXIT, &proc);
 
   std::string got = BasicStringSerializeMessage(&esMsg);
-  std::string want = "action=EXIT|pid=12|pidversion=34|ppid=56|uid=-2|gid=-1\n";
+  std::string want = "action=EXIT|pid=12|pidversion=34|ppid=56|uid=-2|gid=-1|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -185,7 +190,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   esMsg.event.fork.child = &procChild;
 
   std::string got = BasicStringSerializeMessage(&esMsg);
-  std::string want = "action=FORK|pid=67|pidversion=89|ppid=12|uid=-2|gid=-1\n";
+  std::string want = "action=FORK|pid=67|pidversion=89|ppid=12|uid=-2|gid=-1|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -203,7 +208,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::string got = BasicStringSerializeMessage(&esMsg);
   std::string want = "action=LINK|path=link_src|newpath=link_dst/link_name"
                      "|pid=12|ppid=56|process=foo|processpath=foo"
-                     "|uid=-2|user=nobody|gid=-1|group=nogroup\n";
+                     "|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -221,7 +226,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::string got = BasicStringSerializeMessage(&esMsg);
   std::string want = "action=RENAME|path=rename_src|newpath=rename_dst"
                      "|pid=12|ppid=56|process=foo|processpath=foo"
-                     "|uid=-2|user=nobody|gid=-1|group=nogroup\n";
+                     "|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -236,7 +241,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::string got = BasicStringSerializeMessage(&esMsg);
   std::string want = "action=DELETE|path=deleted_file"
                      "|pid=12|ppid=56|process=foo|processpath=foo"
-                     "|uid=-2|user=nobody|gid=-1|group=nogroup\n";
+                     "|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -258,7 +263,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 
   std::string got(ret.begin(), ret.end());
   std::string want = "action=ALLOWLIST|pid=12|pidversion=34|path=foo"
-                     "|sha256=test_hash\n";
+                     "|sha256=test_hash|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -278,7 +283,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 
   std::string want = "action=BUNDLE|sha256=file_hash"
                      "|bundlehash=file_bundle_hash|bundlename=file_bundle_Name|bundleid="
-                     "|bundlepath=file_bundle_path|path=file_path\n";
+                     "|bundlepath=file_bundle_path|path=file_path|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }
@@ -294,6 +299,11 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
     @"DAVolumeKind" : @"apfs",
     @"DADeviceProtocol" : @"usb",
   };
+
+  // Arbitrarily overwriting mock to test not adding machine id in this event
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  OCMStub([self.mockConfigurator enableMachineIDDecoration]).andReturn(NO);
 
   std::vector<uint8_t> ret = BasicString::Create(nullptr, false)->SerializeDiskAppeared(props);
   std::string got(ret.begin(), ret.end());
@@ -314,7 +324,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::vector<uint8_t> ret = BasicString::Create(nullptr, false)->SerializeDiskDisappeared(props);
   std::string got(ret.begin(), ret.end());
 
-  std::string want = "action=DISKDISAPPEAR|mount=path|volume=|bsdname=bsd\n";
+  std::string want = "action=DISKDISAPPEAR|mount=path|volume=|bsdname=bsd|machineid=my_id\n";
 
   XCTAssertCppStringEqual(got, want);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -16,10 +16,12 @@
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_PROTOBUF_H
 
 #import <Foundation/Foundation.h>
+#include <google/protobuf/arena.h>
 
 #include <memory>
 #include <vector>
 
+#include "Source/common/santa_proto_include_wrapper.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
@@ -60,6 +62,16 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeDiskDisappeared(NSDictionary *) override;
 
  private:
+  ::santa::pb::v1::SantaMessage *CreateDefaultProto(google::protobuf::Arena *arena);
+  ::santa::pb::v1::SantaMessage *CreateDefaultProto(
+    google::protobuf::Arena *arena,
+    const santa::santad::event_providers::endpoint_security::EnrichedEventType &msg);
+  ::santa::pb::v1::SantaMessage *CreateDefaultProto(google::protobuf::Arena *arena,
+                                                    const uuid_t &uuid, struct timespec event_time,
+                                                    struct timespec processed_time);
+
+  std::vector<uint8_t> FinalizeProto(::santa::pb::v1::SantaMessage *santa_msg);
+
   std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi_;
 };
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -17,7 +17,6 @@
 #include <EndpointSecurity/EndpointSecurity.h>
 #include <Kernel/kern/cs_blobs.h>
 #include <bsm/libbsm.h>
-// #include <google/protobuf/arena.h>
 #include <mach/message.h>
 #include <math.h>
 #include <sys/proc_info.h>
@@ -31,7 +30,6 @@
 #import "Source/common/SNTConfigurator.h"
 #include "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
-// #include "Source/common/santa_proto_include_wrapper.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 #import "Source/santad/SNTDecisionCache.h"

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -17,7 +17,7 @@
 #include <EndpointSecurity/EndpointSecurity.h>
 #include <Kernel/kern/cs_blobs.h>
 #include <bsm/libbsm.h>
-#include <google/protobuf/arena.h>
+// #include <google/protobuf/arena.h>
 #include <mach/message.h>
 #include <math.h>
 #include <sys/proc_info.h>
@@ -31,7 +31,7 @@
 #import "Source/common/SNTConfigurator.h"
 #include "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
-#include "Source/common/santa_proto_include_wrapper.h"
+// #include "Source/common/santa_proto_include_wrapper.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 #import "Source/santad/SNTDecisionCache.h"
@@ -238,6 +238,12 @@ static inline void EncodeString(std::string *buf, NSString *value) {
   }
 }
 
+static inline void EncodeString(std::string *buf, std::string_view value) {
+  if (value.length() > 0) {
+    buf->append(std::string_view(value.data(), value.length()));
+  }
+}
+
 ::pbv1::Execution::Decision GetDecisionEnum(SNTEventState event_state) {
   if (event_state & SNTEventStateAllow) {
     return ::pbv1::Execution::DECISION_ALLOW;
@@ -296,33 +302,36 @@ static inline void EncodeString(std::string *buf, NSString *value) {
   }
 }
 
-static inline ::pbv1::SantaMessage *CreateDefaultProto(Arena *arena, const EnrichedEventType &msg) {
+::pbv1::SantaMessage *Protobuf::CreateDefaultProto(Arena *arena, const uuid_t &uuid,
+                                                   struct timespec event_time,
+                                                   struct timespec processed_time) {
   ::pbv1::SantaMessage *santa_msg = Arena::CreateMessage<::pbv1::SantaMessage>(arena);
 
-  EncodeUUID(santa_msg, msg.uuid());
-  EncodeTimestamp(santa_msg->mutable_event_time(), msg.es_msg().time);
-  EncodeTimestamp(santa_msg->mutable_processed_time(), msg.enrichment_time());
+  EncodeUUID(santa_msg, uuid);
+  if (EnabledMachineID()) {
+    EncodeString(santa_msg->mutable_machine_id(), MachineID());
+  }
+  EncodeTimestamp(santa_msg->mutable_event_time(), event_time);
+  EncodeTimestamp(santa_msg->mutable_processed_time(), processed_time);
 
   return santa_msg;
 }
 
-static inline ::pbv1::SantaMessage *CreateDefaultProto(Arena *arena) {
-  ::pbv1::SantaMessage *santa_msg = Arena::CreateMessage<::pbv1::SantaMessage>(arena);
+::pbv1::SantaMessage *Protobuf::CreateDefaultProto(Arena *arena, const EnrichedEventType &msg) {
+  return CreateDefaultProto(arena, msg.uuid(), msg.es_msg().time, msg.enrichment_time());
+}
 
+::pbv1::SantaMessage *Protobuf::CreateDefaultProto(Arena *arena) {
   uuid_t uuid;
   uuid_generate_random(uuid);
 
   struct timespec ts;
   clock_gettime(CLOCK_REALTIME, &ts);
 
-  EncodeUUID(santa_msg, uuid);
-  EncodeTimestamp(santa_msg->mutable_event_time(), ts);
-  EncodeTimestamp(santa_msg->mutable_processed_time(), ts);
-
-  return santa_msg;
+  return CreateDefaultProto(arena, uuid, ts, ts);
 }
 
-static inline std::vector<uint8_t> FinalizeProto(::pbv1::SantaMessage *santa_msg) {
+std::vector<uint8_t> Protobuf::FinalizeProto(::pbv1::SantaMessage *santa_msg) {
   std::vector<uint8_t> vec(santa_msg->ByteSizeLong());
   santa_msg->SerializeToArray(vec.data(), (int)vec.capacity());
   return vec;
@@ -435,11 +444,6 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg) {
   NSString *orig_path = Utilities::OriginalPathForTranslocation(msg.es_msg().event.exec.target);
   if (orig_path) {
     pb_exec->set_original_path([orig_path UTF8String], [orig_path length]);
-  }
-
-  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
-    pb_exec->set_machine_id([[[SNTConfigurator configurator] machineID] UTF8String],
-                            [[[SNTConfigurator configurator] machineID] length]);
   }
 
   return FinalizeProto(santa_msg);

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -28,6 +28,7 @@ namespace santa::santad::logs::endpoint_security::serializers {
 
 class Serializer {
  public:
+  Serializer();
   virtual ~Serializer() = default;
 
   std::vector<uint8_t> SerializeMessage(
@@ -35,6 +36,9 @@ class Serializer {
     return std::visit([this](const auto &arg) { return this->SerializeMessageTemplate(arg); },
                       msg->GetEnrichedMessage());
   }
+
+  bool EnabledMachineID();
+  std::string_view MachineID();
 
   virtual std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedClose &) = 0;
@@ -80,6 +84,9 @@ class Serializer {
     const santa::santad::event_providers::endpoint_security::EnrichedRename &);
   std::vector<uint8_t> SerializeMessageTemplate(
     const santa::santad::event_providers::endpoint_security::EnrichedUnlink &);
+
+  bool enabled_machine_id_ = false;
+  std::string machine_id_;
 };
 
 }  // namespace santa::santad::logs::endpoint_security::serializers

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -15,12 +15,29 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
 #include <EndpointSecurity/EndpointSecurity.h>
+#include <string_view>
 
+#import "Source/common/SNTConfigurator.h"
 #import "Source/santad/SNTDecisionCache.h"
 
 namespace es = santa::santad::event_providers::endpoint_security;
 
 namespace santa::santad::logs::endpoint_security::serializers {
+
+Serializer::Serializer() {
+  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
+    enabled_machine_id_ = true;
+    machine_id_ = [[[SNTConfigurator configurator] machineID] UTF8String] ?: "";
+  }
+}
+
+bool Serializer::EnabledMachineID() {
+  return enabled_machine_id_;
+}
+
+std::string_view Serializer::MachineID() {
+  return std::string_view(machine_id_);
+};
 
 std::vector<uint8_t> Serializer::SerializeMessageTemplate(const es::EnrichedClose &msg) {
   return SerializeMessage(msg);

--- a/Source/santad/testdata/protobuf/v1/exec.json
+++ b/Source/santad/testdata/protobuf/v1/exec.json
@@ -147,6 +147,5 @@
   }
  },
  "explain": "extra!",
- "quarantine_url": "google.com",
- "machine_id": "my_machine_id"
+ "quarantine_url": "google.com"
 }

--- a/Source/santad/testdata/protobuf/v2/exec.json
+++ b/Source/santad/testdata/protobuf/v2/exec.json
@@ -201,6 +201,5 @@
   }
  },
  "explain": "extra!",
- "quarantine_url": "google.com",
- "machine_id": "my_machine_id"
+ "quarantine_url": "google.com"
 }

--- a/Source/santad/testdata/protobuf/v4/exec.json
+++ b/Source/santad/testdata/protobuf/v4/exec.json
@@ -255,6 +255,5 @@
   }
  },
  "explain": "extra!",
- "quarantine_url": "google.com",
- "machine_id": "my_machine_id"
+ "quarantine_url": "google.com"
 }

--- a/Source/santad/testdata/protobuf/v5/exec.json
+++ b/Source/santad/testdata/protobuf/v5/exec.json
@@ -255,6 +255,5 @@
   }
  },
  "explain": "extra!",
- "quarantine_url": "google.com",
- "machine_id": "my_machine_id"
+ "quarantine_url": "google.com"
 }


### PR DESCRIPTION
Adds the MachineID field to all basic string serialized messages. And moves the field to the top level SantaMessage message type in the proto schema.