### PR TITLE
Event metrics

### DIFF
--- a/Source/common/TestUtils.h
+++ b/Source/common/TestUtils.h
@@ -38,6 +38,10 @@
 // Pretty print C++ string match errors
 #define XCTAssertCppStringEqual(got, want) XCTAssertCStringEqual((got).c_str(), (want).c_str())
 
+#define XCTAssertSemaTrue(s, sec, m) \
+  XCTAssertEqual(                    \
+    0, dispatch_semaphore_wait((s), dispatch_time(DISPATCH_TIME_NOW, (sec)*NSEC_PER_SEC)), m)
+
 // Helper to ensure at least `ms` milliseconds are slept, even if the sleep
 // function returns early due to interrupts.
 void SleepMS(long ms);

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -674,6 +674,21 @@ objc_library(
     ],
 )
 
+objc_library(
+    name = "MockMetrics",
+    testonly = 1,
+    hdrs = ["MockMetrics.h"],
+    # sdk_dylibs = [
+    #     "EndpointSecurity",
+    # ],
+    deps = [
+        ":Metrics",
+        "//Source/common:SNTMetricSet",
+        # ":EndpointSecurityMessage",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 santa_unit_test(
     name = "SNTEventTableTest",
     srcs = [
@@ -735,6 +750,7 @@ santa_unit_test(
     tags = ["exclusive"],
     deps = [
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":MockEndpointSecurityAPI",
         ":SNTDatabaseController",
         ":SNTEndpointSecurityAuthorizer",
@@ -963,6 +979,8 @@ santa_unit_test(
     srcs = ["MetricsTest.mm"],
     deps = [
         ":Metrics",
+        "//Source/common:SNTMetricSet",
+        "//Source/common:TestUtils",
         "@OCMock",
     ],
 )
@@ -997,6 +1015,7 @@ santa_unit_test(
         ":EndpointSecurityClient",
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":MockEndpointSecurityAPI",
         ":SNTEndpointSecurityClient",
         "//Source/common:TestUtils",
@@ -1044,6 +1063,7 @@ santa_unit_test(
         ":AuthResultCache",
         ":EndpointSecurityClient",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":MockEndpointSecurityAPI",
         ":SNTCompilerController",
         ":SNTEndpointSecurityAuthorizer",
@@ -1063,6 +1083,7 @@ santa_unit_test(
     deps = [
         ":EndpointSecurityClient",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":MockEndpointSecurityAPI",
         ":SNTEndpointSecurityTamperResistance",
         "//Source/common:SNTLogging",
@@ -1085,6 +1106,7 @@ santa_unit_test(
         ":EndpointSecurityEnricher",
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":MockEndpointSecurityAPI",
         ":SNTCompilerController",
         ":SNTEndpointSecurityRecorder",
@@ -1106,6 +1128,7 @@ santa_unit_test(
         ":DiskArbitrationTestLib",
         ":EndpointSecurityClient",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":MockEndpointSecurityAPI",
         ":SNTEndpointSecurityDeviceManager",
         "//Source/common:SNTConfigurator",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -674,21 +674,6 @@ objc_library(
     ],
 )
 
-objc_library(
-    name = "MockMetrics",
-    testonly = 1,
-    hdrs = ["MockMetrics.h"],
-    # sdk_dylibs = [
-    #     "EndpointSecurity",
-    # ],
-    deps = [
-        ":Metrics",
-        "//Source/common:SNTMetricSet",
-        # ":EndpointSecurityMessage",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
 santa_unit_test(
     name = "SNTEventTableTest",
     srcs = [

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -62,6 +62,7 @@ objc_library(
     hdrs = ["EventProviders/SNTEndpointSecurityEventHandler.h"],
     deps = [
         ":EndpointSecurityMessage",
+        ":Metrics",
         "//Source/common:SNTCommon",
     ],
 )
@@ -208,6 +209,7 @@ objc_library(
         ":EndpointSecurityClient",
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
+        ":Metrics",
     ],
 )
 
@@ -220,6 +222,7 @@ objc_library(
         ":EndpointSecurityClient",
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":SNTEndpointSecurityClientBase",
         "//Source/common:SNTCommon",
         "//Source/common:SNTConfigurator",
@@ -238,6 +241,7 @@ objc_library(
         ":EndpointSecurityEnricher",
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":SNTCompilerController",
         ":SNTEndpointSecurityClient",
         ":SNTEndpointSecurityEventHandler",
@@ -254,6 +258,7 @@ objc_library(
         ":EndpointSecurityAPI",
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":SNTEndpointSecurityClient",
         ":SNTEndpointSecurityEventHandler",
         "//Source/common:SNTLogging",
@@ -270,6 +275,7 @@ objc_library(
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityEnricher",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":SNTCompilerController",
         ":SNTEndpointSecurityClient",
         ":SNTEndpointSecurityEventHandler",
@@ -287,6 +293,7 @@ objc_library(
         ":EndpointSecurityAPI",
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
+        ":Metrics",
         ":SNTEndpointSecurityClient",
         ":SNTEndpointSecurityEventHandler",
         "//Source/common:SNTDeviceEvent",
@@ -617,6 +624,7 @@ objc_library(
         ":SantadDeps",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTMetricSet",
         "//Source/common:SNTXPCControlInterface",
     ],
 )

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.h
@@ -18,6 +18,7 @@
 #import "Source/santad/EventProviders/AuthResultCache.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
+#include "Source/santad/Metrics.h"
 #import "Source/santad/SNTCompilerController.h"
 #import "Source/santad/SNTExecutionController.h"
 
@@ -30,6 +31,7 @@
        initWithESAPI:
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)
            esApi
+             metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
       execController:(SNTExecutionController *)execController
   compilerController:(SNTCompilerController *)compilerController
      authResultCache:

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -23,11 +23,15 @@
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "Source/santad/Metrics.h"
 
 @protocol SNTEndpointSecurityClientBase
 
-- (instancetype)initWithESAPI:
-  (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi;
+- (instancetype)
+  initWithESAPI:
+    (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
+        metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+      processor:(santa::santad::Processor)processor;
 
 /// @note If this fails to establish a new ES client via `es_new_client`, an exception is raised
 /// that should terminate the program.

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -28,7 +28,9 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
+#include "Source/santad/Metrics.h"
 
+using santa::santad::Processor;
 using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
 using santa::santad::event_providers::endpoint_security::EnrichedFile;
@@ -40,7 +42,8 @@ using santa::santad::event_providers::endpoint_security::Message;
 - (void)establishClientOrDie;
 - (bool)muteSelf;
 - (NSString *)errorMessageForNewClientResult:(es_new_client_result_t)result;
-- (void)handleMessage:(Message &&)esMsg;
+- (void)handleMessage:(Message &&)esMsg
+   recordEventMetrics:(void (^)(santa::santad::EventDisposition disposition))recordEventMetrics;
 - (BOOL)shouldHandleMessage:(const Message &)esMsg
      ignoringOtherESClients:(BOOL)ignoringOtherESClients;
 
@@ -61,7 +64,10 @@ using santa::santad::event_providers::endpoint_security::Message;
     .WillOnce(testing::Return(Client()))
     .WillOnce(testing::Return(Client(nullptr, ES_NEW_CLIENT_RESULT_SUCCESS)));
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   // First time throws because mock triggers failed connection
   // Second time succeeds
@@ -83,7 +89,10 @@ using santa::santad::event_providers::endpoint_security::Message;
     {(es_new_client_result_t)123, "Unknown error"},
   };
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:nullptr];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:nullptr
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   for (const auto &kv : resultMessagePairs) {
     NSString *message = [client errorMessageForNewClientResult:kv.first];
@@ -97,9 +106,12 @@ using santa::santad::event_providers::endpoint_security::Message;
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
-  { XCTAssertThrows([client handleMessage:Message(mockESApi, &esMsg)]); }
+  { XCTAssertThrows([client handleMessage:Message(mockESApi, &esMsg) recordEventMetrics:nil]); }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
@@ -116,7 +128,10 @@ using santa::santad::event_providers::endpoint_security::Message;
   EXPECT_CALL(*mockESApi, RespondAuthResult(testing::_, testing::_, ES_AUTH_RESULT_ALLOW, true))
     .WillOnce(testing::Return(true));
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   {
     Message msg(mockESApi, &esMsg);
@@ -153,7 +168,10 @@ using santa::santad::event_providers::endpoint_security::Message;
 
 - (void)testMuteSelf {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   EXPECT_CALL(*mockESApi, MuteProcess)
     .WillOnce(testing::Return(true))
@@ -167,7 +185,10 @@ using santa::santad::event_providers::endpoint_security::Message;
 
 - (void)testClearCache {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   // Test the underlying clear cache impl returning both true and false
   EXPECT_CALL(*mockESApi, ClearCache)
@@ -182,7 +203,10 @@ using santa::santad::event_providers::endpoint_security::Message;
 
 - (void)testSubscribe {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   std::set<es_event_type_t> events = {
     ES_EVENT_TYPE_NOTIFY_CLOSE,
@@ -202,7 +226,10 @@ using santa::santad::event_providers::endpoint_security::Message;
 
 - (void)testSubscribeAndClearCache {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   // Have subscribe fail the first time, meaning clear cache only called once.
   EXPECT_CALL(*mockESApi, ClearCache)
@@ -229,7 +256,10 @@ using santa::santad::event_providers::endpoint_security::Message;
   EXPECT_CALL(*mockESApi, RespondAuthResult(testing::_, testing::_, result, cacheable))
     .WillOnce(testing::Return(true));
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   {
     Message msg(mockESApi, &esMsg);
@@ -249,7 +279,10 @@ using santa::santad::event_providers::endpoint_security::Message;
   // Because we don't need to operate on the es_msg_, this simplifies the test.
   EXPECT_CALL(*mockESApi, RetainMessage);
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   es_message_t esMsg;
   auto enrichedMsg = std::make_shared<EnrichedMessage>(
@@ -285,7 +318,10 @@ using santa::santad::event_providers::endpoint_security::Message;
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   {
     XCTAssertThrows([client processMessage:Message(mockESApi, &esMsg)
@@ -313,7 +349,10 @@ using santa::santad::event_providers::endpoint_security::Message;
 
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
 
   {
     XCTAssertNoThrow([client processMessage:Message(mockESApi, &esMsg)
@@ -359,7 +398,10 @@ using santa::santad::event_providers::endpoint_security::Message;
       return true;
     }));
 
-  SNTEndpointSecurityClient *client = [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi];
+  SNTEndpointSecurityClient *client =
+    [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
+                                             metrics:nullptr
+                                           processor:Processor::kUnknown];
   client.deadlineMarginMS = 500;
 
   {

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h
@@ -21,6 +21,7 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#include "Source/santad/Metrics.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +41,7 @@ typedef void (^SNTDeviceBlockCallback)(SNTDeviceEvent *event);
 - (instancetype)
     initWithESAPI:
       (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
+          metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
            logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
   authResultCache:(std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -21,6 +21,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sys/mount.h>
+#include <cstddef>
 
 #include <memory>
 #include <set>
@@ -33,7 +34,9 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h"
+#include "Source/santad/Metrics.h"
 
+using santa::santad::EventDisposition;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::endpoint_security::Message;
@@ -106,6 +109,7 @@ class MockAuthResultCache : public AuthResultCache {
 
   SNTEndpointSecurityDeviceManager *deviceManager =
     [[SNTEndpointSecurityDeviceManager alloc] initWithESAPI:mockESApi
+                                                    metrics:nullptr
                                                      logger:nullptr
                                             authResultCache:nullptr];
 
@@ -122,6 +126,8 @@ class MockAuthResultCache : public AuthResultCache {
   es_message_t esMsg = MakeESMessage(eventType, &proc, ActionType::Auth, 6000);
   // Need a pointer to esMsg to capture in blocks below.
   es_message_t *heapESMsg = &esMsg;
+
+  dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
 
   __block int retainCount = 0;
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
@@ -157,13 +163,17 @@ class MockAuthResultCache : public AuthResultCache {
       return true;
     }));
 
-  [deviceManager handleMessage:Message(mockESApi, &esMsg)];
+  [deviceManager handleMessage:Message(mockESApi, &esMsg)
+            recordEventMetrics:^(EventDisposition d) {
+              XCTAssertEqual(d, deviceManager.blockUSBMount ? EventDisposition::kProcessed
+                                                            : EventDisposition::kDropped);
+              dispatch_semaphore_signal(semaMetrics);
+            }];
 
   [self waitForExpectations:@[ mountExpectation ] timeout:60.0];
 
-  XCTAssertEqual(0,
-                 dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)),
-                 "Failed waiting for message to be processed...");
+  XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
+  XCTAssertSemaTrue(sema, 5, "Failed waiting for message to be processed...");
 
   [partialDeviceManager stopMocking];
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
@@ -303,6 +313,8 @@ class MockAuthResultCache : public AuthResultCache {
   es_process_t proc = MakeESProcess(&file);
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_UNMOUNT, &proc);
 
+  dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
+
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
@@ -312,12 +324,19 @@ class MockAuthResultCache : public AuthResultCache {
 
   SNTEndpointSecurityDeviceManager *deviceManager =
     [[SNTEndpointSecurityDeviceManager alloc] initWithESAPI:mockESApi
+                                                    metrics:nullptr
                                                      logger:nullptr
                                             authResultCache:mockAuthCache];
 
   deviceManager.blockUSBMount = YES;
 
-  [deviceManager handleMessage:Message(mockESApi, &esMsg)];
+  [deviceManager handleMessage:Message(mockESApi, &esMsg)
+            recordEventMetrics:^(EventDisposition d) {
+              XCTAssertEqual(d, EventDisposition::kProcessed);
+              dispatch_semaphore_signal(semaMetrics);
+            }];
+
+  XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
   XCTBubbleMockVerifyAndClearExpectations(mockAuthCache.get());
@@ -332,7 +351,10 @@ class MockAuthResultCache : public AuthResultCache {
   };
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
 
-  id deviceClient = [[SNTEndpointSecurityDeviceManager alloc] initWithESAPI:mockESApi];
+  id deviceClient = [[SNTEndpointSecurityDeviceManager alloc]
+    initWithESAPI:mockESApi
+          metrics:nullptr
+        processor:santa::santad::Processor::kDeviceManager];
 
   EXPECT_CALL(*mockESApi, ClearCache(testing::_))
     .After(EXPECT_CALL(*mockESApi, Subscribe(testing::_, expectedEventSubs))

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -17,13 +17,15 @@
 #include "Source/common/SNTCommon.h"
 
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "Source/santad/Metrics.h"
 
 // Protocol that all subclasses of `SNTEndpointSecurityClient` should adhere to.
 @protocol SNTEndpointSecurityEventHandler <NSObject>
 
 // Called Synchronously and serially for each message provided by the
 // EndpointSecurity framework.
-- (void)handleMessage:(santa::santad::event_providers::endpoint_security::Message &&)esMsg;
+- (void)handleMessage:(santa::santad::event_providers::endpoint_security::Message &&)esMsg
+   recordEventMetrics:(void (^)(santa::santad::EventDisposition))recordEventMetrics;
 
 // Called after Santa has finished initializing itself.
 // This is an optimal place to subscribe to ES events

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
@@ -19,6 +19,7 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#import "Source/santad/Metrics.h"
 #import "Source/santad/SNTCompilerController.h"
 
 /// ES Client focused on subscribing to NOTIFY event variants with the intention of enriching
@@ -29,6 +30,7 @@
        initWithESAPI:
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)
            esApi
+             metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
               logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
             enricher:
               (std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>)enricher

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -31,8 +31,11 @@
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityRecorder.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#include "Source/santad/Metrics.h"
 #import "Source/santad/SNTCompilerController.h"
 
+using santa::santad::EventDisposition;
+using santa::santad::Processor;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
@@ -72,7 +75,9 @@ class MockLogger : public Logger {
   };
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
 
-  id recorderClient = [[SNTEndpointSecurityRecorder alloc] initWithESAPI:mockESApi];
+  id recorderClient = [[SNTEndpointSecurityRecorder alloc] initWithESAPI:mockESApi
+                                                                 metrics:nullptr
+                                                               processor:Processor::kRecorder];
 
   EXPECT_CALL(*mockESApi, Subscribe(testing::_, expectedEventSubs)).WillOnce(testing::Return(true));
 
@@ -99,6 +104,8 @@ class MockLogger : public Logger {
   auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
   EXPECT_CALL(*mockAuthCache, RemoveFromCache(&targetFile)).Times(1);
 
+  dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
+
   // NOTE: Currently unable to create a partial mock of the
   // `SNTEndpointSecurityRecorder` object. There is a bug in OCMock that doesn't
   // properly handle the `processEnrichedMessage:handler:` block. Instead this
@@ -115,6 +122,7 @@ class MockLogger : public Logger {
 
   SNTEndpointSecurityRecorder *recorderClient =
     [[SNTEndpointSecurityRecorder alloc] initWithESAPI:mockESApi
+                                               metrics:nullptr
                                                 logger:mockLogger
                                               enricher:mockEnricher
                                     compilerController:mockCC
@@ -127,7 +135,13 @@ class MockLogger : public Logger {
     esMsg.event.close.modified = false;
     esMsg.event.close.target = NULL;
 
-    XCTAssertNoThrow([recorderClient handleMessage:Message(mockESApi, &esMsg)]);
+    XCTAssertNoThrow([recorderClient handleMessage:Message(mockESApi, &esMsg)
+                                recordEventMetrics:^(EventDisposition d) {
+                                  XCTAssertEqual(d, EventDisposition::kDropped);
+                                  dispatch_semaphore_signal(semaMetrics);
+                                }]);
+
+    XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
   }
 
   // CLOSE modified, remove from cache
@@ -139,11 +153,14 @@ class MockLogger : public Logger {
 
     OCMExpect([mockCC handleEvent:msg withLogger:nullptr]).ignoringNonObjectArgs();
 
-    [recorderClient handleMessage:std::move(msg)];
+    [recorderClient handleMessage:std::move(msg)
+               recordEventMetrics:^(EventDisposition d) {
+                 XCTAssertEqual(d, EventDisposition::kProcessed);
+                 dispatch_semaphore_signal(semaMetrics);
+               }];
 
-    XCTAssertEqual(
-      0, dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)),
-      "Log wasn't called within expected time window");
+    XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
+    XCTAssertSemaTrue(sema, 5, "Log wasn't called within expected time window");
   }
 
   // LINK, Prefix match, bail early
@@ -155,7 +172,13 @@ class MockLogger : public Logger {
 
     OCMExpect([mockCC handleEvent:msg withLogger:nullptr]).ignoringNonObjectArgs();
 
-    [recorderClient handleMessage:std::move(msg)];
+    [recorderClient handleMessage:std::move(msg)
+               recordEventMetrics:^(EventDisposition d) {
+                 XCTAssertEqual(d, EventDisposition::kDropped);
+                 dispatch_semaphore_signal(semaMetrics);
+               }];
+
+    XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
   }
 
   XCTAssertTrue(OCMVerifyAll(mockCC));

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h
@@ -20,6 +20,7 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
+#include "Source/santad/Metrics.h"
 
 /// ES Client focused on mitigating accidental or malicious tampering of Santa and its components.
 @interface SNTEndpointSecurityTamperResistance
@@ -28,6 +29,7 @@
 - (instancetype)
   initWithESAPI:
     (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
+        metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
          logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -19,7 +19,9 @@
 
 #import "Source/common/SNTLogging.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
+#include "Source/santad/Metrics.h"
 
+using santa::santad::EventDisposition;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::Logger;
@@ -31,8 +33,11 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 }
 
 - (instancetype)initWithESAPI:(std::shared_ptr<EndpointSecurityAPI>)esApi
+                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
                        logger:(std::shared_ptr<Logger>)logger {
-  self = [super initWithESAPI:std::move(esApi)];
+  self = [super initWithESAPI:std::move(esApi)
+                      metrics:std::move(metrics)
+                    processor:santa::santad::Processor::kTamperResistance];
   if (self) {
     _logger = logger;
 
@@ -41,54 +46,47 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   return self;
 }
 
-- (void)handleMessage:(Message &&)esMsg {
+- (void)handleMessage:(Message &&)esMsg
+   recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {
+  es_auth_result_t result = ES_AUTH_RESULT_ALLOW;
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_AUTH_UNLINK: {
       if ([SNTEndpointSecurityTamperResistance
             isDatabasePath:esMsg->event.unlink.target->path.data]) {
-        // Do not cache so that each attempt to remove santa is logged
-        [self respondToMessage:esMsg withAuthResult:ES_AUTH_RESULT_DENY cacheable:false];
+        result = ES_AUTH_RESULT_DENY;
         LOGW(@"Preventing attempt to delete Santa databases!");
-      } else {
-        [self respondToMessage:esMsg withAuthResult:ES_AUTH_RESULT_ALLOW cacheable:true];
       }
-
-      return;
+      break;
     }
 
     case ES_EVENT_TYPE_AUTH_RENAME: {
       if ([SNTEndpointSecurityTamperResistance
             isDatabasePath:esMsg->event.rename.source->path.data]) {
-        // Do not cache so that each attempt to remove santa is logged
-        [self respondToMessage:esMsg withAuthResult:ES_AUTH_RESULT_DENY cacheable:false];
+        result = ES_AUTH_RESULT_DENY;
         LOGW(@"Preventing attempt to rename Santa databases!");
-        return;
+        break;
       }
 
       if (esMsg->event.rename.destination_type == ES_DESTINATION_TYPE_EXISTING_FILE) {
         if ([SNTEndpointSecurityTamperResistance
               isDatabasePath:esMsg->event.rename.destination.existing_file->path.data]) {
-          [self respondToMessage:esMsg withAuthResult:ES_AUTH_RESULT_DENY cacheable:false];
+          result = ES_AUTH_RESULT_DENY;
           LOGW(@"Preventing attempt to overwrite Santa databases!");
-          return;
+          break;
         }
       }
 
-      // If we get to here, no more reasons to deny the event, so allow it
-      [self respondToMessage:esMsg withAuthResult:ES_AUTH_RESULT_ALLOW cacheable:true];
-      return;
+      break;
     }
 
     case ES_EVENT_TYPE_AUTH_KEXTLOAD: {
       // TODO(mlw): Since we don't package the kext anymore, we should consider removing this.
       // TODO(mlw): Consider logging when kext loads are attempted.
-      es_auth_result_t res = ES_AUTH_RESULT_ALLOW;
       if (strcmp(esMsg->event.kextload.identifier.data, kSantaKextIdentifier.data()) == 0) {
+        result = ES_AUTH_RESULT_DENY;
         LOGW(@"Preventing attempt to load Santa kext!");
-        res = ES_AUTH_RESULT_DENY;
       }
-      [self respondToMessage:esMsg withAuthResult:res cacheable:true];
-      return;
+      break;
     }
 
     default:
@@ -96,6 +94,13 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
       [NSException raise:@"Invalid event type"
                   format:@"Invalid tamper resistance event type: %d", esMsg->event_type];
   }
+
+  // Do not cache denied operations so that each tamper attempt is logged
+  [self respondToMessage:esMsg withAuthResult:result cacheable:result == ES_AUTH_RESULT_ALLOW];
+
+  // For this client, a processed event is one that was found to be violating anti-tamper policy
+  recordEventMetrics(result == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                   : EventDisposition::kDropped);
 }
 
 - (void)enable {

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdlib.h>
 
 #include <map>
 #include <memory>
@@ -27,7 +28,9 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h"
+#import "Source/santad/Metrics.h"
 
+using santa::santad::EventDisposition;
 using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::Message;
 
@@ -59,7 +62,9 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
     .WillOnce(testing::Return(true));
 
   SNTEndpointSecurityTamperResistance *tamperClient =
-    [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:mockESApi logger:nullptr];
+    [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:mockESApi
+                                                       metrics:nullptr
+                                                        logger:nullptr];
   id mockTamperClient = OCMPartialMock(tamperClient);
 
   [mockTamperClient enable];
@@ -91,12 +96,16 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
     {&benignTok, ES_AUTH_RESULT_ALLOW},
   };
 
+  dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
+
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
 
   SNTEndpointSecurityTamperResistance *tamperClient =
-    [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:mockESApi logger:nullptr];
+    [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:mockESApi
+                                                       metrics:nullptr
+                                                        logger:nullptr];
 
   id mockTamperClient = OCMPartialMock(tamperClient);
 
@@ -118,7 +127,10 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   // First check unhandled event types will crash
   {
     Message msg(mockESApi, &esMsg);
-    XCTAssertThrows([tamperClient handleMessage:Message(mockESApi, &esMsg)]);
+    XCTAssertThrows([tamperClient handleMessage:Message(mockESApi, &esMsg)
+                             recordEventMetrics:^(EventDisposition d) {
+                               XCTFail("Unhandled event types shouldn't call metrics recorder");
+                             }]);
   }
 
   // Check UNLINK tamper events
@@ -128,7 +140,15 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
       Message msg(mockESApi, &esMsg);
       esMsg.event.unlink.target = kv.first;
 
-      [mockTamperClient handleMessage:std::move(msg)];
+      [mockTamperClient
+             handleMessage:std::move(msg)
+        recordEventMetrics:^(EventDisposition d) {
+          XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                             : EventDisposition::kDropped);
+          dispatch_semaphore_signal(semaMetrics);
+        }];
+
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
 
       XCTAssertEqual(gotAuthResult, kv.second);
       XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
@@ -143,8 +163,15 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
       esMsg.event.rename.source = kv.first;
       esMsg.event.rename.destination_type = ES_DESTINATION_TYPE_NEW_PATH;
 
-      [mockTamperClient handleMessage:std::move(msg)];
+      [mockTamperClient
+             handleMessage:std::move(msg)
+        recordEventMetrics:^(EventDisposition d) {
+          XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                             : EventDisposition::kDropped);
+          dispatch_semaphore_signal(semaMetrics);
+        }];
 
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
       XCTAssertEqual(gotAuthResult, kv.second);
       XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
     }
@@ -159,8 +186,15 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
       esMsg.event.rename.destination_type = ES_DESTINATION_TYPE_EXISTING_FILE;
       esMsg.event.rename.destination.existing_file = kv.first;
 
-      [mockTamperClient handleMessage:std::move(msg)];
+      [mockTamperClient
+             handleMessage:std::move(msg)
+        recordEventMetrics:^(EventDisposition d) {
+          XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                             : EventDisposition::kDropped);
+          dispatch_semaphore_signal(semaMetrics);
+        }];
 
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
       XCTAssertEqual(gotAuthResult, kv.second);
       XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
     }
@@ -174,10 +208,17 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
       Message msg(mockESApi, &esMsg);
       esMsg.event.kextload.identifier = *kv.first;
 
-      [mockTamperClient handleMessage:std::move(msg)];
+      [mockTamperClient
+             handleMessage:std::move(msg)
+        recordEventMetrics:^(EventDisposition d) {
+          XCTAssertEqual(d, kv.second == ES_AUTH_RESULT_DENY ? EventDisposition::kProcessed
+                                                             : EventDisposition::kDropped);
+          dispatch_semaphore_signal(semaMetrics);
+        }];
 
+      XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
       XCTAssertEqual(gotAuthResult, kv.second);
-      XCTAssertEqual(gotCachable, true);  // Note: Kext responses always cached
+      XCTAssertEqual(gotCachable, kv.second == ES_AUTH_RESULT_ALLOW);
     }
   }
 

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -87,7 +87,7 @@ const NSString *EventDispositionToString(EventDisposition d) {
     case EventDisposition::kDropped: return kEventDispositionDropped;
     case EventDisposition::kProcessed: return kEventDispositionProcessed;
     default:
-      [NSException raise:@"Invalid processor" format:@"Unknown processor value: %d", d];
+      [NSException raise:@"Invalid disposition" format:@"Unknown disposition value: %d", d];
       return nil;
   }
 }

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -102,12 +102,12 @@ std::shared_ptr<Metrics> Metrics::Create(SNTMetricSet *metricSet, uint64_t inter
 
   SNTMetricInt64Gauge *event_processing_times =
     [metricSet int64GaugeWithName:@"/santa/event_processing_time"
-                       fieldNames:@[ @"Processor", @"Event", @"Disposition" ]
+                       fieldNames:@[ @"Processor", @"Event" ]
                          helpText:@"Time to process various event types by each processor"];
 
   SNTMetricCounter *event_counts =
     [metricSet counterWithName:@"/santa/event_count"
-                    fieldNames:@[ @"Processor", @"Event" ]
+                    fieldNames:@[ @"Processor", @"Event", @"Disposition" ]
                       helpText:@"Events received and processed by each processor"];
 
   std::shared_ptr<Metrics> metrics = std::make_shared<Metrics>(
@@ -204,7 +204,7 @@ void Metrics::SetEventMetrics(Processor processor, es_event_type_t event_type,
     NSString *disposition = (NSString *)EventDispositionToString(event_disposition);
 
     [event_counts_ incrementForFieldValues:@[ processorName, eventName, disposition ]];
-    [event_processing_times_ set:nanos forFieldValues:@[ processorName, eventName, disposition ]];
+    [event_processing_times_ set:nanos forFieldValues:@[ processorName, eventName ]];
   });
 }
 

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -13,17 +13,116 @@
 ///    limitations under the License.
 
 #include "Source/santad/Metrics.h"
+#include <EndpointSecurity/ESTypes.h>
 
 #include <memory>
 
 #import "Source/common/SNTLogging.h"
-#import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTXPCMetricServiceInterface.h"
 #import "Source/santad/SNTApplicationCoreMetrics.h"
 
+static const NSString *kProcessorAuthorizer = @"Authorizer";
+static const NSString *kProcessorDeviceManager = @"DeviceManager";
+static const NSString *kProcessorGlobal = @"Global";
+static const NSString *kProcessorRecorder = @"Recorder";
+static const NSString *kProcessorTamperResistance = @"TamperResistance";
+
+static const NSString *kEventTypeGlobal = @"Global";
+static const NSString *kEventTypeAuthExec = @"AuthExec";
+static const NSString *kEventTypeAuthKextload = @"AuthKextload";
+static const NSString *kEventTypeAuthMount = @"AuthMount";
+static const NSString *kEventTypeAuthRemount = @"AuthRemount";
+static const NSString *kEventTypeAuthRename = @"AuthRename";
+static const NSString *kEventTypeAuthUnlink = @"AuthUnlink";
+static const NSString *kEventTypeNotifyClose = @"NotifyClose";
+static const NSString *kEventTypeNotifyExchangedata = @"NotifyExchangedata";
+static const NSString *kEventTypeNotifyExec = @"NotifyExec";
+static const NSString *kEventTypeNotifyExit = @"NotifyExit";
+static const NSString *kEventTypeNotifyFork = @"NotifyFork";
+static const NSString *kEventTypeNotifyLink = @"NotifyLink";
+static const NSString *kEventTypeNotifyRename = @"NotifyRename";
+static const NSString *kEventTypeNotifyUnlink = @"NotifyUnlink";
+static const NSString *kEventTypeNotifyUnmount = @"NotifyUnmount";
+
+static const NSString *kEventTypeGlobalDropped = @"GlobalDropped";
+static const NSString *kEventTypeAuthExecDropped = @"AuthExecDropped";
+static const NSString *kEventTypeAuthKextloadDropped = @"AuthKextloadDropped";
+static const NSString *kEventTypeAuthMountDropped = @"AuthMountDropped";
+static const NSString *kEventTypeAuthRemountDropped = @"AuthRemountDropped";
+static const NSString *kEventTypeAuthRenameDropped = @"AuthRenameDropped";
+static const NSString *kEventTypeAuthUnlinkDropped = @"AuthUnlinkDropped";
+static const NSString *kEventTypeNotifyCloseDropped = @"NotifyCloseDropped";
+static const NSString *kEventTypeNotifyExchangedataDropped = @"NotifyExchangedataDropped";
+static const NSString *kEventTypeNotifyExecDropped = @"NotifyExecDropped";
+static const NSString *kEventTypeNotifyExitDropped = @"NotifyExitDropped";
+static const NSString *kEventTypeNotifyForkDropped = @"NotifyForkDropped";
+static const NSString *kEventTypeNotifyLinkDropped = @"NotifyLinkDropped";
+static const NSString *kEventTypeNotifyRenameDropped = @"NotifyRenameDropped";
+static const NSString *kEventTypeNotifyUnlinkDropped = @"NotifyUnlinkDropped";
+static const NSString *kEventTypeNotifyUnmountDropped = @"NotifyUnmountDropped";
+
 namespace santa::santad {
 
-std::shared_ptr<Metrics> Metrics::Create(uint64_t interval) {
+const NSString *SantaProcessorToString(Processor processor) {
+  switch (processor) {
+    case Processor::kAuthorizer: return kProcessorAuthorizer;
+    case Processor::kDeviceManager: return kProcessorDeviceManager;
+    case Processor::kRecorder: return kProcessorRecorder;
+    case Processor::kTamperResistance: return kProcessorTamperResistance;
+    default:
+      [NSException raise:@"Invalid processor" format:@"Unknown processor value: %d", processor];
+      return nil;
+  }
+}
+
+const NSString *EventTypeToString(es_event_type_t eventType) {
+  switch (eventType) {
+    case ES_EVENT_TYPE_AUTH_EXEC: return kEventTypeAuthExec;
+    case ES_EVENT_TYPE_AUTH_KEXTLOAD: return kEventTypeAuthKextload;
+    case ES_EVENT_TYPE_AUTH_MOUNT: return kEventTypeAuthMount;
+    case ES_EVENT_TYPE_AUTH_REMOUNT: return kEventTypeAuthRemount;
+    case ES_EVENT_TYPE_AUTH_RENAME: return kEventTypeAuthRename;
+    case ES_EVENT_TYPE_AUTH_UNLINK: return kEventTypeAuthUnlink;
+    case ES_EVENT_TYPE_NOTIFY_CLOSE: return kEventTypeNotifyClose;
+    case ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA: return kEventTypeNotifyExchangedata;
+    case ES_EVENT_TYPE_NOTIFY_EXEC: return kEventTypeNotifyExec;
+    case ES_EVENT_TYPE_NOTIFY_EXIT: return kEventTypeNotifyExit;
+    case ES_EVENT_TYPE_NOTIFY_FORK: return kEventTypeNotifyFork;
+    case ES_EVENT_TYPE_NOTIFY_LINK: return kEventTypeNotifyLink;
+    case ES_EVENT_TYPE_NOTIFY_RENAME: return kEventTypeNotifyRename;
+    case ES_EVENT_TYPE_NOTIFY_UNLINK: return kEventTypeNotifyUnlink;
+    case ES_EVENT_TYPE_NOTIFY_UNMOUNT: return kEventTypeNotifyUnmount;
+    default:
+      [NSException raise:@"Invalid event type" format:@"Invalid event type: %d", eventType];
+      return nil;
+  }
+}
+
+const NSString *DroppedEventTypeToString(es_event_type_t eventType) {
+  switch (eventType) {
+    case ES_EVENT_TYPE_AUTH_EXEC: return kEventTypeAuthExecDropped;
+    case ES_EVENT_TYPE_AUTH_KEXTLOAD: return kEventTypeAuthKextloadDropped;
+    case ES_EVENT_TYPE_AUTH_MOUNT: return kEventTypeAuthMountDropped;
+    case ES_EVENT_TYPE_AUTH_REMOUNT: return kEventTypeAuthRemountDropped;
+    case ES_EVENT_TYPE_AUTH_RENAME: return kEventTypeAuthRenameDropped;
+    case ES_EVENT_TYPE_AUTH_UNLINK: return kEventTypeAuthUnlinkDropped;
+    case ES_EVENT_TYPE_NOTIFY_CLOSE: return kEventTypeNotifyCloseDropped;
+    case ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA: return kEventTypeNotifyExchangedataDropped;
+    case ES_EVENT_TYPE_NOTIFY_EXEC: return kEventTypeNotifyExecDropped;
+    case ES_EVENT_TYPE_NOTIFY_EXIT: return kEventTypeNotifyExitDropped;
+    case ES_EVENT_TYPE_NOTIFY_FORK: return kEventTypeNotifyForkDropped;
+    case ES_EVENT_TYPE_NOTIFY_LINK: return kEventTypeNotifyLinkDropped;
+    case ES_EVENT_TYPE_NOTIFY_RENAME: return kEventTypeNotifyRenameDropped;
+    case ES_EVENT_TYPE_NOTIFY_UNLINK: return kEventTypeNotifyUnlinkDropped;
+    case ES_EVENT_TYPE_NOTIFY_UNMOUNT: return kEventTypeNotifyUnmountDropped;
+    default:
+      [NSException raise:@"Invalid dropped event type"
+                  format:@"Invalid dropped event type: %d", eventType];
+      return nil;
+  }
+}
+
+std::shared_ptr<Metrics> Metrics::Create(SNTMetricSet *metricSet, uint64_t interval) {
   dispatch_queue_t q = dispatch_queue_create("com.google.santa.santametricsservice.q",
                                              DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
@@ -31,8 +130,18 @@ std::shared_ptr<Metrics> Metrics::Create(uint64_t interval) {
 
   MOLXPCConnection *metrics_connection = [SNTXPCMetricServiceInterface configuredConnection];
 
-  std::shared_ptr<Metrics> metrics =
-    std::make_shared<Metrics>(metrics_connection, q, timer_source, interval, ^() {
+  SNTMetricInt64Gauge *event_processing_times =
+    [metricSet int64GaugeWithName:@"/santa/event_processing_time"
+                       fieldNames:@[ @"Processor", @"Event" ]
+                         helpText:@"Time to process various event types by each processor"];
+
+  SNTMetricCounter *event_counts =
+    [metricSet counterWithName:@"/santa/event_count"
+                    fieldNames:@[ @"Processor", @"Event" ]
+                      helpText:@"Events received and processed by each processor"];
+
+  std::shared_ptr<Metrics> metrics = std::make_shared<Metrics>(
+    metrics_connection, q, timer_source, interval, event_processing_times, event_counts, ^() {
       SNTRegisterCoreMetrics();
       [metrics_connection resume];
     });
@@ -45,7 +154,7 @@ std::shared_ptr<Metrics> Metrics::Create(uint64_t interval) {
     }
 
     [[shared_metrics->metrics_connection_ remoteObjectProxy]
-      exportForMonitoring:[[SNTMetricSet sharedInstance] export]];
+      exportForMonitoring:[metricSet export]];
   });
 
   return metrics;
@@ -53,14 +162,20 @@ std::shared_ptr<Metrics> Metrics::Create(uint64_t interval) {
 
 Metrics::Metrics(MOLXPCConnection *metrics_connection, dispatch_queue_t q,
                  dispatch_source_t timer_source, uint64_t interval,
+                 SNTMetricInt64Gauge *event_processing_times, SNTMetricCounter *event_counts,
                  void (^run_on_first_start)(void))
     : q_(q),
       timer_source_(timer_source),
       interval_(interval),
+      event_processing_times_(event_processing_times),
+      event_counts_(event_counts),
       running_(false),
       run_on_first_start_(run_on_first_start) {
   metrics_connection_ = metrics_connection;
   SetInterval(interval_);
+
+  events_q_ = dispatch_queue_create("com.google.santa.santametricsservice.events_q",
+                                    DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 }
 
 Metrics::~Metrics() {
@@ -107,6 +222,50 @@ void Metrics::StopPoll() {
       running_ = false;
     } else {
       LOGW(@"Attempted to stop metrics poll while already stopped");
+    }
+  });
+}
+
+void Metrics::SetEventMetrics(Processor processor, es_event_type_t event_type,
+                              EventDisposition disposition, int64_t nanos) {
+  dispatch_async(events_q_, ^{
+    NSString *processorName = (NSString *)SantaProcessorToString(processor);
+    NSString *eventName = (NSString *)EventTypeToString(event_type);
+
+    // Per-processor, per-eventType
+    [event_counts_ incrementForFieldValues:@[ processorName, eventName ]];
+    [event_processing_times_ set:nanos forFieldValues:@[ processorName, eventName ]];
+
+    // Per-processor, totals
+    [event_counts_ incrementForFieldValues:@[ processorName, (NSString *)kEventTypeGlobal ]];
+    [event_processing_times_ set:nanos
+                  forFieldValues:@[ processorName, (NSString *)kEventTypeGlobal ]];
+
+    // Global, per-eventType
+    [event_counts_ incrementForFieldValues:@[ (NSString *)kProcessorGlobal, eventName ]];
+    [event_processing_times_ set:nanos forFieldValues:@[ (NSString *)kProcessorGlobal, eventName ]];
+
+    // Global, totals
+    [event_counts_
+      incrementForFieldValues:@[ (NSString *)kProcessorGlobal, (NSString *)kEventTypeGlobal ]];
+    [event_processing_times_ set:nanos
+                  forFieldValues:@[ (NSString *)kProcessorGlobal, (NSString *)kEventTypeGlobal ]];
+
+    if (disposition == EventDisposition::kDropped) {
+      NSString *eventNameDropped = (NSString *)DroppedEventTypeToString(event_type);
+
+      // Per-processor, per-eventType dropped counts
+      [event_counts_ incrementForFieldValues:@[ processorName, eventNameDropped ]];
+      // Per-processor, total dropped counts
+      [event_counts_
+        incrementForFieldValues:@[ processorName, (NSString *)kEventTypeGlobalDropped ]];
+
+      // Global, per-eventType dropped counts
+      [event_counts_ incrementForFieldValues:@[ (NSString *)kProcessorGlobal, eventNameDropped ]];
+      // Global, total event counts
+      [event_counts_ incrementForFieldValues:@[
+        (NSString *)kProcessorGlobal, (NSString *)kEventTypeGlobalDropped
+      ]];
     }
   });
 }

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -176,8 +176,8 @@ using santa::santad::ProcessorToString;
       dispatch_semaphore_signal(self.sema);
     });
 
-  OCMStub([(SNTMetricInt64Gauge *)mockEventProcessingTimes set:nanos forFieldValues:OCMOCK_ANY])
-  .ignoringNonObjectArgs()
+  OCMStub([(SNTMetricInt64Gauge *)mockEventProcessingTimes set:nanos forFieldValues:[OCMArg any]])
+    .ignoringNonObjectArgs()
     .andDo(^(NSInvocation *inv) {
       dispatch_semaphore_signal(self.sema);
     });

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -85,6 +85,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
   SNTEndpointSecurityDeviceManager *device_client =
     [[SNTEndpointSecurityDeviceManager alloc] initWithESAPI:esapi
+                                                    metrics:metrics
                                                      logger:logger
                                             authResultCache:auth_result_cache];
 
@@ -100,6 +101,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
   SNTEndpointSecurityRecorder *monitor_client =
     [[SNTEndpointSecurityRecorder alloc] initWithESAPI:esapi
+                                               metrics:metrics
                                                 logger:logger
                                               enricher:enricher
                                     compilerController:compiler_controller
@@ -108,12 +110,13 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
 
   SNTEndpointSecurityAuthorizer *authorizer_client =
     [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:esapi
+                                                 metrics:metrics
                                           execController:exec_controller
                                       compilerController:compiler_controller
                                          authResultCache:auth_result_cache];
 
   SNTEndpointSecurityTamperResistance *tamper_client =
-    [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:esapi logger:logger];
+    [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:esapi metrics:metrics logger:logger];
 
   EstablishSyncServiceConnection(syncd_queue);
 

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -15,12 +15,13 @@
 #ifndef SANTA__SANTAD__SANTAD_DEPS_H
 #define SANTA__SANTAD__SANTAD_DEPS_H
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 #import <MOLXPCConnection/MOLXPCConnection.h>
 
 #include <memory>
 
 #include "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTMetricSet.h"
 #include "Source/common/SNTPrefixTree.h"
 #include "Source/santad/EventProviders/AuthResultCache.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
@@ -36,19 +37,28 @@ namespace santa::santad {
 
 class SantadDeps {
  public:
-  static std::unique_ptr<SantadDeps> Create(SNTConfigurator *configurator);
+  static std::unique_ptr<SantadDeps> Create(SNTConfigurator *configurator,
+                                            SNTMetricSet *metric_set);
 
   SantadDeps(
-    NSUInteger metric_export_interval,
-    std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi,
-    std::unique_ptr<santa::santad::logs::endpoint_security::Logger> logger,
-    MOLXPCConnection *control_connection, SNTCompilerController *compiler_controller,
-    SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
-    SNTExecutionController *exec_controller, std::shared_ptr<SNTPrefixTree> prefix_tree);
+      std::shared_ptr<santa::santad::event_providers::endpoint_security::
+                          EndpointSecurityAPI>
+          esapi,
+      std::shared_ptr<santa::santad::Metrics> metrics,
+      std::unique_ptr<santa::santad::logs::endpoint_security::Logger> logger,
+      MOLXPCConnection *control_connection,
+      SNTCompilerController *compiler_controller,
+      SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
+      SNTExecutionController *exec_controller,
+      std::shared_ptr<SNTPrefixTree> prefix_tree);
 
-  std::shared_ptr<santa::santad::event_providers::AuthResultCache> AuthResultCache();
-  std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher> Enricher();
-  std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> ESAPI();
+  std::shared_ptr<santa::santad::event_providers::AuthResultCache>
+  AuthResultCache();
+  std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>
+  Enricher();
+  std::shared_ptr<
+      santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>
+  ESAPI();
   std::shared_ptr<santa::santad::logs::endpoint_security::Logger> Logger();
   std::shared_ptr<santa::santad::Metrics> Metrics();
   MOLXPCConnection *ControlConnection();
@@ -59,11 +69,15 @@ class SantadDeps {
   std::shared_ptr<SNTPrefixTree> PrefixTree();
 
  private:
-  std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi_;
+  std::shared_ptr<
+      santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>
+      esapi_;
   std::shared_ptr<santa::santad::logs::endpoint_security::Logger> logger_;
   std::shared_ptr<santa::santad::Metrics> metrics_;
-  std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher> enricher_;
-  std::shared_ptr<santa::santad::event_providers::AuthResultCache> auth_result_cache_;
+  std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>
+      enricher_;
+  std::shared_ptr<santa::santad::event_providers::AuthResultCache>
+      auth_result_cache_;
 
   MOLXPCConnection *control_connection_;
   SNTCompilerController *compiler_controller_;

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -13,8 +13,10 @@
 ///    limitations under the License.
 
 #include "Source/santad/SantadDeps.h"
+#include <memory>
 
 #import "Source/common/SNTLogging.h"
+#import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/santad/DataLayer/SNTEventTable.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
@@ -29,7 +31,8 @@ using santa::santad::logs::endpoint_security::Logger;
 
 namespace santa::santad {
 
-std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator) {
+std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
+                                               SNTMetricSet *metric_set) {
   // TODO(mlw): The XPC interfaces should be injectable. Could either make a new
   // protocol defining appropriate methods or accept values as params.
   MOLXPCConnection *control_connection =
@@ -109,13 +112,21 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator) {
     exit(EXIT_FAILURE);
   }
 
-  return std::make_unique<SantadDeps>([configurator metricExportInterval], esapi, std::move(logger),
-                                      control_connection, compiler_controller, notifier_queue,
-                                      syncd_queue, exec_controller, prefix_tree);
+  // TODO: `SNTMetricSet sharedInstance` should be injected
+  std::shared_ptr<::Metrics> metrics =
+    Metrics::Create(metric_set, [configurator metricExportInterval]);
+  if (!metrics) {
+    LOGE(@"Failed to create metrics");
+    exit(EXIT_FAILURE);
+  }
+
+  return std::make_unique<SantadDeps>(esapi, metrics, std::move(logger), control_connection,
+                                      compiler_controller, notifier_queue, syncd_queue,
+                                      exec_controller, prefix_tree);
 }
 
-SantadDeps::SantadDeps(NSUInteger metric_export_interval,
-                       std::shared_ptr<EndpointSecurityAPI> esapi, std::unique_ptr<::Logger> logger,
+SantadDeps::SantadDeps(std::shared_ptr<EndpointSecurityAPI> esapi,
+                       std::shared_ptr<::Metrics> metrics, std::unique_ptr<::Logger> logger,
                        MOLXPCConnection *control_connection,
                        SNTCompilerController *compiler_controller,
                        SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
@@ -123,7 +134,7 @@ SantadDeps::SantadDeps(NSUInteger metric_export_interval,
                        std::shared_ptr<SNTPrefixTree> prefix_tree)
     : esapi_(std::move(esapi)),
       logger_(std::move(logger)),
-      metrics_(Metrics::Create(metric_export_interval)),
+      metrics_(std::move(metrics)),
       enricher_(std::make_shared<::Enricher>()),
       auth_result_cache_(std::make_shared<::AuthResultCache>(esapi_)),
       control_connection_(control_connection),
@@ -148,7 +159,7 @@ std::shared_ptr<Logger> SantadDeps::Logger() {
   return logger_;
 }
 
-std::shared_ptr<santa::santad::Metrics> SantadDeps::Metrics() {
+std::shared_ptr<::Metrics> SantadDeps::Metrics() {
   return metrics_;
 }
 

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -112,7 +112,6 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
     exit(EXIT_FAILURE);
   }
 
-  // TODO: `SNTMetricSet sharedInstance` should be injected
   std::shared_ptr<::Metrics> metrics =
     Metrics::Create(metric_set, [configurator metricExportInterval]);
   if (!metrics) {

--- a/Source/santad/main.mm
+++ b/Source/santad/main.mm
@@ -19,6 +19,7 @@
 
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
+#import "Source/common/SNTMetricSet.h"
 #import "Source/santad/Santad.h"
 #include "Source/santad/SantadDeps.h"
 
@@ -150,7 +151,8 @@ int main(int argc, char *argv[]) {
       LOGE(@"Failed to start Santa watchdog");
     }
 
-    std::unique_ptr<SantadDeps> deps = SantadDeps::Create([SNTConfigurator configurator]);
+    std::unique_ptr<SantadDeps> deps =
+      SantadDeps::Create([SNTConfigurator configurator], [SNTMetricSet sharedInstance]);
 
     // This doesn't return
     SantadMain(deps->ESAPI(), deps->Logger(), deps->Metrics(), deps->Enricher(),


### PR DESCRIPTION
Add metrics for event counts and event processing times.

Current design passes a block to ES client message handlers to be called when they're done processing and event.

Alternative considered was to have the ES client message handlers return a disposition (instead of calling a block) and leave the work to the base class. This could work but would add some complexity for clients that processed messages async. Given there are only a few clients, it wouldn't be a huge burden to go this route in the future if it provided advantages.