### PR TITLE
Fix: duplicates bug in SNTMetricSet when using multiple fields

### DIFF
--- a/Source/common/SNTMetricSet.m
+++ b/Source/common/SNTMetricSet.m
@@ -280,15 +280,12 @@ NSString *SNTMetricMakeStringFromMetricType(SNTMetricType metricType) {
   if (_fieldNames.count == 0) {
     metricDict[@"fields"][@""] = @[ [self encodeMetricValueForFieldValues:@[]] ];
   } else {
-    for (NSString *fieldName in _fieldNames) {
-      NSMutableArray *fieldVals = [[NSMutableArray alloc] init];
+    NSMutableArray *fieldVals = [[NSMutableArray alloc] init];
 
-      for (NSArray<NSString *> *fieldValues in _metricsForFieldValues) {
-        [fieldVals addObject:[self encodeMetricValueForFieldValues:fieldValues]];
-      }
-
-      metricDict[@"fields"][fieldName] = fieldVals;
+    for (NSArray<NSString *> *fieldValues in _metricsForFieldValues) {
+      [fieldVals addObject:[self encodeMetricValueForFieldValues:fieldValues]];
     }
+    metricDict[@"fields"][[_fieldNames componentsJoinedByString:@","]] = fieldVals;
   }
   return metricDict;
 }

--- a/Source/common/SNTMetricSetTest.m
+++ b/Source/common/SNTMetricSetTest.m
@@ -697,7 +697,7 @@
           },
         ],
       },
-    }
+    },
   };
 
   NSDictionary *got = [metricSet export][@"metrics"];

--- a/Source/common/SNTMetricSetTest.m
+++ b/Source/common/SNTMetricSetTest.m
@@ -672,4 +672,35 @@
                           output);
   }
 }
+
+- (void)testEnsureMetricsWithMultipleFieldNamesSerializeOnce {
+  SNTMetricSet *metricSet = [[SNTMetricSet alloc] initWithHostname:@"testHost"
+                                                          username:@"testUser"];
+
+  SNTMetricCounter *c =
+    [metricSet counterWithName:@"/santa/events"
+                    fieldNames:@[ @"client", @"event_type" ]
+                      helpText:@"Count of events on the host for a given ES client"];
+  [c incrementBy:1 forFieldValues:@[ @"device_manager", @"auth_mount" ]];
+
+  NSDictionary *expected = @{
+    @"/santa/events" : @{
+      @"description" : @"Count of events on the host for a given ES client",
+      @"type" : [NSNumber numberWithInt:(int)SNTMetricTypeCounter],
+      @"fields" : @{
+        @"client,event_type" : @[
+          @{
+            @"value" : @"device_manager,auth_mount",
+            @"created" : [NSDate date],
+            @"last_updated" : [NSDate date],
+            @"data" : [NSNumber numberWithInt:1],
+          },
+        ],
+      },
+    }
+  };
+
+  NSDictionary *got = [metricSet export][@"metrics"];
+  XCTAssertEqualObjects(expected, got, @"metrics do not match expected");
+}
 @end

--- a/Source/santactl/Commands/SNTCommandMetrics.m
+++ b/Source/santactl/Commands/SNTCommandMetrics.m
@@ -68,14 +68,33 @@ REGISTER_COMMAND_NAME(@"metrics")
 
     for (NSString *fieldName in metric[@"fields"]) {
       for (NSDictionary *field in metric[@"fields"][fieldName]) {
-        const char *fieldNameStr = [fieldName cStringUsingEncoding:NSUTF8StringEncoding];
-        const char *fieldValueStr = [field[@"value"] cStringUsingEncoding:NSUTF8StringEncoding];
+        //const char *fieldNameStr = [fieldName cStringUsingEncoding:NSUTF8StringEncoding];
+        //const char *fieldValueStr = [field[@"value"] cStringUsingEncoding:NSUTF8StringEncoding];
         const char *createdStr = [field[@"created"] UTF8String];
         const char *lastUpdatedStr = [field[@"last_updated"] UTF8String];
         const char *data = [[NSString stringWithFormat:@"%@", field[@"data"]] UTF8String];
 
-        if (strlen(fieldNameStr) > 0) {
-          printf("  %-25s | %s=%s\n", "Field", fieldNameStr, fieldValueStr);
+        NSArray<NSString *> *fields = [fieldName componentsSeparatedByString:@","];
+        NSArray<NSString *> *fieldValues = [field[@"value"] componentsSeparatedByString:@","];
+
+        if (fields.count != fieldValues.count) {
+          //TODO Log Error
+          continue;
+        }
+
+        NSString *fieldDisplayString = @"";
+
+        if (fields.count >= 1 && ![@"" isEqualToString: fields[0]]) {
+        for (int i = 0; i < fields.count; i++) {
+          fieldDisplayString = [fieldDisplayString stringByAppendingString:[NSString stringWithFormat:@"%@=%@",fields[i], fieldValues[i]]];
+          if (i < fields.count - 1) {
+            fieldDisplayString = [fieldDisplayString stringByAppendingString:@","];
+          }
+        }
+        }
+
+        if (![fieldDisplayString isEqualToString: @""]) {
+          printf("  %-25s | %s\n", "Field", [fieldDisplayString UTF8String]);
         }
 
         printf("  %-25s | %s\n", "Created", createdStr);

--- a/Source/santactl/Commands/SNTCommandMetrics.m
+++ b/Source/santactl/Commands/SNTCommandMetrics.m
@@ -68,8 +68,6 @@ REGISTER_COMMAND_NAME(@"metrics")
 
     for (NSString *fieldName in metric[@"fields"]) {
       for (NSDictionary *field in metric[@"fields"][fieldName]) {
-        //const char *fieldNameStr = [fieldName cStringUsingEncoding:NSUTF8StringEncoding];
-        //const char *fieldValueStr = [field[@"value"] cStringUsingEncoding:NSUTF8StringEncoding];
         const char *createdStr = [field[@"created"] UTF8String];
         const char *lastUpdatedStr = [field[@"last_updated"] UTF8String];
         const char *data = [[NSString stringWithFormat:@"%@", field[@"data"]] UTF8String];
@@ -78,22 +76,25 @@ REGISTER_COMMAND_NAME(@"metrics")
         NSArray<NSString *> *fieldValues = [field[@"value"] componentsSeparatedByString:@","];
 
         if (fields.count != fieldValues.count) {
-          //TODO Log Error
+          fprintf(stderr, "metric %s has a different number of field names and field values",
+                  [fieldName UTF8String]);
           continue;
         }
 
         NSString *fieldDisplayString = @"";
 
-        if (fields.count >= 1 && ![@"" isEqualToString: fields[0]]) {
-        for (int i = 0; i < fields.count; i++) {
-          fieldDisplayString = [fieldDisplayString stringByAppendingString:[NSString stringWithFormat:@"%@=%@",fields[i], fieldValues[i]]];
-          if (i < fields.count - 1) {
-            fieldDisplayString = [fieldDisplayString stringByAppendingString:@","];
+        if (fields.count >= 1 && fields[0].length) {
+          for (int i = 0; i < fields.count; i++) {
+            fieldDisplayString = [fieldDisplayString
+              stringByAppendingString:[NSString
+                                        stringWithFormat:@"%@=%@", fields[i], fieldValues[i]]];
+            if (i < fields.count - 1) {
+              fieldDisplayString = [fieldDisplayString stringByAppendingString:@","];
+            }
           }
         }
-        }
 
-        if (![fieldDisplayString isEqualToString: @""]) {
+        if (![fieldDisplayString isEqualToString:@""]) {
           printf("  %-25s | %s\n", "Field", [fieldDisplayString UTF8String]);
         }
 

--- a/Source/santactl/Commands/testdata/metrics-prettyprint.json
+++ b/Source/santactl/Commands/testdata/metrics-prettyprint.json
@@ -38,18 +38,18 @@
       "type" : 9,
       "description" : "Count of process exec events on the host",
       "fields" : {
-        "rule_type" : [
+        "rule_type,client" : [
           {
             "created" : "2021-09-16T21:07:34.826Z",
             "last_updated" : "2021-09-16T21:07:34.826Z",
-            "value" : "binary",
-            "data" : 1
+            "value" : "certificate,authorizer",
+            "data" : 2
           },
           {
             "created" : "2021-09-16T21:07:34.826Z",
             "last_updated" : "2021-09-16T21:07:34.826Z",
-            "value" : "certificate",
-            "data" : 2
+            "value" : "binary,authorizer",
+            "data" : 1
           }
         ]
       }

--- a/Source/santactl/Commands/testdata/metrics-prettyprint.txt
+++ b/Source/santactl/Commands/testdata/metrics-prettyprint.txt
@@ -30,14 +30,14 @@
   Metric Name               | /santa/events
   Description               | Count of process exec events on the host
   Type                      | SNTMetricTypeCounter
-  Field                     | rule_type=binary
-  Created                   | 2021-09-16T21:07:34.826Z
-  Last Updated              | 2021-09-16T21:07:34.826Z
-  Data                      | 1
-  Field                     | rule_type=certificate
+  Field                     | rule_type=certificate,client=authorizer
   Created                   | 2021-09-16T21:07:34.826Z
   Last Updated              | 2021-09-16T21:07:34.826Z
   Data                      | 2
+  Field                     | rule_type=binary,client=authorizer
+  Created                   | 2021-09-16T21:07:34.826Z
+  Last Updated              | 2021-09-16T21:07:34.826Z
+  Data                      | 1
 
   Metric Name               | /santa/using_endpoint_security_framework
   Description               | Is santad using the endpoint security framework

--- a/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
+++ b/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
@@ -70,11 +70,11 @@
                          value:(long long)(0x12345668910)];
   // Add Metrics
   SNTMetricCounter *c = [metricSet counterWithName:@"/santa/events"
-                                        fieldNames:@[ @"rule_type" ]
+                                        fieldNames:@[ @"rule_type", @"client"]
                                           helpText:@"Count of process exec events on the host"];
 
-  [c incrementForFieldValues:@[ @"binary" ]];
-  [c incrementBy:2 forFieldValues:@[ @"certificate" ]];
+  [c incrementForFieldValues:@[ @"binary", @"authorizer" ]];
+  [c incrementBy:2 forFieldValues:@[ @"certificate", @"authorizer" ]];
 
   SNTMetricInt64Gauge *g = [metricSet int64GaugeWithName:@"/santa/rules"
                                               fieldNames:@[ @"rule_type" ]

--- a/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
+++ b/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
@@ -70,7 +70,7 @@
                          value:(long long)(0x12345668910)];
   // Add Metrics
   SNTMetricCounter *c = [metricSet counterWithName:@"/santa/events"
-                                        fieldNames:@[ @"rule_type", @"client"]
+                                        fieldNames:@[ @"rule_type", @"client" ]
                                           helpText:@"Count of process exec events on the host"];
 
   [c incrementForFieldValues:@[ @"binary", @"authorizer" ]];

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
@@ -24,6 +24,7 @@ const NSString *kStreamKind = @"streamKind";
 const NSString *kValueType = @"valueType";
 const NSString *kDescription = @"description";
 const NSString *kData = @"data";
+const NSString *kField = @"field";
 const NSString *kFieldDescriptor = @"fieldDescriptor";
 const NSString *kBoolValue = @"boolValue";
 const NSString *kBoolValueType = @"BOOL";
@@ -54,7 +55,7 @@ const NSString *kKey = @"key";
   return self;
 }
 
-- (void)encodeValueAndStreamKindFor:(NSString *)metricName
+- (void)encodeValueTypeAndStreamKindFor:(NSString *)metricName
                          withMetric:(NSDictionary *)metric
                                into:(NSMutableDictionary *)monarchMetric {
   if (!metric[@"type"]) {
@@ -109,7 +110,19 @@ const NSString *kKey = @"key";
       NSMutableDictionary *monarchDataEntry = [[NSMutableDictionary alloc] init];
 
       if (![fieldName isEqualToString:@""]) {
-        monarchDataEntry[@"field"] = @[ @{kName : fieldName, kStringValue : entry[@"value"]} ];
+        // We encode multiple fields as a single comma separated string.
+        NSArray<NSString *> *fieldNames = [fieldName componentsSeparatedByString:@","];
+        NSArray<NSString *> *fieldValues = [entry[@"value"] componentsSeparatedByString:@","];
+
+        if (fieldNames.count != fieldValues.count) {
+          LOGE(@"malformed metric data encounterd: %@", fieldName);
+          continue;
+        }
+        monarchDataEntry[kField] = [[NSMutableArray alloc] init];
+
+        for (int i = 0; i < fieldNames.count; i++) {
+          [monarchDataEntry[kField] addObject: @{kName: fieldNames[i], kStringValue: fieldValues[i]}];
+        }
       }
 
       monarchDataEntry[kStartTimestamp] = [self->_dateFormatter stringFromDate:entry[@"created"]];
@@ -146,13 +159,17 @@ const NSString *kKey = @"key";
  * Translates SNTMetricSet fields to monarch's expected format. In this implementation only string
  * type fields are supported.
  */
-- (NSArray<NSDictionary *> *)encodeFieldsFor:(NSDictionary *)metric {
+- (NSArray<NSDictionary *> *)encodeFieldDescriptorsFor:(NSDictionary *)metric {
   NSMutableArray<NSDictionary *> *monarchFields = [[NSMutableArray alloc] init];
 
-  for (NSString *fieldName in metric[@"fields"]) {
-    if (![fieldName isEqualToString:@""]) {
-      [monarchFields addObject:@{kName : fieldName, @"fieldType" : kStringValueType}];
-    }
+  for (NSString *field in metric[@"fields"]) {
+    if (![field isEqualToString:@""]) {
+      // we encode multiple field names as comma separated strings.
+      NSArray<NSString *> *fieldNames = [field componentsSeparatedByString:@","];
+      for (NSString *fieldName in fieldNames) {
+        [monarchFields addObject:@{kName : fieldName, @"fieldType" : kStringValueType}];
+      }
+    } 
   }
   return monarchFields;
 }
@@ -173,12 +190,12 @@ const NSString *kKey = @"key";
     monarchMetric[kDescription] = metric[kDescription];
   }
 
-  NSArray<NSDictionary *> *fieldDescriptorEntries = [self encodeFieldsFor:metric];
+  NSArray<NSDictionary *> *fieldDescriptorEntries = [self encodeFieldDescriptorsFor:metric];
   if (fieldDescriptorEntries.count > 0) {
-    monarchMetric[kFieldDescriptor] = [self encodeFieldsFor:metric];
+    monarchMetric[kFieldDescriptor] = fieldDescriptorEntries;
   }
 
-  [self encodeValueAndStreamKindFor:name withMetric:metric into:monarchMetric];
+  [self encodeValueTypeAndStreamKindFor:name withMetric:metric into:monarchMetric];
   monarchMetric[@"data"] = [self encodeDataForMetric:metric withEndTimestamp:endTimestamp];
 
   return monarchMetric;

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
@@ -56,8 +56,8 @@ const NSString *kKey = @"key";
 }
 
 - (void)encodeValueTypeAndStreamKindFor:(NSString *)metricName
-                         withMetric:(NSDictionary *)metric
-                               into:(NSMutableDictionary *)monarchMetric {
+                             withMetric:(NSDictionary *)metric
+                                   into:(NSMutableDictionary *)monarchMetric {
   if (!metric[@"type"]) {
     LOGE(@"metric type not supposed to be nil for %@", metricName);
     return;
@@ -115,13 +115,14 @@ const NSString *kKey = @"key";
         NSArray<NSString *> *fieldValues = [entry[@"value"] componentsSeparatedByString:@","];
 
         if (fieldNames.count != fieldValues.count) {
-          LOGE(@"malformed metric data encounterd: %@", fieldName);
+          LOGE(@"malformed metric data encountered: %@", fieldName);
           continue;
         }
         monarchDataEntry[kField] = [[NSMutableArray alloc] init];
 
         for (int i = 0; i < fieldNames.count; i++) {
-          [monarchDataEntry[kField] addObject: @{kName: fieldNames[i], kStringValue: fieldValues[i]}];
+          [monarchDataEntry[kField]
+            addObject:@{kName : fieldNames[i], kStringValue : fieldValues[i]}];
         }
       }
 
@@ -169,7 +170,7 @@ const NSString *kKey = @"key";
       for (NSString *fieldName in fieldNames) {
         [monarchFields addObject:@{kName : fieldName, @"fieldType" : kStringValueType}];
       }
-    } 
+    }
   }
   return monarchFields;
 }

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormatTest.m
@@ -42,6 +42,7 @@
                                       error:&err];
 
   XCTAssertNotNil(expectedJSONDict);
+  XCTAssertNil(err);
   XCTAssertEqualObjects(expectedJSONDict, jsonDict, @"generated JSON does not match golden file.");
 }
 

--- a/Source/santametricservice/Formats/testdata/json/monarch.json
+++ b/Source/santametricservice/Formats/testdata/json/monarch.json
@@ -67,21 +67,14 @@
             {
               "name" : "rule_type",
               "fieldType" : "STRING"
+            },
+            {
+              "name" : "client",
+              "fieldType" : "STRING"
             }
           ],
           "streamKind" : "CUMULATIVE",
           "data" : [
-            {
-              "int64Value" : 1,
-              "endTimestamp" : "2021-09-16T21:08:10.000Z",
-              "field" : [
-                {
-                  "name" : "rule_type",
-                  "stringValue" : "binary"
-                }
-              ],
-              "startTimestamp" : "2021-09-16T21:07:34.826Z"
-            },
             {
               "int64Value" : 2,
               "endTimestamp" : "2021-09-16T21:08:10.000Z",
@@ -89,6 +82,25 @@
                 {
                   "name" : "rule_type",
                   "stringValue" : "certificate"
+                },
+                {
+                  "name" : "client",
+                  "stringValue" : "authorizer"
+                }
+              ],
+              "startTimestamp" : "2021-09-16T21:07:34.826Z"
+            },
+            {
+              "int64Value" : 1,
+              "endTimestamp" : "2021-09-16T21:08:10.000Z",
+              "field" : [
+                {
+                  "name" : "rule_type",
+                  "stringValue" : "binary"
+                },
+                {
+                  "name" : "client",
+                  "stringValue" : "authorizer"
                 }
               ],
               "startTimestamp" : "2021-09-16T21:07:34.826Z"

--- a/Source/santametricservice/Formats/testdata/json/test.json
+++ b/Source/santametricservice/Formats/testdata/json/test.json
@@ -24,18 +24,18 @@
       "type" : 9,
       "description" : "Count of process exec events on the host",
       "fields" : {
-        "rule_type" : [
+        "rule_type,client" : [
           {
-            "value" : "binary",
-            "created" : "2021-09-16T21:07:34.826Z",
-            "last_updated" : "2021-09-16T21:07:34.826Z",
-            "data" : 1
-          },
-          {
-            "value" : "certificate",
+            "value" : "certificate,authorizer",
             "created" : "2021-09-16T21:07:34.826Z",
             "last_updated" : "2021-09-16T21:07:34.826Z",
             "data" : 2
+          },
+          {
+            "value" : "binary,authorizer",
+            "created" : "2021-09-16T21:07:34.826Z",
+            "last_updated" : "2021-09-16T21:07:34.826Z",
+            "data" : 1
           }
         ]
       }


### PR DESCRIPTION
Fix a bug in `SNTMetricSet` that was producing duplicates of a metric cell when the metric had multiple fields.

### Other Changes

- This changes the `santactl metric` command to print metrics with multiple fields as key value pairs e.g. `key=value,key2=value2`
- Updates to JSON test files.