### PR TITLE
Fix SNTFileInfoTest for macOS 13

### DIFF
--- a/Source/common/SNTFileInfoTest.m
+++ b/Source/common/SNTFileInfoTest.m
@@ -34,7 +34,12 @@
 - (void)testPathStandardizing {
   SNTFileInfo *sut = [[SNTFileInfo alloc] initWithPath:@"/Applications/Safari.app"];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.path, @"/Applications/Safari.app/Contents/MacOS/Safari");
+  if (@available(macOS 13.0, *)) {
+    XCTAssertEqualObjects(sut.path, @"/System/Volumes/Preboot/Cryptexes/App/System/Applications/"
+                                    @"Safari.app/Contents/MacOS/Safari");
+  } else {
+    XCTAssertEqualObjects(sut.path, @"/System/Safari.app/Contents/MacOS/Safari");
+  }
 
   sut = [[SNTFileInfo alloc] initWithPath:@"../../../../../../../../../../../../../../../bin/ls"];
   XCTAssertEqualObjects(sut.path, @"/bin/ls");
@@ -90,6 +95,11 @@
 }
 
 - (void)testKext {
+  // Skip this test on macOS 13 as KEXTs have moved into the kernelcache.
+  if (@available(macOS 13.0, *)) {
+    return;
+  }
+
   SNTFileInfo *sut = [[SNTFileInfo alloc]
     initWithPath:@"/System/Library/Extensions/AppleAPIC.kext/Contents/MacOS/AppleAPIC"];
 

--- a/Source/common/SNTFileInfoTest.m
+++ b/Source/common/SNTFileInfoTest.m
@@ -38,7 +38,7 @@
     XCTAssertEqualObjects(sut.path, @"/System/Volumes/Preboot/Cryptexes/App/System/Applications/"
                                     @"Safari.app/Contents/MacOS/Safari");
   } else {
-    XCTAssertEqualObjects(sut.path, @"/System/Safari.app/Contents/MacOS/Safari");
+    XCTAssertEqualObjects(sut.path, @"/Applications/Safari.app/Contents/MacOS/Safari");
   }
 
   sut = [[SNTFileInfo alloc] initWithPath:@"../../../../../../../../../../../../../../../bin/ls"];


### PR DESCRIPTION
This PR updates `SNTFileInfo` unit tests to account for Safari coming from a [cryptex](https://eclecticlight.co/2022/11/16/cryptex-how-a-custom-iphone-is-changing-macos-updates/) on macOS 13. Also skips the KEXT test on macOS 13 due to KEXTs moving into the kernel cache.

Fixes #886 