### PR TITLE
Run fuzzing in a VM

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup libfuzzer
         run: Fuzzing/install_libclang_fuzzer.sh
-      - name: Cleanup any existing fuzz runs
-        run: rm -rf /tmp/fuzzing/artifacts  # N.B. keeps the corpus
       - name: Fuzz
         run: |
           for target in $(bazel query 'kind(fuzzing_launcher, //Fuzzing:all)'); do

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,8 +6,15 @@ on:
   workflow_dispatch:  # Allows you to run this workflow manually from the Actions tab
 
 jobs:
+  start_vm:
+    runs-on: e2e-host
+    steps:
+      - uses: actions/checkout@v2
+      - name: Start VM
+        run: python3 Testing/integration/actions/start_vm.py macOS_13.bundle.tar.gz
+
   fuzz:
-    runs-on: self-hosted
+    runs-on: e2e-vm
     steps:
       - uses: actions/checkout@v2
       - name: Setup libfuzzer


### PR DESCRIPTION
Meant to do this as part of #976. This PR uses the E2E framework to spin up a VM and runs the fuzzer in it. This will also make it viable (with just a bit more work) to fuzz against a running santad as the existing fuzz tests do.