### PR TITLE
USB: usbBlockMessage is not being used.

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -380,12 +380,6 @@
 @property(nonatomic) NSArray<NSString *> *remountUSBMode;
 
 ///
-/// When `blockUSBMount` is set, this is the message shown to the user when a device is blocked
-/// If this message is not configured, a reasonable default is provided.
-///
-@property(readonly, nonatomic) NSString *usbBlockMessage;
-
-///
 ///  If set, this over-rides the default machine ID used for syncing.
 ///
 @property(readonly, nonatomic) NSString *machineID;


### PR DESCRIPTION
Remove unused `usbBlockMessage` attribute from `SNTConfigurator`.