### PR TITLE
Drop macOS 10.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
      - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -85,7 +85,7 @@ macos_application(
         "//conditions:default": None,
     }),
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/gui/main.m
+++ b/Source/gui/main.m
@@ -62,28 +62,24 @@ int main(int argc, const char *argv[]) {
       sysxOperation = @(2);
     }
     if (sysxOperation) {
-      if (@available(macOS 10.15, *)) {
-        NSString *e = [SNTXPCControlInterface systemExtensionID];
-        dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-        OSSystemExtensionRequest *req;
-        if (sysxOperation.intValue == 1) {
-          NSLog(@"Requesting SystemExtension activation");
-          req = [OSSystemExtensionRequest activationRequestForExtension:e queue:q];
-        } else if (sysxOperation.intValue == 2) {
-          NSLog(@"Requesting SystemExtension deactivation");
-          req = [OSSystemExtensionRequest deactivationRequestForExtension:e queue:q];
-        }
-        if (req) {
-          SNTSystemExtensionDelegate *ed = [[SNTSystemExtensionDelegate alloc] init];
-          req.delegate = ed;
-          [[OSSystemExtensionManager sharedManager] submitRequest:req];
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 60), q, ^{
-            exit(1);
-          });
-          [[NSRunLoop mainRunLoop] run];
-        }
-      } else {
-        exit(1);
+      NSString *e = [SNTXPCControlInterface systemExtensionID];
+      dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+      OSSystemExtensionRequest *req;
+      if (sysxOperation.intValue == 1) {
+        NSLog(@"Requesting SystemExtension activation");
+        req = [OSSystemExtensionRequest activationRequestForExtension:e queue:q];
+      } else if (sysxOperation.intValue == 2) {
+        NSLog(@"Requesting SystemExtension deactivation");
+        req = [OSSystemExtensionRequest deactivationRequestForExtension:e queue:q];
+      }
+      if (req) {
+        SNTSystemExtensionDelegate *ed = [[SNTSystemExtensionDelegate alloc] init];
+        req.delegate = ed;
+        [[OSSystemExtensionManager sharedManager] submitRequest:req];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 60), q, ^{
+          exit(1);
+        });
+        [[NSRunLoop mainRunLoop] run];
       }
     }
 

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -34,7 +34,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -91,7 +91,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -649,7 +649,7 @@ macos_bundle(
     }),
     infoplists = ["Info.plist"],
     linkopts = ["-execute"],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:daemon_dev",
@@ -728,7 +728,7 @@ santa_unit_test(
     data = [
         "//Source/santad/testdata:binaryrules_testdata",
     ],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     sdk_dylibs = [
         "bsm",
         "EndpointSecurity",
@@ -758,7 +758,7 @@ santa_unit_test(
     srcs = [
         "SNTApplicationCoreMetricsTest.m",
     ],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     deps = [
         ":SNTApplicationCoreMetrics",
         "//Source/common:SNTCommonEnums",

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
@@ -33,8 +33,8 @@ class EndpointSecurityAPI : public std::enable_shared_from_this<EndpointSecurity
 
   virtual bool Subscribe(const Client &client, const std::set<es_event_type_t> &);
 
-  virtual es_message_t *RetainMessage(const es_message_t *msg);
-  virtual void ReleaseMessage(es_message_t *msg);
+  virtual void RetainMessage(const es_message_t *msg);
+  virtual void ReleaseMessage(const es_message_t *msg);
 
   virtual bool RespondAuthResult(const Client &client, const Message &msg, es_auth_result_t result,
                                  bool cache);

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -33,28 +33,12 @@ Client EndpointSecurityAPI::NewClient(void (^message_handler)(es_client_t *, Mes
   return Client(client, res);
 }
 
-es_message_t *EndpointSecurityAPI::RetainMessage(const es_message_t *msg) {
-  if (@available(macOS 11.0, *)) {
-    es_retain_message(msg);
-    es_message_t *nonconst = const_cast<es_message_t *>(msg);
-    return nonconst;
-  } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return es_copy_message(msg);
-#pragma clang diagnostic pop
-  }
+void EndpointSecurityAPI::RetainMessage(const es_message_t *msg) {
+  es_retain_message(msg);
 }
 
-void EndpointSecurityAPI::ReleaseMessage(es_message_t *msg) {
-  if (@available(macOS 11.0, *)) {
-    es_release_message(msg);
-  } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return es_free_message(msg);
-#pragma clang diagnostic pop
-  }
+void EndpointSecurityAPI::ReleaseMessage(const es_message_t *msg) {
+  es_release_message(msg);
 }
 
 bool EndpointSecurityAPI::Subscribe(const Client &client,

--- a/Source/santad/EventProviders/EndpointSecurity/Message.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.h
@@ -34,8 +34,6 @@ class Message {
   // Note: Safe to implement this, just not currently needed so left deleted.
   Message& operator=(Message&& rhs) = delete;
 
-  // In macOS 10.15, es_retain_message/es_release_message were unsupported
-  // and required a full copy, which impacts performance if done too much...
   Message(const Message& other);
   Message& operator=(const Message& other) = delete;
 
@@ -47,7 +45,7 @@ class Message {
 
  private:
   std::shared_ptr<EndpointSecurityAPI> esapi_;
-  es_message_t* es_msg_;
+  const es_message_t* es_msg_;
 
   mutable std::string pname_;
   mutable std::string parent_pname_;

--- a/Source/santad/EventProviders/EndpointSecurity/Message.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.mm
@@ -22,8 +22,8 @@
 namespace santa::santad::event_providers::endpoint_security {
 
 Message::Message(std::shared_ptr<EndpointSecurityAPI> esapi, const es_message_t *es_msg)
-    : esapi_(esapi) {
-  es_msg_ = esapi_->RetainMessage(es_msg);
+    : esapi_(esapi), es_msg_(es_msg) {
+  esapi_->RetainMessage(es_msg);
 }
 
 Message::~Message() {

--- a/Source/santad/EventProviders/EndpointSecurity/MessageTest.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/MessageTest.mm
@@ -65,7 +65,7 @@ pid_t AttemptToFindUnusedPID() {
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXIT, &proc);
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   // Constructing a `Message` retains the underlying `es_message_t` and it is
   // released when the `Message` object is destructed.
@@ -83,8 +83,7 @@ pid_t AttemptToFindUnusedPID() {
   EXPECT_CALL(*mockESApi, ReleaseMessage(testing::_))
     .Times(2)
     .After(EXPECT_CALL(*mockESApi, RetainMessage(testing::_))
-             .Times(2)
-             .WillRepeatedly(testing::Return(&esMsg)));
+             .Times(2));
 
   {
     Message msg1(mockESApi, &esMsg);
@@ -106,7 +105,7 @@ pid_t AttemptToFindUnusedPID() {
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXIT, &proc);
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   // Search for an *existing* parent process.
   {

--- a/Source/santad/EventProviders/EndpointSecurity/MessageTest.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/MessageTest.mm
@@ -82,8 +82,7 @@ pid_t AttemptToFindUnusedPID() {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   EXPECT_CALL(*mockESApi, ReleaseMessage(testing::_))
     .Times(2)
-    .After(EXPECT_CALL(*mockESApi, RetainMessage(testing::_))
-             .Times(2));
+    .After(EXPECT_CALL(*mockESApi, RetainMessage(testing::_)).Times(2));
 
   {
     Message msg1(mockESApi, &esMsg);

--- a/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
@@ -40,7 +40,7 @@ class MockEndpointSecurityAPI
                const std::set<es_event_type_t> &));
 
   MOCK_METHOD(void, RetainMessage, (const es_message_t *msg));
-  MOCK_METHOD(void, ReleaseMessage, (const es_message_t * msg));
+  MOCK_METHOD(void, ReleaseMessage, (const es_message_t *msg));
 
   MOCK_METHOD(bool, RespondAuthResult,
               (const santa::santad::event_providers::endpoint_security::Client &,

--- a/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
@@ -39,8 +39,8 @@ class MockEndpointSecurityAPI
               (const santa::santad::event_providers::endpoint_security::Client &,
                const std::set<es_event_type_t> &));
 
-  MOCK_METHOD(es_message_t *, RetainMessage, (const es_message_t *msg));
-  MOCK_METHOD(void, ReleaseMessage, (es_message_t * msg));
+  MOCK_METHOD(void, RetainMessage, (const es_message_t *msg));
+  MOCK_METHOD(void, ReleaseMessage, (const es_message_t * msg));
 
   MOCK_METHOD(bool, RespondAuthResult,
               (const santa::santad::event_providers::endpoint_security::Client &,
@@ -72,9 +72,9 @@ class MockEndpointSecurityAPI
     EXPECT_CALL(*this, Subscribe).WillRepeatedly(testing::Return(true));
   }
 
-  void SetExpectationsRetainReleaseMessage(es_message_t *msg) {
+  void SetExpectationsRetainReleaseMessage() {
     EXPECT_CALL(*this, ReleaseMessage).Times(testing::AnyNumber());
-    EXPECT_CALL(*this, RetainMessage).WillRepeatedly(testing::Return(msg));
+    EXPECT_CALL(*this, RetainMessage).Times(testing::AnyNumber());
   }
 };
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -90,7 +90,7 @@ class MockAuthResultCache : public AuthResultCache {
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   // There is a benign leak of the mock object in this test.
   // `handleMessage:recordEventMetrics:` will call `processMessage:handler:` in the parent
@@ -186,7 +186,7 @@ class MockAuthResultCache : public AuthResultCache {
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
   EXPECT_CALL(*mockAuthCache, CheckCache)
@@ -253,7 +253,7 @@ class MockAuthResultCache : public AuthResultCache {
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
   EXPECT_CALL(*mockAuthCache, AddToCache(&execFile, ACTION_RESPOND_ALLOW_COMPILER))

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -224,7 +224,6 @@ using santa::santad::event_providers::endpoint_security::Message;
   // the event will be denied).
 
   // Workaround for compiler bug that doesn't properly close over variables
-  // Note: On macOS 10.15 this will cause extra message copies.
   __block Message processMsg = msg;
   __block Message deadlineMsg = msg;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -104,7 +104,7 @@ using santa::santad::event_providers::endpoint_security::Message;
   es_message_t esMsg;
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   SNTEndpointSecurityClient *client =
     [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
@@ -122,7 +122,7 @@ using santa::santad::event_providers::endpoint_security::Message;
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_FORK, &proc);
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   // Have subscribe fail the first time, meaning clear cache only called once.
   EXPECT_CALL(*mockESApi, RespondAuthResult(testing::_, testing::_, ES_AUTH_RESULT_ALLOW, true))
@@ -247,7 +247,7 @@ using santa::santad::event_providers::endpoint_security::Message;
 - (void)testRespondToMessageWithAuthResultCacheable {
   es_message_t esMsg;
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   es_auth_result_t result = ES_AUTH_RESULT_DENY;
   bool cacheable = true;
@@ -270,21 +270,17 @@ using santa::santad::event_providers::endpoint_security::Message;
 }
 
 - (void)testProcessEnrichedMessageHandler {
+  es_message_t esMsg;
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
 
-  // Note: In this test, `RetainMessage` isn't setup to return anything. This
-  // means that the underlying `es_msg_` in the `Message` object is NULL, and
-  // therefore no call to `ReleaseMessage` is ever made (hence no expectations).
-  // Because we don't need to operate on the es_msg_, this simplifies the test.
-  EXPECT_CALL(*mockESApi, RetainMessage);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   SNTEndpointSecurityClient *client =
     [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
                                              metrics:nullptr
                                            processor:Processor::kUnknown];
 
-  es_message_t esMsg;
   auto enrichedMsg = std::make_shared<EnrichedMessage>(
     EnrichedClose(Message(mockESApi, &esMsg),
                   EnrichedProcess(std::nullopt, std::nullopt, std::nullopt, std::nullopt,
@@ -316,7 +312,7 @@ using santa::santad::event_providers::endpoint_security::Message;
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_EXIT, &proc);
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   SNTEndpointSecurityClient *client =
     [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
@@ -345,7 +341,7 @@ using santa::santad::event_providers::endpoint_security::Message;
                                      45 * 1000);  // Long deadline to not hit
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
@@ -386,7 +382,7 @@ using santa::santad::event_providers::endpoint_security::Message;
                                      750);  // 750ms timeout
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   dispatch_semaphore_t deadlineSema = dispatch_semaphore_create(0);
   dispatch_semaphore_t controlSema = dispatch_semaphore_create(0);

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -124,8 +124,6 @@ class MockAuthResultCache : public AuthResultCache {
   es_file_t file = MakeESFile("foo");
   es_process_t proc = MakeESProcess(&file);
   es_message_t esMsg = MakeESMessage(eventType, &proc, ActionType::Auth, 6000);
-  // Need a pointer to esMsg to capture in blocks below.
-  es_message_t *heapESMsg = &esMsg;
 
   dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
 
@@ -142,7 +140,6 @@ class MockAuthResultCache : public AuthResultCache {
   });
   EXPECT_CALL(*mockESApi, RetainMessage).WillRepeatedly(^{
     retainCount++;
-    return heapESMsg;
   });
 
   if (eventType == ES_EVENT_TYPE_AUTH_MOUNT) {
@@ -317,7 +314,7 @@ class MockAuthResultCache : public AuthResultCache {
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
   EXPECT_CALL(*mockAuthCache, FlushCache);

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -98,7 +98,7 @@ class MockLogger : public Logger {
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   std::shared_ptr<EnrichedMessage> enrichedMsg = std::shared_ptr<EnrichedMessage>(nullptr);
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -100,7 +100,7 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsESNewClient();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   SNTEndpointSecurityTamperResistance *tamperClient =
     [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:mockESApi

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -128,11 +128,7 @@ class MockWriter : public Null {
   // Ensure all Logger::Log* methods call the serializer followed by the writer
   es_message_t msg;
 
-  // Note: In this test, `RetainMessage` isn't setup to return anything. This
-  // means that the underlying `es_msg_` in the `Message` object is NULL, and
-  // therefore no call to `ReleaseMessage` is ever made (hence no expectations).
-  // Because we don't need to operate on the es_msg_, this simplifies the test.
-  EXPECT_CALL(*mockESApi, RetainMessage);
+  mockESApi->SetExpectationsRetainReleaseMessage();
   auto enrichedMsg = std::make_shared<EnrichedMessage>(
     EnrichedClose(Message(mockESApi, &msg),
                   EnrichedProcess(std::nullopt, std::nullopt, std::nullopt, std::nullopt,
@@ -156,7 +152,7 @@ class MockWriter : public Null {
   es_message_t msg;
   std::string_view hash = "this_is_my_test_hash";
 
-  EXPECT_CALL(*mockESApi, RetainMessage);
+  mockESApi->SetExpectationsRetainReleaseMessage();
   EXPECT_CALL(*mockSerializer, SerializeAllowlist(testing::_, hash));
   EXPECT_CALL(*mockWriter, Write);
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -53,7 +53,7 @@ using santa::santad::logs::endpoint_security::serializers::GetReasonString;
 
 std::string BasicStringSerializeMessage(std::shared_ptr<MockEndpointSecurityAPI> mockESApi,
                                         es_message_t *esMsg) {
-  mockESApi->SetExpectationsRetainReleaseMessage(esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   std::shared_ptr<Serializer> bs = BasicString::Create(mockESApi, false);
   std::vector<uint8_t> ret = bs->SerializeMessage(Enricher().Enrich(Message(mockESApi, esMsg)));
@@ -253,7 +253,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   esMsg.event.close.target = &file;
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   std::vector<uint8_t> ret = BasicString::Create(mockESApi, false)
                                ->SerializeAllowlist(Message(mockESApi, &esMsg), "test_hash");

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -195,7 +195,7 @@ void SerializeAndCheck(es_event_type_t eventType,
     esMsg.process->tty = &ttyFile;
     esMsg.version = cur_version;
 
-    mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+    mockESApi->SetExpectationsRetainReleaseMessage();
 
     messageSetup(mockESApi, &esMsg);
 
@@ -509,7 +509,7 @@ void SerializeAndCheck(es_event_type_t eventType,
     esMsg.event.close.modified = true;
     esMsg.event.close.target = &closeFile;
 
-    mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+    mockESApi->SetExpectationsRetainReleaseMessage();
 
     std::shared_ptr<Serializer> bs = Protobuf::Create(mockESApi);
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
@@ -38,7 +38,7 @@ using santa::santad::logs::endpoint_security::serializers::Utilities::GetAllowLi
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_CLOSE, &proc);
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   {
     esMsg.event.close.target = &closeTargetFile;

--- a/Source/santad/SNTCompilerControllerTest.mm
+++ b/Source/santad/SNTCompilerControllerTest.mm
@@ -160,7 +160,7 @@ static const pid_t PID_MAX = 99999;
   es_message_t esMsg;
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   SNTCompilerController *cc = [[SNTCompilerController alloc] init];
 

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -132,7 +132,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(santa_action_t wantAct
   esMsg.event.exec.target = &procExec;
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   // Undo the default mocks
   self.mockDecisionCache = OCMStrictClassMock([SNTDecisionCache class]);
@@ -199,7 +199,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(santa_action_t wantAct
   esMsg.event.exec.target = &procExec;
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
-  mockESApi->SetExpectationsRetainReleaseMessage(&esMsg);
+  mockESApi->SetExpectationsRetainReleaseMessage();
 
   {
     Message msg(mockESApi, &esMsg);

--- a/Source/santad/SantadTest.mm
+++ b/Source/santad/SantadTest.mm
@@ -109,8 +109,6 @@ NSString *testBinariesPath = @"santa/Source/santad/testdata/binaryrules";
   // deadline block to run and release the message.
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, &proc, ActionType::Auth, 6500);
   esMsg.event.exec.target = &proc;
-  // Need a pointer to esMsg to capture in blocks below.
-  es_message_t *heapESMsg = &esMsg;
 
   // The test must wait for the ES client async message processing to complete.
   // Otherwise, the `es_message_t` stack variable will go out of scope and will
@@ -131,7 +129,6 @@ NSString *testBinariesPath = @"santa/Source/santad/testdata/binaryrules";
   });
   EXPECT_CALL(*mockESApi, RetainMessage).WillRepeatedly(^{
     retainCount++;
-    return heapESMsg;
   });
 
   [authClient handleMessage:Message(mockESApi, &esMsg)

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -65,7 +65,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/santametricservice/Writers/SNTMetricFileWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricFileWriter.m
@@ -59,12 +59,8 @@
 
       [entryData appendBytes:newline length:1];
 
-      if (@available(macos 10.15, *)) {
-        if (![file writeData:entryData error:error]) {
-          return NO;
-        }
-      } else {
-        [file writeData:entryData];
+      if (![file writeData:entryData error:error]) {
+        return NO;
       }
     }
   }

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -169,7 +169,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Testing/integration/BUILD
+++ b/Testing/integration/BUILD
@@ -12,7 +12,7 @@ santa_unit_test(
     data = [
         "//Source/santad/testdata:binaryrules_testdata",
     ],
-    minimum_os_version = "10.15",
+    minimum_os_version = "11.0",
     deps = [],
 )
 

--- a/helper.bzl
+++ b/helper.bzl
@@ -22,7 +22,7 @@ def santa_unit_test(
         srcs = [],
         deps = [],
         size = "medium",
-        minimum_os_version = "10.15",
+        minimum_os_version = "11.0",
         resources = [],
         structured_resources = [],
         copts = [],


### PR DESCRIPTION
Removing support for macOS 10.15 now that it is no longer supported by Apple.

Note: Dependent upon https://github.com/google/santa/pull/939 to fix broken test.