### PR TITLE
Batch SantaMessage messages before wrapping in the Any message

### DIFF
--- a/Source/santactl/Commands/SNTCommandPrintLog.mm
+++ b/Source/santactl/Commands/SNTCommandPrintLog.mm
@@ -28,7 +28,8 @@
 
 using google::protobuf::util::JsonPrintOptions;
 using google::protobuf::util::MessageToJsonString;
-using santa::fsspool::binaryproto::LogBatch;
+// using santa::fsspool::binaryproto::LogBatch;
+using santa::pb::v1::LogBatch;
 namespace pbv1 = ::santa::pb::v1;
 
 @interface SNTCommandPrintLog : SNTCommand <SNTCommandProtocol>
@@ -88,36 +89,19 @@ REGISTER_COMMAND_NAME(@"printlog")
       continue;
     }
 
+    std::string json;
+    if (!MessageToJsonString(logBatch, &json, options).ok()) {
+      LOGE(@"Unable to convert message to JSON in file: '%@'", path);
+    }
+
     if (argIdx != 0) {
-      std::cout << ",";
+      std::cout << ",\n" << std::flush;
     } else {
       // Print the opening outer JSON array
       std::cout << "[";
     }
-    std::cout << "\n[\n";
 
-    int numRecords = logBatch.records_size();
-
-    for (int i = 0; i < numRecords; i++) {
-      const google::protobuf::Any &any = logBatch.records(i);
-      ::pbv1::SantaMessage santaMsg;
-      if (!any.UnpackTo(&santaMsg)) {
-        LOGE(@"Failed to unpack Any proto to SantaMessage in file '%@'", path);
-        break;
-      }
-
-      if (i != 0) {
-        std::cout << ",\n";
-      }
-
-      std::string json;
-      if (!MessageToJsonString(santaMsg, &json, options).ok()) {
-        LOGE(@"Unable to convert message to JSON in file: '%@'", path);
-      }
-      std::cout << json;
-    }
-
-    std::cout << "]" << std::flush;
+    std::cout << json;
 
     if (argIdx == ([arguments count] - 1)) {
       // Print the closing outer JSON array

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -411,6 +411,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTStoredEvent",
         "//Source/common:santa_cc_proto_library_wrapper",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -442,6 +443,7 @@ objc_library(
     srcs = ["Logs/EndpointSecurity/Writers/Spool.mm"],
     hdrs = ["Logs/EndpointSecurity/Writers/Spool.h"],
     deps = [
+        ":EndpointSecuritySerializerProtobuf",
         ":EndpointSecurityWriter",
         "//Source/common:SNTLogging",
         "//Source/common:santa_cc_proto_library_wrapper",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -841,6 +841,7 @@ santa_unit_test(
         "//Source/common:TestUtils",
         "//Source/common:santa_cc_proto_library_wrapper",
         "@OCMock",
+        "@com_google_absl//absl/synchronization",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -888,11 +889,16 @@ santa_unit_test(
 santa_unit_test(
     name = "EndpointSecurityWriterSpoolTest",
     srcs = ["Logs/EndpointSecurity/Writers/SpoolTest.mm"],
+    sdk_dylibs = [
+        "EndpointSecurity",
+    ],
     deps = [
+        ":EndpointSecuritySerializerProtobuf",
         ":EndpointSecurityWriterSpool",
         "//Source/common:TestUtils",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool_log_batch_writer",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -30,6 +30,8 @@ namespace santa::santad::logs::endpoint_security::serializers {
 
 class Protobuf : public Serializer {
  public:
+  using Serializer::SerializeMessage;
+
   static std::shared_ptr<Protobuf> Create(
     std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi);
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -26,6 +26,11 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 #include "absl/synchronization/mutex.h"
 
+// Forward declarations
+namespace santa::santad::logs::endpoint_security::serializers {
+class ProtobufPeer;
+}
+
 namespace santa::santad::logs::endpoint_security::serializers {
 
 class Protobuf : public Serializer {
@@ -64,7 +69,10 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeDiskAppeared(NSDictionary *) override;
   std::vector<uint8_t> SerializeDiskDisappeared(NSDictionary *) override;
 
-  bool Drain(std::string *output, size_t threshold);
+  virtual bool Drain(std::string *output, size_t threshold);
+
+  // Peer class for testing
+  friend class santa::santad::logs::endpoint_security::serializers::ProtobufPeer;
 
  private:
   ::santa::pb::v1::SantaMessage *CreateDefaultProto();

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
@@ -23,6 +23,7 @@
 #include <string_view>
 #include <vector>
 
+#include "Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_log_batch_writer.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
@@ -36,11 +37,14 @@ namespace santa::santad::logs::endpoint_security::writers {
 class Spool : public Writer, public std::enable_shared_from_this<Spool> {
  public:
   // Factory
-  static std::shared_ptr<Spool> Create(std::string_view base_dir, size_t max_spool_disk_size,
-                                       size_t max_spool_batch_size, uint64_t flush_timeout_ms);
+  static std::shared_ptr<Spool> Create(
+    std::shared_ptr<santa::santad::logs::endpoint_security::serializers::Protobuf> data_source,
+    std::string_view base_dir, size_t max_spool_disk_size, size_t spool_file_size_threshold,
+    size_t max_spool_batch_size, uint64_t flush_timeout_ms);
 
-  Spool(dispatch_queue_t q, dispatch_source_t timer_source, std::string_view base_dir,
-        size_t max_spool_disk_size, size_t max_spool_batch_size,
+  Spool(std::shared_ptr<santa::santad::logs::endpoint_security::serializers::Protobuf> data_source,
+        dispatch_queue_t q, dispatch_source_t timer_source, std::string_view base_dir,
+        size_t max_spool_disk_size, size_t spool_file_size_threshold, size_t max_spool_batch_size,
         void (^write_complete_f)(void) = nullptr, void (^flush_task_complete_f)(void) = nullptr);
 
   ~Spool();
@@ -48,17 +52,21 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   void Write(std::vector<uint8_t> &&bytes) override;
   bool Flush();
 
-  void BeginFlushTask();
+  void BeginPeriodicTask();
+  void WriteFromDataSource(size_t threshold);
 
   // Peer class for testing
   friend class santa::santad::logs::endpoint_security::writers::SpoolPeer;
 
  private:
+  std::shared_ptr<santa::santad::logs::endpoint_security::serializers::Protobuf> data_source_;
   dispatch_queue_t q_ = NULL;
   dispatch_source_t timer_source_ = NULL;
   ::fsspool::FsSpoolWriter spool_writer_;
   ::fsspool::FsSpoolLogBatchWriter log_batch_writer_;
   std::string type_url_;
+  const size_t spool_file_size_threshold_;
+  const size_t max_spool_batch_size_;
   bool flush_task_started_ = false;
   void (^write_complete_f_)(void);
   void (^flush_task_complete_f_)(void);

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
@@ -18,12 +18,16 @@
 #include "Source/common/santa_proto_include_wrapper.h"
 #include "absl/strings/string_view.h"
 
+using santa::santad::logs::endpoint_security::serializers::Protobuf;
+
 static const char *kTypeGoogleApisComPrefix = "type.googleapis.com/";
 
 namespace santa::santad::logs::endpoint_security::writers {
 
-std::shared_ptr<Spool> Spool::Create(std::string_view base_dir, size_t max_spool_disk_size,
-                                     size_t max_spool_batch_size, uint64_t flush_timeout_ms) {
+std::shared_ptr<Spool> Spool::Create(std::shared_ptr<Protobuf> data_source,
+                                     std::string_view base_dir, size_t max_spool_disk_size,
+                                     size_t spool_file_size_threshold, size_t max_spool_batch_size,
+                                     uint64_t flush_timeout_ms) {
   dispatch_queue_t q = dispatch_queue_create("com.google.santa.daemon.file_base_q",
                                              DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
   dispatch_source_t timer_source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
@@ -31,23 +35,29 @@ std::shared_ptr<Spool> Spool::Create(std::string_view base_dir, size_t max_spool
                             NSEC_PER_MSEC * flush_timeout_ms, 0);
 
   auto spool_writer =
-    std::make_shared<Spool>(q, timer_source, base_dir, max_spool_disk_size, max_spool_batch_size);
+    std::make_shared<Spool>(std::move(data_source), q, timer_source, base_dir, max_spool_disk_size,
+                            spool_file_size_threshold, max_spool_batch_size);
 
-  spool_writer->BeginFlushTask();
+  spool_writer->BeginPeriodicTask();
 
   return spool_writer;
 }
 
-Spool::Spool(dispatch_queue_t q, dispatch_source_t timer_source, std::string_view base_dir,
-             size_t max_spool_disk_size, size_t max_spool_batch_size,
+Spool::Spool(std::shared_ptr<Protobuf> data_source, dispatch_queue_t q,
+             dispatch_source_t timer_source, std::string_view base_dir, size_t max_spool_disk_size,
+             size_t spool_file_size_threshold, size_t max_spool_batch_size,
              void (^write_complete_f)(void), void (^flush_task_complete_f)(void))
-    : q_(q),
+    : data_source_(std::move(data_source)),
+      q_(q),
       timer_source_(timer_source),
       spool_writer_(absl::string_view(base_dir.data(), base_dir.length()), max_spool_disk_size),
       log_batch_writer_(&spool_writer_, max_spool_batch_size),
+      spool_file_size_threshold_(spool_file_size_threshold),
+      max_spool_batch_size_(max_spool_batch_size),
       write_complete_f_(write_complete_f),
       flush_task_complete_f_(flush_task_complete_f) {
-  type_url_ = kTypeGoogleApisComPrefix + ::santa::pb::v1::SantaMessage::descriptor()->full_name();
+  type_url_ =
+    kTypeGoogleApisComPrefix + ::santa::pb::v1::SantaMessageBatch::descriptor()->full_name();
 }
 
 Spool::~Spool() {
@@ -61,7 +71,29 @@ Spool::~Spool() {
   }
 }
 
-void Spool::BeginFlushTask() {
+// Note: Not thread safe. Calls should be gated by `q_`.
+void Spool::WriteFromDataSource(size_t threshold) {
+  std::string serialized_output;
+
+  bool result = data_source_->Drain(&serialized_output, threshold);
+
+  if (result) {
+    google::protobuf::Any any;
+    any.set_type_url(type_url_);
+#if SANTA_OPEN_SOURCE
+    any.set_value(serialized_output);
+#else
+    any.set_value(absl::string_view(serialized_output));
+#endif
+
+    auto status = log_batch_writer_.WriteMessage(any);
+    if (!status.ok()) {
+      LOGE(@"Logging from data source failed with: %s", status.ToString().c_str());
+    }
+  }
+}
+
+void Spool::BeginPeriodicTask() {
   if (flush_task_started_) {
     return;
   }
@@ -73,7 +105,11 @@ void Spool::BeginFlushTask() {
       return;
     }
 
-    if (!shared_writer->Flush()) {
+    shared_writer->WriteFromDataSource(0);
+
+    // Only flush if batch size is larger than 1, otherwise flushes
+    // happen on every write.
+    if (shared_writer->max_spool_batch_size_ > 1 && !shared_writer->Flush()) {
       LOGE(@"Spool writer: periodic flush failed.");
     }
 
@@ -90,31 +126,14 @@ bool Spool::Flush() {
   return log_batch_writer_.Flush().ok();
 }
 
-void Spool::Write(std::vector<uint8_t> &&bytes) {
+void Spool::Write([[maybe_unused]] std::vector<uint8_t> &&bytes) {
   auto shared_this = shared_from_this();
 
-  // Workaround to move `bytes` into the block without a copy
-  __block std::vector<uint8_t> temp_bytes = std::move(bytes);
-
   dispatch_async(q_, ^{
-    std::vector<uint8_t> moved_bytes = std::move(temp_bytes);
+    shared_this->WriteFromDataSource(spool_file_size_threshold_);
 
-    // Manually pack an `Any` with a pre-serialized SantaMessage
-    google::protobuf::Any any;
-#if SANTA_OPEN_SOURCE
-    any.set_value(moved_bytes.data(), moved_bytes.size());
-#else
-    any.set_value(absl::string_view((const char*)moved_bytes.data(), moved_bytes.size()));
-#endif
-    any.set_type_url(type_url_);
-
-    auto status = log_batch_writer_.WriteMessage(any);
-    if (!status.ok()) {
-      LOGE(@"ProtoEventLogger::LogProto failed with: %s", status.ToString().c_str());
-    }
-
-    if (write_complete_f_) {
-      write_complete_f_();
+    if (shared_this->write_complete_f_) {
+      shared_this->write_complete_f_();
     }
   });
 }

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
@@ -107,9 +107,7 @@ void Spool::BeginPeriodicTask() {
 
     shared_writer->WriteFromDataSource(0);
 
-    // Only flush if batch size is larger than 1, otherwise flushes
-    // happen on every write.
-    if (shared_writer->max_spool_batch_size_ > 1 && !shared_writer->Flush()) {
+    if (!shared_writer->Flush()) {
       LOGE(@"Spool writer: periodic flush failed.");
     }
 


### PR DESCRIPTION
The Any message type includes a `type_url` field that contains type information useful for unpacking. However this is duplicated for every message for `repeated` `Any` messages, causing unnecessary overhead.

This change introduces an intermediate type, `SantaMessageBatch` that contains a `repeated SantaMessage` field. Then this one field is wrapped in the `Any` message, amortizing the cost of the `type_url`.