### PR TITLE
Use the appropriate variable when asynchronously processing auth messages

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -251,7 +251,7 @@ using santa::santad::event_providers::endpoint_security::Message;
     });
 
   dispatch_async(self->_authQueue, ^{
-    messageHandler(deadlineMsg);
+    messageHandler(processMsg);
     if (dispatch_semaphore_wait(processingSema, DISPATCH_TIME_NOW) != 0) {
       // Deadline expired, wait for deadline block to finish.
       dispatch_semaphore_wait(deadlineExpiredSema, DISPATCH_TIME_FOREVER);


### PR DESCRIPTION
There isn't an underlying bug here, retain counts are still appropriately set. It just looks weird so cleaning it up.