### PR TITLE
Change SantaCache to wrap std::unordered_map

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -34,16 +34,19 @@ cc_library(
 cc_library(
     name = "SantaCache",
     hdrs = ["SantaCache.h"],
-    deps = ["//Source/common:SNTCommon"],
+    deps = [
+        "//Source/common:SNTCommon",
+        "@com_google_absl//absl/synchronization",
+    ],
 )
 
 santa_unit_test(
     name = "SantaCacheTest",
-    srcs = [
-        "SantaCache.h",
-        "SantaCacheTest.mm",
+    srcs = ["SantaCacheTest.mm"],
+    deps = [
+        ":SantaCache",
+        "//Source/common:SNTCommon",
     ],
-    deps = ["//Source/common:SNTCommon"],
 )
 
 objc_library(

--- a/Source/common/SantaCache.h
+++ b/Source/common/SantaCache.h
@@ -47,8 +47,7 @@ class SantaCache {
     @param maximum_size The maximum number of entries in this cache. Once this
         number is reached all the entries will be purged.
   */
-  SantaCache(uint64_t maximum_size = 10000)
-      : max_size_(maximum_size) {}
+  SantaCache(uint64_t maximum_size = 10000) : max_size_(maximum_size) {}
 
   /**
     Clear and free memory
@@ -130,9 +129,7 @@ class SantaCache {
 
  private:
   ABSL_SHARED_LOCKS_REQUIRED(lock_)
-  uint64_t CountLocked() const {
-    return cache_.size();
-  }
+  uint64_t CountLocked() const { return cache_.size(); }
 
   ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_)
   void ClearLocked() { cache_.clear(); }
@@ -156,8 +153,8 @@ class SantaCache {
     @return true if the entry was set, false if it was not
   */
   ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_)
-  bool SetLocked(const KeyT &key, const ValueT &value, const ValueT &previous_value,
-           bool has_prev_value) {
+  bool SetLocked(const KeyT &key, const ValueT &value,
+                 const ValueT &previous_value, bool has_prev_value) {
     const auto iter = cache_.find(key);
 
     if (has_prev_value) {

--- a/Source/common/SantaCache.h
+++ b/Source/common/SantaCache.h
@@ -53,12 +53,12 @@ class SantaCache {
   /**
     Clear and free memory
   */
-  ~SantaCache() { clear(); }
+  ~SantaCache() { Clear(); }
 
   /**
     Get an element from the cache. Returns zero_ if item doesn't exist.
   */
-  ValueT get(KeyT key) {
+  ValueT Get(KeyT key) {
     absl::ReaderMutexLock lock(&lock_);
 
     const auto iter = cache_.find(key);
@@ -80,7 +80,7 @@ class SantaCache {
 
     @return true if the value was set.
   */
-  bool set(const KeyT &key, const ValueT &value) {
+  bool Set(const KeyT &key, const ValueT &value) {
     absl::MutexLock lock(&lock_);
     return SetLocked(key, value, {}, false);
   }
@@ -99,7 +99,7 @@ class SantaCache {
 
     @return true if the value was set
   */
-  bool set(const KeyT &key, const ValueT &value, const ValueT &previous_value) {
+  bool Set(const KeyT &key, const ValueT &value, const ValueT &previous_value) {
     absl::MutexLock lock(&lock_);
     return SetLocked(key, value, previous_value, true);
   }
@@ -107,7 +107,7 @@ class SantaCache {
   /**
     Remove a key from the cache
   */
-  inline void remove(const KeyT &key) {
+  inline void Remove(const KeyT &key) {
     absl::MutexLock lock(&lock_);
     RemoveLocked(key);
   }
@@ -115,7 +115,7 @@ class SantaCache {
   /**
     Remove all entries
   */
-  void clear() {
+  void Clear() {
     absl::MutexLock lock(&lock_);
     ClearLocked();
   }
@@ -123,7 +123,7 @@ class SantaCache {
   /**
     Return number of entries currently in cache.
   */
-  uint64_t count() const {
+  uint64_t Count() const {
     absl::ReaderMutexLock lock(&lock_);
     return CountLocked();
   }

--- a/Source/common/SantaCacheTest.mm
+++ b/Source/common/SantaCacheTest.mm
@@ -32,31 +32,31 @@
 - (void)testSetAndGet {
   auto sut = SantaCache<uint64_t, uint64_t>();
 
-  sut.set(72057611258548992llu, 10000192);
-  XCTAssertEqual(sut.get(72057611258548992llu), 10000192);
+  sut.Set(72057611258548992llu, 10000192);
+  XCTAssertEqual(sut.Get(72057611258548992llu), 10000192);
 }
 
 - (void)testCacheRemove {
   auto sut = SantaCache<uint64_t, uint64_t>();
 
-  sut.set(0xDEADBEEF, 42);
-  sut.remove(0xDEADBEEF);
+  sut.Set(0xDEADBEEF, 42);
+  sut.Remove(0xDEADBEEF);
 
-  XCTAssertEqual(sut.get(0xDEADBEEF), 0);
+  XCTAssertEqual(sut.Get(0xDEADBEEF), 0);
 }
 
 - (void)testCacheResetAtLimit {
   auto sut = SantaCache<uint64_t, uint64_t>(5);
 
-  sut.set(1, 42);
-  sut.set(2, 42);
-  sut.set(3, 42);
-  sut.set(4, 42);
-  sut.set(5, 42);
-  XCTAssertEqual(sut.get(3), 42);
-  sut.set(6, 42);
-  XCTAssertEqual(sut.get(3), 0);
-  XCTAssertEqual(sut.get(6), 42);
+  sut.Set(1, 42);
+  sut.Set(2, 42);
+  sut.Set(3, 42);
+  sut.Set(4, 42);
+  sut.Set(5, 42);
+  XCTAssertEqual(sut.Get(3), 42);
+  sut.Set(6, 42);
+  XCTAssertEqual(sut.Get(3), 0);
+  XCTAssertEqual(sut.Get(6), 42);
 }
 
 - (void)testThreading {
@@ -68,14 +68,14 @@
     dispatch_group_enter(group);
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
       for (int i = 0; i < 5000; ++i)
-        sut->set(i, 10000 - i);
+        sut->Set(i, 10000 - i);
       dispatch_group_leave(group);
     });
 
     dispatch_group_enter(group);
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
       for (int i = 5000; i < 10000; ++i)
-        sut->set(i, 10000 - i);
+        sut->Set(i, 10000 - i);
       dispatch_group_leave(group);
     });
 
@@ -84,7 +84,7 @@
     }
 
     for (int i = 0; i < 10000; ++i)
-      XCTAssertEqual(sut->get(i), 10000 - i);
+      XCTAssertEqual(sut->Get(i), 10000 - i);
   }
 
   delete sut;
@@ -93,31 +93,31 @@
 - (void)testCount {
   auto sut = SantaCache<uint64_t, int>();
 
-  XCTAssertEqual(sut.count(), 0);
+  XCTAssertEqual(sut.Count(), 0);
 
-  sut.set(4012, 42);
-  sut.set(42, 0);
-  sut.set(0x8BADF00D, 40010);
+  sut.Set(4012, 42);
+  sut.Set(42, 0);
+  sut.Set(0x8BADF00D, 40010);
 
-  XCTAssertEqual(sut.count(), 2);
+  XCTAssertEqual(sut.Count(), 2);
 }
 
 - (void)testDoubles {
   auto sut = SantaCache<double, double>();
 
-  sut.set(3.14, 2.718281);
-  sut.set(1.41429, 2.5029);
-  sut.set(4.6692, 1.2020569);
-  sut.set(1.61803398, 0.57721);
+  sut.Set(3.14, 2.718281);
+  sut.Set(1.41429, 2.5029);
+  sut.Set(4.6692, 1.2020569);
+  sut.Set(1.61803398, 0.57721);
 
-  XCTAssertEqual(sut.count(), 4);
-  XCTAssertEqual(sut.get(3.14), 2.718281);
-  XCTAssertEqual(sut.get(1.41429), 2.5029);
-  XCTAssertEqual(sut.get(4.6692), 1.2020569);
-  XCTAssertEqual(sut.get(1.61803398), 0.57721);
+  XCTAssertEqual(sut.Count(), 4);
+  XCTAssertEqual(sut.Get(3.14), 2.718281);
+  XCTAssertEqual(sut.Get(1.41429), 2.5029);
+  XCTAssertEqual(sut.Get(4.6692), 1.2020569);
+  XCTAssertEqual(sut.Get(1.61803398), 0.57721);
 
-  XCTAssertEqual(sut.get(5.5555), 0);
-  XCTAssertEqual(sut.get(3.1459124), 0);
+  XCTAssertEqual(sut.Get(5.5555), 0);
+  XCTAssertEqual(sut.Get(3.1459124), 0);
 }
 
 - (void)testStrings {
@@ -126,39 +126,39 @@
   std::string s1 = "foo";
   std::string s2 = "bar";
 
-  sut.set(s1, "deadbeef");
-  sut.set(s2, "feedface");
+  sut.Set(s1, "deadbeef");
+  sut.Set(s2, "feedface");
 
-  XCTAssertEqual(sut.count(), 2);
-  XCTAssertEqual(sut.get(s1), "deadbeef");
-  XCTAssertEqual(sut.get(s2), "feedface");
+  XCTAssertEqual(sut.Count(), 2);
+  XCTAssertEqual(sut.Get(s1), "deadbeef");
+  XCTAssertEqual(sut.Get(s2), "feedface");
 
-  sut.remove(s2);
+  sut.Remove(s2);
 
-  XCTAssertTrue(sut.get(s2).empty());
+  XCTAssertTrue(sut.Get(s2).empty());
 }
 
 - (void)testCompareAndSwap {
   auto sut = SantaCache<uint64_t, uint64_t>(100);
 
-  sut.set(1, 42);
-  sut.set(1, 666, 1);
-  sut.set(1, 666, 0);
-  XCTAssertEqual(sut.get(1), 42);
+  sut.Set(1, 42);
+  sut.Set(1, 666, 1);
+  sut.Set(1, 666, 0);
+  XCTAssertEqual(sut.Get(1), 42);
 
-  sut.set(1, 0);
-  XCTAssertEqual(sut.get(1), 0);
+  sut.Set(1, 0);
+  XCTAssertEqual(sut.Get(1), 0);
 
-  sut.set(1, 42, 1);
-  XCTAssertEqual(sut.get(1), 0);
+  sut.Set(1, 42, 1);
+  XCTAssertEqual(sut.Get(1), 0);
 
-  sut.set(1, 42, 0);
-  XCTAssertEqual(sut.get(1), 42);
+  sut.Set(1, 42, 0);
+  XCTAssertEqual(sut.Get(1), 42);
 
-  sut.set(1, 0, 666);
-  XCTAssertEqual(sut.get(1), 42);
-  sut.set(1, 0, 42);
-  XCTAssertEqual(sut.get(1), 0);
+  sut.Set(1, 0, 666);
+  XCTAssertEqual(sut.Get(1), 42);
+  sut.Set(1, 0, 42);
+  XCTAssertEqual(sut.Get(1), 0);
 }
 
 struct S {
@@ -183,13 +183,13 @@ struct std::hash<S> {
   S s1 = {1024, 2048};
   S s2 = {4096, 8192};
   S s3 = {16384, 32768};
-  sut.set(s1, 10);
-  sut.set(s2, 20);
-  sut.set(s3, 30);
+  sut.Set(s1, 10);
+  sut.Set(s2, 20);
+  sut.Set(s3, 30);
 
-  XCTAssertEqual(sut.get(s1), 10);
-  XCTAssertEqual(sut.get(s2), 20);
-  XCTAssertEqual(sut.get(s3), 30);
+  XCTAssertEqual(sut.Get(s1), 10);
+  XCTAssertEqual(sut.Get(s2), 20);
+  XCTAssertEqual(sut.Get(s3), 30);
 }
 
 @end

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -85,11 +85,11 @@ bool AuthResultCache::AddToCache(const es_file_t *es_file, santa_action_t decisi
   SantaCache<santa_vnode_id_t, uint64_t> *cache = CacheForVnodeID(vnode_id);
   switch (decision) {
     case ACTION_REQUEST_BINARY:
-      return cache->set(vnode_id, CacheableAction(ACTION_REQUEST_BINARY, 0), 0);
+      return cache->Set(vnode_id, CacheableAction(ACTION_REQUEST_BINARY, 0), 0);
     case ACTION_RESPOND_ALLOW: OS_FALLTHROUGH;
     case ACTION_RESPOND_ALLOW_COMPILER: OS_FALLTHROUGH;
     case ACTION_RESPOND_DENY:
-      return cache->set(vnode_id, CacheableAction(decision),
+      return cache->Set(vnode_id, CacheableAction(decision),
                         CacheableAction(ACTION_REQUEST_BINARY, 0));
     default:
       // This is a programming error. Bail.
@@ -100,7 +100,7 @@ bool AuthResultCache::AddToCache(const es_file_t *es_file, santa_action_t decisi
 
 void AuthResultCache::RemoveFromCache(const es_file_t *es_file) {
   santa_vnode_id_t vnode_id = VnodeForFile(es_file);
-  CacheForVnodeID(vnode_id)->remove(vnode_id);
+  CacheForVnodeID(vnode_id)->Remove(vnode_id);
 }
 
 santa_action_t AuthResultCache::CheckCache(const es_file_t *es_file) {
@@ -110,7 +110,7 @@ santa_action_t AuthResultCache::CheckCache(const es_file_t *es_file) {
 santa_action_t AuthResultCache::CheckCache(santa_vnode_id_t vnode_id) {
   SantaCache<santa_vnode_id_t, uint64_t> *cache = CacheForVnodeID(vnode_id);
 
-  uint64_t cached_val = cache->get(vnode_id);
+  uint64_t cached_val = cache->Get(vnode_id);
   if (cached_val == 0) {
     return ACTION_UNSET;
   }
@@ -120,7 +120,7 @@ santa_action_t AuthResultCache::CheckCache(santa_vnode_id_t vnode_id) {
   if (result == ACTION_RESPOND_DENY) {
     uint64_t expiry_time = TimestampFromCachedValue(cached_val) + cache_deny_time_ns_;
     if (expiry_time < GetCurrentUptime()) {
-      cache->remove(vnode_id);
+      cache->Remove(vnode_id);
       return ACTION_UNSET;
     }
   }
@@ -134,9 +134,9 @@ SantaCache<santa_vnode_id_t, uint64_t> *AuthResultCache::CacheForVnodeID(
 }
 
 void AuthResultCache::FlushCache(FlushCacheMode mode) {
-  nonroot_cache_->clear();
+  nonroot_cache_->Clear();
   if (mode == FlushCacheMode::kAllCaches) {
-    root_cache_->clear();
+    root_cache_->Clear();
 
     // Clear the ES cache when all local caches are flushed. Assume the ES cache
     // doesn't need to be cleared when only flushing the non-root cache.
@@ -152,7 +152,7 @@ void AuthResultCache::FlushCache(FlushCacheMode mode) {
 }
 
 NSArray<NSNumber *> *AuthResultCache::CacheCounts() {
-  return @[ @(root_cache_->count()), @(nonroot_cache_->count()) ];
+  return @[ @(root_cache_->Count()), @(nonroot_cache_->Count()) ];
 }
 
 }  // namespace santa::santad::event_providers

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -25,9 +25,11 @@ using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 
 template <>
-uint64_t SantaCacheHasher<santa_vnode_id_t>(santa_vnode_id_t const &t) {
-  return (SantaCacheHasher<uint64_t>(t.fsid) << 1) ^ SantaCacheHasher<uint64_t>(t.fileid);
-}
+struct std::hash<santa_vnode_id_t> {
+  std::size_t operator()(santa_vnode_id_t const &vnode) const noexcept {
+    return (std::hash<uint64_t>{}(vnode.fsid) << 1) ^ std::hash<uint64_t>{}(vnode.fileid);
+  }
+};
 
 namespace santa::santad::event_providers {
 

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -97,7 +97,7 @@ EnrichedFile Enricher::Enrich(const es_file_t &es_file) {
 }
 
 std::optional<std::shared_ptr<std::string>> Enricher::UsernameForUID(uid_t uid) {
-  std::optional<std::shared_ptr<std::string>> username = username_cache_.get(uid);
+  std::optional<std::shared_ptr<std::string>> username = username_cache_.Get(uid);
 
   if (username.has_value()) {
     return username;
@@ -109,14 +109,14 @@ std::optional<std::shared_ptr<std::string>> Enricher::UsernameForUID(uid_t uid) 
       username = std::nullopt;
     }
 
-    username_cache_.set(uid, username);
+    username_cache_.Set(uid, username);
 
     return username;
   }
 }
 
 std::optional<std::shared_ptr<std::string>> Enricher::UsernameForGID(gid_t gid) {
-  std::optional<std::shared_ptr<std::string>> groupname = groupname_cache_.get(gid);
+  std::optional<std::shared_ptr<std::string>> groupname = groupname_cache_.Get(gid);
 
   if (groupname.has_value()) {
     return groupname;
@@ -128,7 +128,7 @@ std::optional<std::shared_ptr<std::string>> Enricher::UsernameForGID(gid_t gid) 
       groupname = std::nullopt;
     }
 
-    groupname_cache_.set(gid, groupname);
+    groupname_cache_.Set(gid, groupname);
 
     return groupname;
   }


### PR DESCRIPTION
Removes the custom map implementation that was previously used in the kernel. This now wraps an `std::unordered_map`. Also moved to using a R/W lock.