### PR TITLE
Fix SNTFileInfo Fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,3 +30,6 @@ jobs:
         with:
           name: artifacts
           path: /tmp/fuzzing/artifacts
+      - name: Poweroff VM
+        if: ${{ always() }}
+        run: sudo shutdown -h +1

--- a/Fuzzing/common/MachOParse.mm
+++ b/Fuzzing/common/MachOParse.mm
@@ -1,17 +1,24 @@
 #import <Foundation/Foundation.h>
+#include <libproc.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #import "Source/common/SNTFileInfo.h"
 
+int get_num_fds() {
+  return proc_pidinfo(getpid(), PROC_PIDLISTFDS, 0, NULL, 0) / PROC_PIDLISTFD_SIZE;
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   static NSString *tmpPath =
     [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
 
+  int num_fds_pre = get_num_fds();
+
   @autoreleasepool {
-    assert([[NSFileManager defaultManager] createFileAtPath:tmpPath
-                                                   contents:[NSData dataWithBytes:data length:size]
-                                                 attributes:nil]);
+    NSData *input = [NSData dataWithBytesNoCopy:(void *)data length:size freeWhenDone:false];
+    [input writeToFile:tmpPath atomically:false];
+
     NSError *error;
     SNTFileInfo *fi = [[SNTFileInfo alloc] initWithResolvedPath:tmpPath error:&error];
     if (!fi || error != nil) {
@@ -20,8 +27,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
 
     // Mach-O Parsing
-    [fi architectures];  // forces machHeaders evaluation
+    [fi architectures];
     [fi isMissingPageZero];
+  }
+
+  if (num_fds_pre != get_num_fds()) {
+    abort();
   }
 
   return 0;

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -642,7 +642,9 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 ///
 - (NSData *)safeSubdataWithRange:(NSRange)range {
   @try {
-    if ((range.location + range.length) > self.fileSize) return nil;
+    if (range.location > self.fileSize || range.length > self.fileSize ||
+        (range.location + range.length) > self.fileSize)
+      return nil;
     [self.fileHandle seekToFileOffset:range.location];
     NSData *d = [self.fileHandle readDataOfLength:range.length];
     if (d.length != range.length) return nil;

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -642,9 +642,10 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
 ///
 - (NSData *)safeSubdataWithRange:(NSRange)range {
   @try {
-    if (range.location > self.fileSize || range.length > self.fileSize ||
-        (range.location + range.length) > self.fileSize)
+    NSUInteger size;
+    if (__builtin_add_overflow(range.location, range.length, &size) || size > self.fileSize) {
       return nil;
+    }
     [self.fileHandle seekToFileOffset:range.location];
     NSData *d = [self.fileHandle readDataOfLength:range.length];
     if (d.length != range.length) return nil;

--- a/Testing/integration/VM/VMGUI/AppDelegate.m
+++ b/Testing/integration/VM/VMGUI/AppDelegate.m
@@ -85,11 +85,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     self->_virtualMachineView.virtualMachine = self->_virtualMachine;
 
     [self->_virtualMachine startWithOptions:options
-                           completionHandler:^(NSError *_Nullable error) {
-                             if (error) {
-                               abortWithErrorMessage(error.localizedDescription);
-                             }
-                           }];
+                          completionHandler:^(NSError *_Nullable error) {
+                            if (error) {
+                              abortWithErrorMessage(error.localizedDescription);
+                            }
+                          }];
   });
 #endif
 }


### PR DESCRIPTION
Fixes a file descriptor leak which was killing fuzzing. Also automatically turns off/destroys the fuzzing VM after it's done instead of waiting for the 15 minute timeout.