### PR TITLE
Watch items

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -50,6 +50,7 @@ santa_unit_test(
     deps = [
         ":WatchItems",
         "//Source/common:PrefixTree",
+        "//Source/common:TestUtils",
         "@OCMock",
     ],
 )
@@ -1202,6 +1203,7 @@ test_suite(
         ":SNTExecutionControllerTest",
         ":SNTRuleTableTest",
         ":SantadTest",
+        ":WatchItemsTest",
         "//Source/santad/Logs/EndpointSecurity/Writers/FSSpool:fsspool_test",
     ],
     visibility = ["//:santa_package_group"],

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -35,6 +35,26 @@ objc_library(
 )
 
 objc_library(
+    name = "WatchItems",
+    srcs = ["DataLayer/WatchItems.mm"],
+    hdrs = ["DataLayer/WatchItems.h"],
+    deps = [
+        "//Source/common:PrefixTree",
+        "//Source/common:SNTLogging",
+    ],
+)
+
+santa_unit_test(
+    name = "WatchItemsTest",
+    srcs = ["DataLayer/WatchItemsTest.mm"],
+    deps = [
+        ":WatchItems",
+        "//Source/common:PrefixTree",
+        "@OCMock",
+    ],
+)
+
+objc_library(
     name = "SNTEventTable",
     srcs = ["DataLayer/SNTEventTable.m"],
     hdrs = ["DataLayer/SNTEventTable.h"],

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -44,19 +44,19 @@ namespace santa::santad::data_layer {
 
 struct WatchItemPolicy {
   WatchItemPolicy(std::string_view n, std::string_view p, bool wo = false, bool ip = false,
-                  bool ao = true, std::vector<std::string> &&abp = {},
-                  std::vector<std::string> &&acs = {}, std::vector<std::string> &&ati = {},
-                  std::vector<std::string> &&ach = {});
+                  bool ao = true, std::set<std::string> &&abp = {},
+                  std::set<std::string> &&acs = {}, std::set<std::string> &&ati = {},
+                  std::set<std::string> &&ach = {});
 
   std::string name;
   std::string path;
   bool write_only;
   bool is_prefix;
   bool audit_only;
-  std::vector<std::string> allowed_binary_paths;
-  std::vector<std::string> allowed_certificates_sha256;
-  std::vector<std::string> allowed_team_ids;
-  std::vector<std::string> allowed_cdhashes;
+  std::set<std::string> allowed_binary_paths;
+  std::set<std::string> allowed_certificates_sha256;
+  std::set<std::string> allowed_team_ids;
+  std::set<std::string> allowed_cdhashes;
 };
 
 struct WatchItem {

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -1,0 +1,61 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA__SANTAD__DATALAYER_WATCHITEMS_H
+#define SANTA__SANTAD__DATALAYER_WATCHITEMS_H
+
+#import <Foundation/Foundation.h>
+#include <dispatch/dispatch.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Source/common/PrefixTree.h"
+
+namespace santa::santad::data_layer {
+struct WatchItem {
+  WatchItem(std::string n, std::string p, bool wo, bool ip, bool ao, std::vector<std::string> &&abp,
+            std::vector<std::string> &&acs, std::vector<std::string> &&ati,
+            std::vector<std::string> &&ach);
+  std::string name;
+  std::string path;
+  bool write_only;
+  bool is_prefix;
+  bool audit_only;
+  std::vector<std::string> allowed_binary_paths;
+  std::vector<std::string> allowed_certificates_sha256;
+  std::vector<std::string> allowed_team_ids;
+  std::vector<std::string> allowed_cdhashes;
+};
+
+class WatchItems : public std::enable_shared_from_this<WatchItems> {
+ public:
+  std::unique_ptr<WatchItems> Create(NSString *config_path, uint64_t reapply_config_frequency_secs);
+  WatchItems(NSString *config_path_, dispatch_source_t timer_source);
+
+  void BeginPeriodicTask();
+  void ReloadConfig();
+
+ private:
+  NSString *config_path_;
+  dispatch_source_t timer_source_;
+  santa::common::PrefixTree<std::shared_ptr<WatchItem>> watch_items_;
+  bool periodic_task_started_ = false;
+  NSDictionary *current_config_ = nil;
+};
+
+}  // namespace santa::santad::data_layer
+
+#endif

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -59,17 +59,6 @@ struct WatchItemPolicy {
   std::set<std::string> allowed_cdhashes;
 };
 
-struct WatchItem {
-  WatchItem(std::string p, bool ip);
-
-  std::string path;
-  bool is_prefix;
-
-  bool operator<(const WatchItem &wi) const;
-  bool operator==(const WatchItem &wi) const;
-  friend std::ostream &operator<<(std::ostream &os, const WatchItem &wi);
-};
-
 class WatchItems : public std::enable_shared_from_this<WatchItems> {
  public:
   using WatchItemsTree = santa::common::PrefixTree<std::shared_ptr<WatchItemPolicy>>;
@@ -90,17 +79,17 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
  private:
   void ReloadConfig(NSDictionary *new_config);
   bool SetCurrentConfig(std::unique_ptr<WatchItemsTree> new_tree,
-                        std::set<WatchItem> &&new_monitored_paths, NSDictionary *new_config);
+                        std::set<std::string> &&new_monitored_paths, NSDictionary *new_config);
   bool ParseConfig(NSDictionary *config, std::vector<std::shared_ptr<WatchItemPolicy>> &policies);
   bool BuildPolicyTree(const std::vector<std::shared_ptr<WatchItemPolicy>> &watch_items,
-                       WatchItemsTree &tree, std::set<WatchItem> &paths);
+                       WatchItemsTree &tree, std::set<std::string> &paths);
 
   NSString *config_path_;
   dispatch_source_t timer_source_;
   void (^periodic_task_complete_f_)(void);
   std::unique_ptr<WatchItemsTree> watch_items_;
   NSDictionary *current_config_;
-  std::set<WatchItem> currently_monitored_paths_;
+  std::set<std::string> currently_monitored_paths_;
   absl::Mutex lock_;
   bool periodic_task_started_ = false;
 };

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -77,7 +77,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   // Factory
   std::shared_ptr<WatchItems> Create(NSString *config_path, uint64_t reapply_config_frequency_secs);
 
-  WatchItems(NSString *config_path_, dispatch_source_t timer_source, void (^periodic_task_complete_f)(void) = nullptr);
+  WatchItems(NSString *config_path_, dispatch_source_t timer_source,
+             void (^periodic_task_complete_f)(void) = nullptr);
   ~WatchItems();
 
   void BeginPeriodicTask();

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -17,15 +17,20 @@
 #include <set>
 #include <utility>
 
-#ifdef __BLOCKS__
+// Note: Because this file is compiled with block support, there is a compiler
+// error including `<glob.h>`:
+//
+// error: call to implicitly-deleted default constructor of 'glob_t'
+//
+// This is because of the `glob_t` member field `gl_errblk` being an ObjC pointer.
+// Because we don't rely on the error function in this implementation,
+// we undef `__BLOCKS__` so that the `gl_errblk` type isn't added to
+// the union.
 #pragma push_macro("__BLOCKS__")
 #define REDEF_BLOCKS
 #undef __BLOCKS__
-#endif
 #include <glob.h>
-#ifdef REDEF_BLOCKS
 #pragma pop_macro("__BLOCKS__")
-#endif
 
 #include <memory>
 

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -119,7 +119,7 @@ std::vector<std::string> ConfigArrayToVector(NSArray *array) {
   return vec;
 }
 
-WatchItemPolicy::WatchItemPolicy(std::string n, std::string p, bool wo, bool ip, bool ao,
+WatchItemPolicy::WatchItemPolicy(std::string_view n, std::string_view p, bool wo, bool ip, bool ao,
                                  std::vector<std::string> &&abp, std::vector<std::string> &&acs,
                                  std::vector<std::string> &&ati, std::vector<std::string> &&ach)
     : name(n),
@@ -171,7 +171,9 @@ std::unique_ptr<WatchItems> WatchItems::Create(NSString *config_path,
 }
 
 WatchItems::WatchItems(NSString *config_path, dispatch_source_t timer_source)
-    : config_path_(config_path), timer_source_(timer_source) {}
+    : config_path_(config_path),
+      timer_source_(timer_source),
+      watch_items_(std::make_unique<WatchItemsTree>()) {}
 
 bool WatchItems::BuildPolicyTree(const std::vector<std::shared_ptr<WatchItemPolicy>> &watch_items,
                                  PrefixTree<std::shared_ptr<WatchItemPolicy>> &tree,

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -172,7 +172,7 @@ std::shared_ptr<WatchItems> WatchItems::Create(NSString *config_path,
   dispatch_source_set_timer(timer_source, dispatch_time(DISPATCH_TIME_NOW, 0),
                             NSEC_PER_SEC * reapply_config_frequency_secs, 0);
 
-  return std::make_unique<WatchItems>(config_path, timer_source);
+  return std::make_shared<WatchItems>(config_path, timer_source);
 }
 
 WatchItems::WatchItems(NSString *config_path, dispatch_source_t timer_source,

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -1,0 +1,198 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/DataLayer/WatchItems.h"
+
+#include <memory>
+
+#import "Source/common/SNTLogging.h"
+
+static const NSString *kWatchItemConfigKeyPath = @"Path";
+static const NSString *kWatchItemConfigKeyWriteOnly = @"WriteOnly";
+static const NSString *kWatchItemConfigKeyIsPrefix = @"IsPrefix";
+static const NSString *kWatchItemConfigKeyAuditOnly = @"AuditOnly";
+static const NSString *kWatchItemConfigKeyAllowedBinaryPaths = @"AllowedBinaryPaths";
+static const NSString *kWatchItemConfigKeyAllowedCertificatesSha256 = @"AllowedCertificatesSha256";
+static const NSString *kWatchItemConfigKeyAllowedTeamIDs = @"AllowedTeamIDs";
+static const NSString *kWatchItemConfigKeyAllowedCDHashes = @"AllowedCDHashes";
+
+namespace santa::santad::data_layer {
+
+// If the `key` exists in the `dict`, it must be of type `cls`.
+// Return true if either the key does not exist, or does exist and is the correct type.
+bool CheckType(const NSDictionary *dict, const NSString *key, Class cls) {
+  // If the key exists, it must be of the correct type
+  if (dict[key] && ![dict[key] isKindOfClass:cls]) {
+    LOGE(@"Unexpected type for watch item key '%@' (got: %@, want: %@)", key,
+         NSStringFromClass([dict[key] class]), NSStringFromClass(cls));
+
+    return false;
+  } else {
+    return true;
+  }
+}
+
+bool CheckTypeAll(const NSArray *array, const NSString *key, Class cls) {
+  for (id obj : array) {
+    if (![obj isKindOfClass:cls]) {
+      LOGE(@"Unexpected type for watch item key '%@' (got: %@, want: %@)", key,
+           NSStringFromClass([obj class]), NSStringFromClass(cls));
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool ConfirmValidWatchItemConfig(const NSDictionary *watch_item_dict) {
+  NSDictionary *configTypes = @{
+    kWatchItemConfigKeyPath : [NSString class],
+    kWatchItemConfigKeyWriteOnly : [NSNumber class],
+    kWatchItemConfigKeyIsPrefix : [NSNumber class],
+    kWatchItemConfigKeyAuditOnly : [NSNumber class],
+    kWatchItemConfigKeyAllowedBinaryPaths : [NSArray class],
+    kWatchItemConfigKeyAllowedCertificatesSha256 : [NSArray class],
+    kWatchItemConfigKeyAllowedTeamIDs : [NSArray class],
+    kWatchItemConfigKeyAllowedCDHashes : [NSArray class],
+  };
+
+  __block bool success = false;
+
+  // First ensure the required keys exist
+  if (!watch_item_dict[kWatchItemConfigKeyPath]) {
+    LOGE(@"Missing required key '%@' for watch item", kWatchItemConfigKeyPath);
+    return false;
+  }
+
+  // Ensure all keys are the expected types if they exist
+  [configTypes enumerateKeysAndObjectsUsingBlock:^(NSString *key, Class cls, BOOL *stop) {
+    success = CheckType(watch_item_dict, key, cls);
+
+    // For array types, make sure all the contained objects are strings
+    if (success && cls == [NSArray class]) {
+      success = CheckTypeAll(watch_item_dict[key], key, [NSString class]);
+    }
+
+    // Bail early if any of the checks failed
+    if (!success) {
+      *stop = YES;
+    }
+  }];
+
+  return success;
+}
+
+std::vector<std::string> ConfigArrayToVector(NSArray *array) {
+  std::vector<std::string> vec;
+  vec.reserve([array count]);
+
+  for (NSString *obj in array) {
+    vec.push_back(std::string([obj UTF8String]));
+  }
+  return vec;
+}
+
+WatchItem::WatchItem(std::string n, std::string p, bool wo, bool ip, bool ao,
+                     std::vector<std::string> &&abp, std::vector<std::string> &&acs,
+                     std::vector<std::string> &&ati, std::vector<std::string> &&ach)
+    : name(n),
+      path(p),
+      write_only(wo),
+      is_prefix(ip),
+      audit_only(ao),
+      allowed_binary_paths(std::move(abp)),
+      allowed_certificates_sha256(std::move(acs)),
+      allowed_team_ids(std::move(ati)),
+      allowed_cdhashes(std::move(ach)) {}
+
+std::unique_ptr<WatchItems> WatchItems::Create(NSString *config_path,
+                                               uint64_t reapply_config_frequency_secs) {
+  if (!config_path) {
+    return nullptr;
+  }
+
+  dispatch_queue_t q = dispatch_queue_create("com.google.santa.daemon.watch_items.q",
+                                             DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+  dispatch_source_t timer_source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
+  dispatch_source_set_timer(timer_source, dispatch_time(DISPATCH_TIME_NOW, 0),
+                            NSEC_PER_SEC * reapply_config_frequency_secs, 0);
+
+  return std::make_unique<WatchItems>(config_path, timer_source);
+}
+
+WatchItems::WatchItems(NSString *config_path, dispatch_source_t timer_source)
+    : config_path_(config_path), timer_source_(timer_source) {}
+
+void WatchItems::ReloadConfig() {
+  NSDictionary *new_config = [NSDictionary dictionaryWithContentsOfFile:config_path_];
+
+  if ([new_config isEqualToDictionary:current_config_]) {
+    // Config wasn't updated, nothing to do
+    return;
+  }
+
+  LOGI(@"File system monitoring config changed. Applying new settings.");
+
+  std::vector<std::shared_ptr<WatchItem>> new_watch_items;
+
+  for (id key in new_config) {
+    if (![key isKindOfClass:[NSString class]]) {
+      LOGE(@"In valid key %@ (class: %@), skipping", key, NSStringFromClass([key class]));
+      continue;
+    }
+
+    if (![new_config[key] isKindOfClass:[NSDictionary class]]) {
+      LOGE(@"Config for '%@' must be a dictionary (got: %@), skipping", key,
+           NSStringFromClass([new_config[key] class]));
+      continue;
+    }
+
+    NSDictionary *watch_item = new_config[key];
+
+    if (!ConfirmValidWatchItemConfig(watch_item)) {
+      LOGE(@"Invalid config for watch item: '%@', skipping", key);
+      continue;
+    }
+
+    new_watch_items.push_back(std::make_shared<WatchItem>(
+      [key UTF8String], [watch_item[kWatchItemConfigKeyPath] UTF8String],
+      [(watch_item[kWatchItemConfigKeyWriteOnly] ?: @(0)) boolValue],
+      [(watch_item[kWatchItemConfigKeyIsPrefix] ?: @(0)) boolValue],
+      [(watch_item[kWatchItemConfigKeyAuditOnly] ?: @(1)) boolValue],
+      ConfigArrayToVector(watch_item[kWatchItemConfigKeyAllowedBinaryPaths]),
+      ConfigArrayToVector(watch_item[kWatchItemConfigKeyAllowedCertificatesSha256]),
+      ConfigArrayToVector(watch_item[kWatchItemConfigKeyAllowedTeamIDs]),
+      ConfigArrayToVector(watch_item[kWatchItemConfigKeyAllowedCDHashes])));
+  }
+
+  current_config_ = new_config;
+}
+
+void WatchItems::BeginPeriodicTask() {
+  if (periodic_task_started_) {
+    return;
+  }
+
+  std::weak_ptr<WatchItems> weak_watcher = weak_from_this();
+  dispatch_source_set_event_handler(timer_source_, ^{
+    std::shared_ptr<WatchItems> shared_watcher = weak_watcher.lock();
+    if (!shared_watcher) {
+      return;
+    }
+
+    shared_watcher->ReloadConfig();
+  });
+}
+
+}  // namespace santa::santad::data_layer

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -199,13 +199,13 @@ bool WatchItems::ParseConfig(NSDictionary *config,
 
   for (id key in config) {
     if (![key isKindOfClass:[NSString class]]) {
-      LOGE(@"In valid key %@ (class: %@), skipping", key, NSStringFromClass([key class]));
+      LOGE(@"Invalid key %@ (class: %@)", key, NSStringFromClass([key class]));
       config_ok = false;
       break;
     }
 
     if (![config[key] isKindOfClass:[NSDictionary class]]) {
-      LOGE(@"Config for '%@' must be a dictionary (got: %@), skipping", key,
+      LOGE(@"Config for '%@' must be a dictionary (got: %@)", key,
            NSStringFromClass([config[key] class]));
       config_ok = false;
       break;
@@ -214,7 +214,7 @@ bool WatchItems::ParseConfig(NSDictionary *config,
     NSDictionary *watch_item = config[key];
 
     if (!ConfirmValidWatchItemConfig(watch_item)) {
-      LOGE(@"Invalid config for watch item: '%@', skipping", key);
+      LOGE(@"Invalid config for watch item: '%@'", key);
       config_ok = false;
       break;
     }

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -170,7 +170,8 @@ std::shared_ptr<WatchItems> WatchItems::Create(NSString *config_path,
   return std::make_unique<WatchItems>(config_path, timer_source);
 }
 
-WatchItems::WatchItems(NSString *config_path, dispatch_source_t timer_source, void (^periodic_task_complete_f)(void))
+WatchItems::WatchItems(NSString *config_path, dispatch_source_t timer_source,
+                       void (^periodic_task_complete_f)(void))
     : config_path_(config_path),
       timer_source_(timer_source),
       periodic_task_complete_f_(periodic_task_complete_f),

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -1,0 +1,31 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include "Source/santad/DataLayer/WatchItems.h"
+
+using santa::santad::data_layer::WatchItem;
+using santa::santad::data_layer::WatchItems;
+
+@interface WatchItemsTest : XCTestCase
+@end
+
+@implementation WatchItemsTest
+
+- (void)testBasic {
+}
+
+@end

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -45,14 +45,6 @@ class WatchItemsPeer : public WatchItems {
 
 using santa::santad::data_layer::WatchItemsPeer;
 
-template <typename T>
-void print(const T &v, std::string_view start = "", std::string_view end = "\n") {
-  std::cout << start << "{ ";
-  for (const auto &i : v)
-    std::cout << i << ' ';
-  std::cout << "} " << end;
-};
-
 static constexpr std::string_view kBadPolicyName("__BAD_NAME__");
 static constexpr std::string_view kBadPolicyPath("__BAD_PATH__");
 

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -29,7 +29,6 @@
 #include "Source/santad/DataLayer/WatchItems.h"
 
 using santa::common::PrefixTree;
-using santa::santad::data_layer::WatchItem;
 using santa::santad::data_layer::WatchItemPolicy;
 using santa::santad::data_layer::WatchItems;
 

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -14,18 +14,199 @@
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
+#include <dispatch/dispatch.h>
+#include <sys/syslimits.h>
+#include <unistd.h>
 
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <stack>
+#include <vector>
+
+#define SANTA_PREFIX_TREE_DEBUG 1
+#include "Source/common/PrefixTree.h"
 #include "Source/santad/DataLayer/WatchItems.h"
 
 using santa::santad::data_layer::WatchItem;
+using santa::santad::data_layer::WatchItemPolicy;
 using santa::santad::data_layer::WatchItems;
 
+namespace santa::santad::data_layer {
+
+class WatchItemsPeer : public WatchItems {
+ public:
+  using WatchItems::WatchItems;
+};
+
+}  // namespace santa::santad::data_layer
+
+using santa::santad::data_layer::WatchItemsPeer;
+
+void pushd(std::stack<std::string> &dirStack, std::string dir) {
+  char *buf = new char[PATH_MAX]();
+  getcwd(buf, PATH_MAX);
+
+  dirStack.push(buf);
+  delete[] buf;
+
+  chdir(dir.c_str());
+}
+
+void popd(std::stack<std::string> &dirStack) {
+  chdir(dirStack.top().c_str());
+  dirStack.pop();
+}
+
+auto print = [](const auto &v, std::string_view start = "", std::string_view end = "") {
+  std::cout << start << "{ ";
+  for (const auto &i : v)
+    std::cout << i << ' ';
+  std::cout << "} " << end;
+};
+
 @interface WatchItemsTest : XCTestCase
+@property NSFileManager *fileMgr;
+@property NSString *testDir;
+@property dispatch_queue_t q;
 @end
 
 @implementation WatchItemsTest
 
+- (void)setUp {
+  self.fileMgr = [NSFileManager defaultManager];
+  self.testDir =
+    [NSString stringWithFormat:@"%@santa-watchitems-%d", NSTemporaryDirectory(), getpid()];
+
+  XCTAssertTrue([self.fileMgr createDirectoryAtPath:self.testDir
+                        withIntermediateDirectories:YES
+                                         attributes:nil
+                                              error:nil]);
+
+  self.q = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
+  XCTAssertNotNil(self.q);
+}
+
+- (void)tearDown {
+  XCTAssertTrue([self.fileMgr removeItemAtPath:self.testDir error:nil]);
+}
+
+- (void)createDirStructure:(NSArray *)fs rootedAt:(NSString *)root {
+  char *buf = new char[PATH_MAX]();
+  getcwd(buf, PATH_MAX);
+  chdir([root UTF8String]);
+
+  for (id item in fs) {
+    if ([item isKindOfClass:[NSString class]]) {
+      XCTAssertTrue([self.fileMgr createFileAtPath:item contents:nil attributes:nil]);
+    } else if ([item isKindOfClass:[NSDictionary class]]) {
+      for (id dir in item) {
+        XCTAssertTrue([item[dir] isKindOfClass:[NSArray class]]);
+        XCTAssertTrue([self.fileMgr createDirectoryAtPath:dir
+                              withIntermediateDirectories:NO
+                                               attributes:nil
+                                                    error:nil]);
+
+        [self createDirStructure:item[dir] rootedAt:dir];
+      }
+    } else {
+      XCTFail("Unexpected dir structure item: %@: %@", item, [item class]);
+    }
+  }
+
+  chdir(buf);
+  delete[] buf;
+}
+
+- (NSString *)createTestDirPath:(NSString *)path withRoot:(NSString *)root {
+  return [NSString pathWithComponents:@[ self.testDir, root, path ]];
+}
+
+- (NSString *)createTestDirPath:(NSString *)path {
+  return [NSString pathWithComponents:@[ self.testDir, path ]];
+}
+
 - (void)testBasic {
+  NSArray *fs = @[
+    @{
+      @"a" : @[
+        @{
+          @"d1" : @[
+            @"f1",
+            @"f2",
+            @{
+              @"d1_nested" : @[],
+            },
+          ],
+          @"d2" : @[
+            @"f1",
+          ]
+        },
+        @"f1",
+        @"f2",
+      ],
+    },
+    @{
+      @"b" : @[
+        @{
+          @"d1" : @[
+            @"f1",
+            @"f2",
+          ],
+          @"d2" : @[
+            @"f1",
+          ]
+        },
+        @"f1",
+      ],
+    }
+  ];
+  fs = @[ @{
+    @"a" : @[ @"f1", @"f2" ],
+    @"b" : @[ @"f1", @"f2" ],
+  } ];
+
+  [self createDirStructure:fs rootedAt:self.testDir];
+
+  std::stack<std::string> dirStack;
+  WatchItemsPeer watchItems(@"config.plist", NULL);
+
+  std::vector<std::shared_ptr<WatchItemPolicy>> configuredWatchItems1;
+  std::vector<std::shared_ptr<WatchItemPolicy>> configuredWatchItems2;
+
+  santa::common::PrefixTree<std::shared_ptr<WatchItemPolicy>> tree1;
+  santa::common::PrefixTree<std::shared_ptr<WatchItemPolicy>> tree2;
+
+  std::set<WatchItem> paths1;
+  std::set<WatchItem> paths2;
+
+  // Add initial set of items as "prefix" types
+  configuredWatchItems1.push_back(std::make_shared<WatchItemPolicy>("wi2", "./*", false, true));
+
+  pushd(dirStack, [[self createTestDirPath:@"a"] UTF8String]);
+  watchItems.BuildPolicyTree(configuredWatchItems1, tree1, paths1);
+  popd(dirStack);
+
+  printf("First Generate...\n");
+  tree1.Print();
+
+  // Re-apply policy as "literal" types
+  configuredWatchItems2.push_back(std::make_shared<WatchItemPolicy>("wi2", "./*"));
+
+  pushd(dirStack, [[self createTestDirPath:@"b"] UTF8String]);
+  watchItems.BuildPolicyTree(configuredWatchItems2, tree2, paths2);
+  popd(dirStack);
+
+  printf("Second Generate...\n");
+  tree2.Print();
+
+  std::set<WatchItem> removed_items;
+  std::set_difference(paths1.begin(), paths1.end(), paths2.begin(), paths2.end(),
+                      std::inserter(removed_items, removed_items.begin()));
+
+  print(paths1, "paths1: ", "\n");
+  print(paths2, "paths2: ", "\n");
+  print(removed_items, "Diff: ", "\n");
 }
 
 @end

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -242,7 +242,7 @@ static std::shared_ptr<WatchItemPolicy> MakeBadPolicy() {
 }
 
 - (void)testPolicyLookup {
-  // Test multiple, more comprehensive poolicies before/after config reload
+  // Test multiple, more comprehensive policies before/after config reload
   [self createTestDirStructure:@[
     @{
       @"foo" : @[ @"bar.txt", @"bar.txt.tmp" ],


### PR DESCRIPTION
This PR is another step on the way to upcoming monitoring features. It adds the following:

1. `WatchItems` - An object that loads the watch configuration and maintains the prefix tree of the configuration and the overall set of watched paths. The tree nodes contain `shared_ptr`s to `WatchItemPolicy` objects.
2. `WatchItemPolicy` - Contains the information described in the configuration file

This functionality is not yet integrated into the rest of Santa and is not exercised outside of the tests.