### PR TITLE
Update spool to flush on size thresholds instead of batch counts

### DIFF
--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -214,7 +214,7 @@
 ///
 ///  If eventLogType is set to protobuf, spoolDirectoryFileSizeThresholdKB sets the per-file size
 ///  limit for files saved in the spoolDirectory.
-///  Defaults to 100.
+///  Defaults to 250.
 ///
 ///  @note: This property is KVO compliant, but should only be read once at santad startup.
 ///
@@ -232,7 +232,7 @@
 ///
 ///  If eventLogType is set to protobuf, spoolDirectoryEventMaxFlushTimeSec sets the maximum amount
 ///  of time an event will be stored in memory before being written to disk.
-///  Defaults to 10.0.
+///  Defaults to 15.0.
 ///
 ///  @note: This property is KVO compliant, but should only be read once at santad startup.
 ///

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -770,7 +770,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 - (NSUInteger)spoolDirectoryFileSizeThresholdKB {
   return self.configState[kSpoolDirectoryFileSizeThresholdKB]
            ? [self.configState[kSpoolDirectoryFileSizeThresholdKB] unsignedIntegerValue]
-           : 100;
+           : 250;
 }
 
 - (NSUInteger)spoolDirectorySizeThresholdMB {
@@ -782,7 +782,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 - (float)spoolDirectoryEventMaxFlushTimeSec {
   return self.configState[kSpoolDirectoryEventMaxFlushTimeSec]
            ? [self.configState[kSpoolDirectoryEventMaxFlushTimeSec] floatValue]
-           : 10.0;
+           : 15.0;
 }
 
 - (BOOL)enableMachineIDDecoration {

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
@@ -37,10 +37,10 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
  public:
   // Factory
   static std::shared_ptr<Spool> Create(std::string_view base_dir, size_t max_spool_disk_size,
-                                       size_t max_spool_batch_size, uint64_t flush_timeout_ms);
+                                       size_t max_spool_file_size, uint64_t flush_timeout_ms);
 
   Spool(dispatch_queue_t q, dispatch_source_t timer_source, std::string_view base_dir,
-        size_t max_spool_disk_size, size_t max_spool_batch_size,
+        size_t max_spool_disk_size, size_t max_spool_file_size,
         void (^write_complete_f)(void) = nullptr, void (^flush_task_complete_f)(void) = nullptr);
 
   ~Spool();
@@ -58,10 +58,13 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   dispatch_source_t timer_source_ = NULL;
   ::fsspool::FsSpoolWriter spool_writer_;
   ::fsspool::FsSpoolLogBatchWriter log_batch_writer_;
+  size_t spool_file_size_threshold_;
   std::string type_url_;
   bool flush_task_started_ = false;
   void (^write_complete_f_)(void);
   void (^flush_task_complete_f_)(void);
+
+  size_t accumulated_bytes_ = 0;
 };
 
 }  // namespace santa::santad::logs::endpoint_security::writers


### PR DESCRIPTION
Fixes an issue where the "file size" configuration option was instead treated as "batch count".