### PR TITLE
Use new public api for booting VM into recoveryOS

### DIFF
--- a/Testing/integration/VM/VMGUI/AppDelegate.m
+++ b/Testing/integration/VM/VMGUI/AppDelegate.m
@@ -27,22 +27,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import <Virtualization/Virtualization.h>
 
-// MARK: Private Virtualization.framework API to boot into recoveryOS
-@interface _VZVirtualMachineStartOptions : NSObject
-
-@property(assign) BOOL bootMacOSRecovery;
-
-@end
-
-@interface VZVirtualMachine (Private)
-
-#if !defined(MAC_OS_VERSION_13_0)
-- (void)_startWithOptions:(_VZVirtualMachineStartOptions *__nullable)options
-        completionHandler:(void (^__nonnull)(NSError *_Nullable errorOrNil))completionHandler;
-#endif
-
-@end
-
 // MARK: AppDelegate
 
 @interface AppDelegate ()
@@ -65,7 +49,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   dispatch_async(dispatch_get_main_queue(), ^{
     NSArray *args = [[NSProcessInfo processInfo] arguments];
 
-    _VZVirtualMachineStartOptions *options = [_VZVirtualMachineStartOptions new];
+    VZMacOSVirtualMachineStartOptions *options = [VZMacOSVirtualMachineStartOptions new];
     NSString *bundleDir;
     NSString *roDisk;
 
@@ -75,7 +59,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     int bundleArg = 1;
     if ([args[1] isEqualToString:@"-recovery"]) {
-      options.bootMacOSRecovery = YES;
+      options.startUpFromMacOSRecovery = YES;
       if (args.count < 3) {
         abortWithErrorMessage(@"Usage: VMGUI [-recovery] bundle_path [ro_disk]");
       }
@@ -100,7 +84,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     self->_virtualMachine.delegate = self->_delegate;
     self->_virtualMachineView.virtualMachine = self->_virtualMachine;
 
-    [self->_virtualMachine _startWithOptions:options
+    [self->_virtualMachine startWithOptions:options
                            completionHandler:^(NSError *_Nullable error) {
                              if (error) {
                                abortWithErrorMessage(error.localizedDescription);

--- a/Testing/integration/VM/VMGUI/BUILD
+++ b/Testing/integration/VM/VMGUI/BUILD
@@ -30,7 +30,7 @@ macos_application(
     bundle_id = "com.google.santa.e2e.vmgui",
     entitlements = "//Testing/integration/VM/Common:entitlements",
     infoplists = ["//Testing/integration/VM/Common:plist"],
-    minimum_os_version = "12.0",
+    minimum_os_version = "13.0",
     deps = [
         ":vmgui_lib",
     ],


### PR DESCRIPTION
macOS 12.6.1 changed the private API for this. Since Ventura is now out, go ahead and upgrade to it and use the (new) public API to boot into recoveryOS.