### PR TITLE
Fix: duplicates bug in SNTMetricSet when using multiple fields

### DIFF
--- a/Source/common/SNTMetricSet.m
+++ b/Source/common/SNTMetricSet.m
@@ -280,15 +280,12 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
   if (_fieldNames.count == 0) {
     metricDict[@"fields"][@""] = @[ [self encodeMetricValueForFieldValues:@[]] ];
   } else {
-    for (NSString *fieldName in _fieldNames) {
-      NSMutableArray *fieldVals = [[NSMutableArray alloc] init];
+    NSMutableArray *fieldVals = [[NSMutableArray alloc] init];
 
-      for (NSArray<NSString *> *fieldValues in _metricsForFieldValues) {
-        [fieldVals addObject:[self encodeMetricValueForFieldValues:fieldValues]];
-      }
-
-      metricDict[@"fields"][fieldName] = fieldVals;
+    for (NSArray<NSString *> *fieldValues in _metricsForFieldValues) {
+      [fieldVals addObject:[self encodeMetricValueForFieldValues:fieldValues]];
     }
+    metricDict[@"fields"][[_fieldNames componentsJoinedByString:@","]] = fieldVals;
   }
   return metricDict;
 }

--- a/Source/common/SNTMetricSetTest.m
+++ b/Source/common/SNTMetricSetTest.m
@@ -672,4 +672,35 @@
                           output);
   }
 }
+
+- (void)testEnsureMetricsWithMultipleFieldNamesSerializeOnce {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] initWithHostname:@"testHost"
+                                                          username:@"testUser"];
+
+  SNTMetricCounter *c =
+    [metricSet counterWithName:@"/santa/events"
+                    fieldNames:@[ @"client", @"event_type" ]
+                      helpText:@"Count of events on the host for a given ES client"];
+  [c incrementBy:1 forFieldValues:@[ @"device_manager", @"auth_mount" ]];
+
+  NSDictionary *expected = @{
+    @"/santa/events" : @{
+      @"description" : @"Count of events on the host for a given ES client",
+      @"type" : [NSNumber numberWithInt:(int)SNTMetricTypeCounter],
+      @"fields" : @{
+        @"client,event_type" : @[
+          @{
+            @"value" : @"device_manager,auth_mount",
+            @"created" : [NSDate date],
+            @"last_updated" : [NSDate date],
+            @"data" : [NSNumber numberWithInt:1],
+          },
+        ],
+      },
+    }
+  };
+
+  NSDictionary *got = [metricSet export][@"metrics"];
+  XCTAssertEqualObjects(expected, got, @"metrics do not match expected");
+}
 @end


### PR DESCRIPTION
Fix a bug in `SNTMetricSet` that was producing duplicates of a metric cell when the metric had multiple fields.