### PR TITLE
Dynamically enable/disable FS Access client based on config

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -39,6 +39,7 @@ objc_library(
     srcs = ["DataLayer/WatchItems.mm"],
     hdrs = ["DataLayer/WatchItems.h"],
     deps = [
+        ":SNTEndpointSecurityEventHandler",
         "//Source/common:PrefixTree",
         "//Source/common:SNTLogging",
     ],

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "Source/common/PrefixTree.h"
+#import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 
 extern const NSString *kWatchItemConfigKeyPath;
 extern const NSString *kWatchItemConfigKeyWriteOnly;
@@ -78,6 +79,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   void BeginPeriodicTask();
 
+  void RegisterClient(id<SNTEndpointSecurityDynamicEventHandler> client);
+
   void SetConfigPath(NSString *config_path);
   std::optional<std::shared_ptr<WatchItemPolicy>> FindPolicyForPath(const char *input);
   std::string PolicyVersion();
@@ -103,6 +106,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   absl::Mutex lock_;
   bool periodic_task_started_ = false;
   std::string policy_version_;
+  std::set<id<SNTEndpointSecurityDynamicEventHandler>> registerd_clients_;
 };
 
 }  // namespace santa::santad::data_layer

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -78,12 +78,15 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   void BeginPeriodicTask();
 
+  void SetConfigPath(NSString *config_path);
   std::optional<std::shared_ptr<WatchItemPolicy>> FindPolicyForPath(const char *input);
   std::string PolicyVersion();
 
   friend class santa::santad::data_layer::WatchItemsPeer;
 
  private:
+  NSDictionary *ReadConfig();
+  ABSL_SHARED_LOCKS_REQUIRED(lock_) NSDictionary *ReadConfigLocked();
   void ReloadConfig(NSDictionary *new_config);
   bool SetCurrentConfig(std::unique_ptr<WatchItemsTree> new_tree,
                         std::set<std::string> &&new_monitored_paths, NSDictionary *new_config);

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -331,7 +331,6 @@ void WatchItems::UpdateCurrentState(
       (current_config_ == nil && new_config != nil) ||
       (currently_monitored_paths_ != new_monitored_paths) ||
       (new_config && ![current_config_ isEqualToDictionary:new_config])) {
-
     // TODO(mlw): In upcoming PR, need to use ES API to stop watching removed paths,
     // and start watching newly configured paths.
 

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -41,6 +41,11 @@ const NSString *kWatchItemConfigKeyAllowedCertificatesSha256 = @"AllowedCertific
 const NSString *kWatchItemConfigKeyAllowedTeamIDs = @"AllowedTeamIDs";
 const NSString *kWatchItemConfigKeyAllowedCDHashes = @"AllowedCDHashes";
 
+// Semi-arbitrary minimum allowed reapplication frequency.
+// Goal is to prevent a configuration setting that would cause too much
+// churn rebuilding glob paths based on the state of the filesystem.
+static const uint64_t kMinReapplyConfigFrequencySecs = 15;
+
 namespace santa::santad::data_layer {
 
 // If the `key` exists in the `dict`, it must be of type `cls`.
@@ -197,13 +202,9 @@ WatchItemPolicy::WatchItemPolicy(std::string_view n, std::string_view p, bool wo
 
 std::shared_ptr<WatchItems> WatchItems::Create(NSString *config_path,
                                                uint64_t reapply_config_frequency_secs) {
-  if (!config_path) {
-    LOGW(@"Watch item config not provided");
-    return nullptr;
-  }
-
-  if (reapply_config_frequency_secs < 1) {
-    LOGW(@"Invalid watch item update interval provided (0)");
+  if (reapply_config_frequency_secs < kMinReapplyConfigFrequencySecs) {
+    LOGW(@"Invalid watch item update interval provided: %llu. Min allowed: %llu",
+         reapply_config_frequency_secs, kMinReapplyConfigFrequencySecs);
     return nullptr;
   }
 
@@ -213,12 +214,13 @@ std::shared_ptr<WatchItems> WatchItems::Create(NSString *config_path,
   dispatch_source_set_timer(timer_source, dispatch_time(DISPATCH_TIME_NOW, 0),
                             NSEC_PER_SEC * reapply_config_frequency_secs, 0);
 
-  return std::make_shared<WatchItems>(config_path, timer_source);
+  return std::make_shared<WatchItems>(config_path, q, timer_source);
 }
 
-WatchItems::WatchItems(NSString *config_path, dispatch_source_t timer_source,
+WatchItems::WatchItems(NSString *config_path, dispatch_queue_t q, dispatch_source_t timer_source,
                        void (^periodic_task_complete_f)(void))
     : config_path_(config_path),
+      q_(q),
       timer_source_(timer_source),
       periodic_task_complete_f_(periodic_task_complete_f),
       watch_items_(std::make_unique<WatchItemsTree>()) {}
@@ -315,55 +317,70 @@ bool WatchItems::ParseConfig(NSDictionary *config,
   return config_ok;
 }
 
-bool WatchItems::SetCurrentConfig(
+void WatchItems::UpdateCurrentState(
   std::unique_ptr<PrefixTree<std::shared_ptr<WatchItemPolicy>>> new_tree,
   std::set<std::string> &&new_monitored_paths, NSDictionary *new_config) {
   absl::MutexLock lock(&lock_);
 
-  // TODO(mlw): In upcoming PR, need to use ES API to stop watching removed paths,
-  // and start watching newly configured paths.
+  // The following conditions require updating the current config:
+  // 1. The current config doesn't exist but the new one does
+  // 2. The current config exists but the new one doesn't
+  // 3. The set of monitored paths changed
+  // 4. The configuration changed
+  if ((current_config_ != nil && new_config == nil) ||
+      (current_config_ == nil && new_config != nil) ||
+      (currently_monitored_paths_ != new_monitored_paths) ||
+      (new_config && ![current_config_ isEqualToDictionary:new_config])) {
 
-  std::swap(watch_items_, new_tree);
-  std::swap(currently_monitored_paths_, new_monitored_paths);
-  current_config_ = new_config;
-  policy_version_ = [new_config[kWatchItemConfigKeyVersion] UTF8String];
+    // TODO(mlw): In upcoming PR, need to use ES API to stop watching removed paths,
+    // and start watching newly configured paths.
 
-  for (const id<SNTEndpointSecurityDynamicEventHandler> &client : registerd_clients_) {
-    if (currently_monitored_paths_.size() > 0) {
-      [client enable];
+    std::swap(watch_items_, new_tree);
+    std::swap(currently_monitored_paths_, new_monitored_paths);
+    current_config_ = new_config;
+    if (new_config) {
+      policy_version_ = [new_config[kWatchItemConfigKeyVersion] UTF8String];
     } else {
-      [client disable];
+      policy_version_ = "";
     }
-  }
 
-  return true;
+    bool anyPathsMonitored = currently_monitored_paths_.size() > 0;
+    for (const id<SNTEndpointSecurityDynamicEventHandler> &client : registerd_clients_) {
+      // Note: Enable clients on an async queue in case they perform any
+      // synchronous work that could trigger ES events. Otherwise they might
+      // trigger AUTH ES events that would attempt to re-enter this object and
+      // potentially deadlock.
+      dispatch_async(q_, ^{
+        if (anyPathsMonitored) {
+          [client enable];
+        } else {
+          [client disable];
+        }
+      });
+    }
+  } else {
+    LOGD(@"No changes to set of watched paths.");
+  }
 }
 
 void WatchItems::ReloadConfig(NSDictionary *new_config) {
   std::vector<std::shared_ptr<WatchItemPolicy>> new_policies;
-
-  if (!ParseConfig(new_config, new_policies)) {
-    LOGE(@"Failed to apply new filesystem monitoring config");
-    return;
-  }
-
   auto new_tree = std::make_unique<PrefixTree<std::shared_ptr<WatchItemPolicy>>>();
   std::set<std::string> new_monitored_paths;
 
-  if (!BuildPolicyTree(new_policies, *new_tree, new_monitored_paths)) {
-    LOGE(@"Failed to build new filesystem monitoring policy");
-    return;
+  if (new_config) {
+    if (!ParseConfig(new_config, new_policies)) {
+      LOGE(@"Failed to apply new filesystem monitoring config");
+      return;
+    }
+
+    if (!BuildPolicyTree(new_policies, *new_tree, new_monitored_paths)) {
+      LOGE(@"Failed to build new filesystem monitoring policy");
+      return;
+    }
   }
 
-  if (new_monitored_paths == currently_monitored_paths_ &&
-      [current_config_ isEqualToDictionary:new_config]) {
-    LOGD(@"No changes to set of watched paths.");
-    return;
-  }
-
-  LOGD(@"Updating set of configured watch paths");
-
-  SetCurrentConfig(std::move(new_tree), std::move(new_monitored_paths), new_config);
+  UpdateCurrentState(std::move(new_tree), std::move(new_monitored_paths), new_config);
 }
 
 NSDictionary *WatchItems::ReadConfig() {

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -154,7 +154,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   // Changes in config dictionary will update policy info even if the
   // filesystem didn't change.
   {
-    WatchItemsPeer watchItems(nil, NULL);
+    WatchItemsPeer watchItems(nil, NULL, NULL);
     [self pushd:@"a"];
     watchItems.ReloadConfig(configAllFilesOriginal);
 
@@ -172,7 +172,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 
   // Changes to fileystem structure are reflected when a config is reloaded
   {
-    WatchItemsPeer watchItems(nil, NULL);
+    WatchItemsPeer watchItems(nil, NULL, NULL);
     [self pushd:@"a"];
     watchItems.ReloadConfig(configAllFilesOriginal);
     [self popd];
@@ -217,7 +217,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
                             NSEC_PER_MSEC * periodicFlushMS, 0);
 
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-  auto watchItems = std::make_shared<WatchItemsPeer>(configFile, timer, ^{
+  auto watchItems = std::make_shared<WatchItemsPeer>(configFile, self.q, timer, ^{
     dispatch_semaphore_signal(sema);
   });
 
@@ -266,7 +266,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     }
   });
 
-  WatchItemsPeer watchItems(nil, NULL);
+  WatchItemsPeer watchItems(nil, NULL, NULL);
 
   // Initially nothing should be in the map
   XCTAssertFalse(watchItems.FindPolicyForPath("./foo").has_value());
@@ -374,7 +374,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 - (void)testPolicyVersion {
   NSMutableDictionary *config = WrapWatchItemsConfig(@{});
 
-  WatchItemsPeer watchItems(nil, NULL);
+  WatchItemsPeer watchItems(nil, NULL, NULL);
   watchItems.ReloadConfig(config);
 
   XCTAssertCStringEqual(watchItems.PolicyVersion().c_str(), kVersion.data());

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
@@ -32,6 +32,7 @@ class EndpointSecurityAPI : public std::enable_shared_from_this<EndpointSecurity
   virtual Client NewClient(void (^message_handler)(es_client_t *, Message));
 
   virtual bool Subscribe(const Client &client, const std::set<es_event_type_t> &);
+  virtual bool UnsubscribeAll(const Client &client);
 
   virtual void RetainMessage(const es_message_t *msg);
   virtual void ReleaseMessage(const es_message_t *msg);

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -47,6 +47,10 @@ bool EndpointSecurityAPI::Subscribe(const Client &client,
   return es_subscribe(client.Get(), subs.data(), (uint32_t)subs.size()) == ES_RETURN_SUCCESS;
 }
 
+bool EndpointSecurityAPI::UnsubscribeAll(const Client &client) {
+  return es_unsubscribe_all(client.Get()) == ES_RETURN_SUCCESS;
+}
+
 bool EndpointSecurityAPI::RespondAuthResult(const Client &client, const Message &msg,
                                             es_auth_result_t result, bool cache) {
   return es_respond_auth_result(client.Get(), &(*msg), result, cache) == ES_RESPOND_RESULT_SUCCESS;

--- a/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
@@ -38,6 +38,7 @@ class MockEndpointSecurityAPI
   MOCK_METHOD(bool, Subscribe,
               (const santa::santad::event_providers::endpoint_security::Client &,
                const std::set<es_event_type_t> &));
+  MOCK_METHOD(bool, UnsubscribeAll, (const Client &client));
 
   MOCK_METHOD(void, RetainMessage, (const es_message_t *msg));
   MOCK_METHOD(void, ReleaseMessage, (const es_message_t *msg));

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -181,6 +181,10 @@ using santa::santad::event_providers::endpoint_security::Message;
   return [self subscribe:events] && [self clearCache];
 }
 
+- (bool)unsubscribeAll {
+  return _esApi->UnsubscribeAll(_esClient);
+}
+
 - (bool)respondToMessage:(const Message &)msg
           withAuthResult:(es_auth_result_t)result
                cacheable:(bool)cacheable {

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -46,6 +46,8 @@
 /// subscribing mitigates this posibility.
 - (bool)subscribeAndClearCache:(const std::set<es_event_type_t> &)events;
 
+- (bool)unsubscribeAll;
+
 /// Responds to the Message with the given auth result
 ///
 /// @param Message The wrapped es_message_t being responded to

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -30,3 +30,13 @@
 - (void)enable;
 
 @end
+
+// Extension of the `SNTEndpointSecurityEventHandler` protocol for
+// `SNTEndpointSecurityClient` subclasses that can be dynamically
+// enabled and disabled.
+@protocol SNTEndpointSecurityDynamicEventHandler <SNTEndpointSecurityEventHandler>
+
+// Called when a client should no longer receive events.
+- (void)disable;
+
+@end

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -33,7 +33,7 @@ enum class FileAccessPolicyDecision {
 };
 
 @interface SNTEndpointSecurityFileAccessAuthorizer
-    : SNTEndpointSecurityClient <SNTEndpointSecurityEventHandler>
+    : SNTEndpointSecurityClient <SNTEndpointSecurityDynamicEventHandler>
 
 - (instancetype)
   initWithESAPI:

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -357,4 +357,8 @@ PathTargets GetPathTargets(const Message &msg) {
   [super subscribeAndClearCache:{ES_EVENT_TYPE_AUTH_OPEN}];
 }
 
+- (void)disable {
+  [super unsubscribeAll];
+}
+
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -157,8 +157,6 @@ PathTargets GetPathTargets(const Message &msg) {
     _decisionCache = decisionCache;
 
     [self establishClientOrDie];
-
-    _watchItems->RegisterClient(self);
   }
   return self;
 }

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -157,6 +157,8 @@ PathTargets GetPathTargets(const Message &msg) {
     _decisionCache = decisionCache;
 
     [self establishClientOrDie];
+
+    _watchItems->RegisterClient(self);
   }
   return self;
 }

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -429,6 +429,24 @@ extern es_auth_result_t CombinePolicyResults(es_auth_result_t result1, es_auth_r
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
 
+- (void)testDisable {
+  auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
+  mockESApi->SetExpectationsESNewClient();
+
+  SNTEndpointSecurityFileAccessAuthorizer *accessClient =
+    [[SNTEndpointSecurityFileAccessAuthorizer alloc] initWithESAPI:mockESApi
+                                                           metrics:nullptr
+                                                            logger:nullptr
+                                                        watchItems:nullptr
+                                                     decisionCache:nil];
+
+  EXPECT_CALL(*mockESApi, UnsubscribeAll);
+
+  [accessClient disable];
+
+  XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
+}
+
 - (void)testGetPathTargets {
   // This test ensures that the `GetPathTargets` functions returns the
   // expected combination of targets for each handled event variant

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -288,6 +288,17 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                         [newValue componentsJoinedByString:@","]);
                                    device_client.remountArgs = newValue;
                                  }],
+    [[SNTKVOManager alloc]
+      initWithObject:configurator
+            selector:@selector(filesystemMonitoringPolicyPlistPath)
+                type:[NSString class]
+            callback:^(NSString *oldValue, NSString *newValue) {
+              if (oldValue != newValue || ![oldValue isEqualToString:newValue]) {
+                LOGI(@"Filesystem monitoring policy config path changed: %@ -> %@", oldValue,
+                     newValue);
+                watch_items->SetConfigPath(newValue);
+              }
+            }],
   ];
 
   // Make the compiler happy. The variable is only used to ensure proper lifetime

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -133,6 +133,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                                             logger:logger
                                                         watchItems:watch_items
                                                      decisionCache:[SNTDecisionCache sharedCache]];
+  watch_items->RegisterClient(access_authorizer_client);
 
   EstablishSyncServiceConnection(syncd_queue);
 
@@ -311,8 +312,8 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
   // execution policy appropriately.
   [authorizer_client enable];
   [tamper_client enable];
-  // [access_authorizer_client enable];
-  (void)access_authorizer_client;  // NOTE: For now, not enabling
+  // Start monitoring any watched items
+  watch_items->BeginPeriodicTask();
   [monitor_client enable];
   [device_client enable];
 

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -294,7 +294,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
             selector:@selector(filesystemMonitoringPolicyPlistPath)
                 type:[NSString class]
             callback:^(NSString *oldValue, NSString *newValue) {
-              if (oldValue != newValue || ![oldValue isEqualToString:newValue]) {
+              if (oldValue != newValue || (newValue && ![oldValue isEqualToString:newValue])) {
                 LOGI(@"Filesystem monitoring policy config path changed: %@ -> %@", oldValue,
                      newValue);
                 watch_items->SetConfigPath(newValue);

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -120,6 +120,10 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
   std::shared_ptr<::WatchItems> watch_items =
     WatchItems::Create([configurator filesystemMonitoringPolicyPlistPath],
                        [configurator filesystemMonitoringPolicyUpdateIntervalSec]);
+  if (!watch_items) {
+    LOGE(@"Failed to create watch items");
+    exit(EXIT_FAILURE);
+  }
 
   std::shared_ptr<::Metrics> metrics =
     Metrics::Create(metric_set, [configurator metricExportInterval]);

--- a/Source/santad/SantadTest.mm
+++ b/Source/santad/SantadTest.mm
@@ -68,6 +68,7 @@ NSString *testBinariesPath = @"santa/Source/santad/testdata/binaryrules";
   // Ensure the mode is set.
   OCMStub([mockConfigurator clientMode]).andReturn(clientMode);
   OCMStub([mockConfigurator failClosed]).andReturn(NO);
+  OCMStub([mockConfigurator filesystemMonitoringPolicyUpdateIntervalSec]).andReturn(600);
 
   NSString *baseTestPath = @"santa/Source/santad/testdata/binaryrules";
   NSString *testPath = [NSString pathWithComponents:@[


### PR DESCRIPTION
This change allows the FS Access client to be dynamically enabled/disabled based on whether or not any configured watch items exist. It also adopts watching the changes to the appropriate config key to see if the config path for watch items is modified.