### PR TITLE
Address policy consistency issues

### DIFF
--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -49,6 +49,8 @@ namespace santa::santad::data_layer {
 
 class WatchItems : public std::enable_shared_from_this<WatchItems> {
  public:
+  using VersionAndPolicies =
+    std::pair<std::string, std::vector<std::optional<std::shared_ptr<WatchItemPolicy>>>>;
   using WatchItemsTree = santa::common::PrefixTree<std::shared_ptr<WatchItemPolicy>>;
 
   // Factory
@@ -64,7 +66,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   void RegisterClient(id<SNTEndpointSecurityDynamicEventHandler> client);
 
   void SetConfigPath(NSString *config_path);
-  std::optional<std::shared_ptr<WatchItemPolicy>> FindPolicyForPath(const char *input);
+  VersionAndPolicies FindPolciesForPaths(std::vector<std::string_view> paths);
   std::string PolicyVersion();
 
   friend class santa::santad::data_layer::WatchItemsPeer;

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -66,7 +66,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   void RegisterClient(id<SNTEndpointSecurityDynamicEventHandler> client);
 
   void SetConfigPath(NSString *config_path);
-  VersionAndPolicies FindPolciesForPaths(std::vector<std::string_view> paths);
+  VersionAndPolicies FindPolciesForPaths(const std::vector<std::string> &paths);
   std::string PolicyVersion();
 
   friend class santa::santad::data_layer::WatchItemsPeer;

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -415,7 +415,7 @@ std::string WatchItems::PolicyVersion() {
 }
 
 WatchItems::VersionAndPolicies WatchItems::FindPolciesForPaths(
-  std::vector<std::string_view> paths) {
+  const std::vector<std::string> &paths) {
   absl::ReaderMutexLock lock(&lock_);
   std::vector<std::optional<std::shared_ptr<WatchItemPolicy>>> policies;
 

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -414,13 +414,16 @@ std::string WatchItems::PolicyVersion() {
   return policy_version_;
 }
 
-std::optional<std::shared_ptr<WatchItemPolicy>> WatchItems::FindPolicyForPath(const char *input) {
-  if (!input) {
-    return std::nullopt;
+WatchItems::VersionAndPolicies WatchItems::FindPolciesForPaths(
+  std::vector<std::string_view> paths) {
+  absl::ReaderMutexLock lock(&lock_);
+  std::vector<std::optional<std::shared_ptr<WatchItemPolicy>>> policies;
+
+  for (const auto &path : paths) {
+    policies.push_back(watch_items_->LookupLongestMatchingPrefix(path.data()));
   }
 
-  absl::ReaderMutexLock lock(&lock_);
-  return watch_items_->LookupLongestMatchingPrefix(input);
+  return {policy_version_, policies};
 }
 
 void WatchItems::SetConfigPath(NSString *config_path) {


### PR DESCRIPTION
This PR addresses two issues:

1. Policies from different configurations could be applied to event types with more than target path (e.g. rename with src/dst) if a config update occurred at the same time as the event being handled.
1. If a config update occurred after a policy was applied but before it was logged, it would be possible to log the new policy version for the event that had the old policy applied.