### PR TITLE
Opportunistically use ES cache when possible

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -141,6 +141,7 @@ enum class FileAccessPolicyDecision {
   kDenied,
   kDeniedInvalidSignature,
   kAllowed,
+  kAllowedReadAccess,
   kAllowedAuditOnly,
 };
 #endif

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -62,6 +62,10 @@
 /// @param result Either ES_AUTH_RESULT_ALLOW or ES_AUTH_RESULT_DENY
 /// @param cacheable true if ES should attempt to cache the result, otherwise false
 /// @return true if the response was successful, otherwise false
+///
+/// @note If the msg event type requires a flags response, the correct ES API will automatically
+/// be called. ALLOWED results will be translated to having all flags set, and DENIED results
+/// will be translated to having all flags cleared.
 - (bool)respondToMessage:(const santa::santad::event_providers::endpoint_security::Message &)msg
           withAuthResult:(es_auth_result_t)result
                cacheable:(bool)cacheable;

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -51,6 +51,11 @@ using santa::santad::logs::endpoint_security::Logger;
 
 NSString *kBadCertHash = @"BAD_CERT_HASH";
 
+static constexpr uint32_t kOpenFlagsIndicatingWrite = FWRITE | O_APPEND | O_TRUNC;
+// static constexpr uint32_t kOpenFlagsAllowAll = 0xffffffff;
+// static constexpr uint32_t kOpenFlagsAllowNone = 0x0;
+// static constexpr uint32_t kOpenFlagsAllowRead = (kOpenFlagsAllowAll & ~kOpenFlagsIndicatingWrite);
+
 static inline std::string Path(const es_file_t *esFile) {
   return std::string(esFile->path.data, esFile->path.length);
 }
@@ -72,12 +77,67 @@ static inline void PushBackIfNotTruncated(std::vector<std::string> &vec, const e
   }
 }
 
+// // A local type to encapsulate fewer options than FileAccessPolicyDecision
+// //
+// enum class FileAccessPolicyDecisionBasic {
+//   kDenied,
+//   kAllowed,
+//   kAllowedReadAccess,
+// };
+
+// FileAccessPolicyDecisionBasic FileAccessPolicyDecisionToBasic(FileAccessPolicyDecision decision) {
+//   switch (decision) {
+//     case FileAccessPolicyDecision::kNoPolicy: return FileAccessPolicyDecisionBasic::kAllowed;
+//     case FileAccessPolicyDecision::kDenied: return FileAccessPolicyDecisionBasic::kDenied;
+//     case FileAccessPolicyDecision::kDeniedInvalidSignature:
+//       return FileAccessPolicyDecisionBasic::kDenied;
+//     case FileAccessPolicyDecision::kAllowed: return FileAccessPolicyDecisionBasic::kAllowed;
+//     case FileAccessPolicyDecision::kAllowedReadAccess:
+//       return FileAccessPolicyDecisionBasic::kAllowedReadAccess;
+//     case FileAccessPolicyDecision::kAllowedAuditOnly:
+//       return FileAccessPolicyDecisionBasic::kAllowed;
+//     default:
+//       // This is a programming error. Bail.
+//       LOGE(@"Invalid file access decision encountered: %d", decision);
+//       [NSException raise:@"Invalid FileAccessPolicyDecision"
+//                   format:@"Invalid FileAccessPolicyDecision: %d", decision];
+//   }
+// }
+
+// es_auth_result_t FileAccessPolicyDecisionBasicToESAuthResult(
+//   FileAccessPolicyDecisionBasic decision) {
+//   switch (decision) {
+//     case FileAccessPolicyDecisionBasic::kDenied: return ES_AUTH_RESULT_DENY;
+//     case FileAccessPolicyDecisionBasic::kAllowed: return ES_AUTH_RESULT_ALLOW;
+//     case FileAccessPolicyDecisionBasic::kAllowedReadAccess: return ES_AUTH_RESULT_ALLOW;
+//     default:
+//       // This is a programming error. Bail.
+//       LOGE(@"Invalid file access decision encountered: %d", decision);
+//       [NSException raise:@"Invalid FileAccessPolicyDecisionBasic"
+//                   format:@"Invalid FileAccessPolicyDecisionBasic: %d", decision];
+//   }
+// }
+
+// uint32_t FileAccessPolicyDecisionBasicToESFlagsResult(FileAccessPolicyDecisionBasic decision) {
+//   switch (decision) {
+//     case FileAccessPolicyDecisionBasic::kDenied: return kOpenFlagsAllowNone;
+//     case FileAccessPolicyDecisionBasic::kAllowed: return kOpenFlagsAllowAll;
+//     case FileAccessPolicyDecisionBasic::kAllowedReadAccess: return kOpenFlagsAllowRead;
+//     default:
+//       // This is a programming error. Bail.
+//       LOGE(@"Invalid file access decision encountered: %d", decision);
+//       [NSException raise:@"Invalid FileAccessPolicyDecisionBasic"
+//                   format:@"Invalid FileAccessPolicyDecisionBasic: %d", decision];
+//   }
+// }
+
 es_auth_result_t FileAccessPolicyDecisionToESAuthResult(FileAccessPolicyDecision decision) {
   switch (decision) {
     case FileAccessPolicyDecision::kNoPolicy: return ES_AUTH_RESULT_ALLOW;
     case FileAccessPolicyDecision::kDenied: return ES_AUTH_RESULT_DENY;
     case FileAccessPolicyDecision::kDeniedInvalidSignature: return ES_AUTH_RESULT_DENY;
     case FileAccessPolicyDecision::kAllowed: return ES_AUTH_RESULT_ALLOW;
+    case FileAccessPolicyDecision::kAllowedReadAccess: return ES_AUTH_RESULT_ALLOW;
     case FileAccessPolicyDecision::kAllowedAuditOnly: return ES_AUTH_RESULT_ALLOW;
     default:
       // This is a programming error. Bail.
@@ -91,10 +151,36 @@ bool ShouldLogDecision(FileAccessPolicyDecision decision) {
   switch (decision) {
     case FileAccessPolicyDecision::kDenied: return true;
     case FileAccessPolicyDecision::kDeniedInvalidSignature: return true;
-    case FileAccessPolicyDecision::kAllowedAuditOnly: return true; ;
+    case FileAccessPolicyDecision::kAllowedAuditOnly: return true;
     default: return false;
   }
 }
+
+// // This function combines the two input decisions into the most restrictive
+// // result. For example:
+// //   * "allowed + denied = denied"
+// //   * "allowed + allowed_read_access = allowed_read_access"
+// FileAccessPolicyDecisionBasic CombinePolicyResultsNewest(FileAccessPolicyDecisionBasic d1,
+//                                                          FileAccessPolicyDecisionBasic d2) {
+//   // If either input is denied, the result is denied
+//   if (d1 == FileAccessPolicyDecisionBasic::kDenied ||
+//       d2 == FileAccessPolicyDecisionBasic::kDenied) {
+//     return FileAccessPolicyDecisionBasic::kDenied;
+//   }
+
+//   // If either input allows read access, the result allows read access
+//   if (d1 == FileAccessPolicyDecisionBasic::kAllowedReadAccess ||
+//       d2 == FileAccessPolicyDecisionBasic::kAllowedReadAccess) {
+//     return FileAccessPolicyDecisionBasic::kAllowedReadAccess;
+//   }
+
+//   return FileAccessPolicyDecisionBasic::kAllowed;
+// }
+
+// uint32_t CombinePolicyResultsNew(uint32_t result1, uint32_t result2) {
+//   // Combine the flags
+//   return result1 & result2;
+// }
 
 es_auth_result_t CombinePolicyResults(es_auth_result_t result1, es_auth_result_t result2) {
   // If either policy denied the operation, the operation is denied
@@ -233,13 +319,11 @@ void PopulatePathTargets(const Message &msg, std::vector<std::string> &targets) 
 
 - (FileAccessPolicyDecision)specialCaseForPolicy:(std::shared_ptr<WatchItemPolicy>)policy
                                          message:(const Message &)msg {
-  constexpr int openFlagsIndicatingWrite = FWRITE | O_APPEND | O_TRUNC;
-
   switch (msg->event_type) {
     case ES_EVENT_TYPE_AUTH_OPEN:
       // If the policy is write-only, but the operation isn't a write action, it's allowed
-      if (policy->write_only && !(msg->event.open.fflag & openFlagsIndicatingWrite)) {
-        return FileAccessPolicyDecision::kAllowed;
+      if (policy->write_only && !(msg->event.open.fflag & kOpenFlagsIndicatingWrite)) {
+        return FileAccessPolicyDecision::kAllowedReadAccess;
       }
 
       break;
@@ -364,6 +448,30 @@ void PopulatePathTargets(const Message &msg, std::vector<std::string> &targets) 
   return policyDecision;
 }
 
+// - (void)processMessage:(const Message &)msg {
+//   std::vector<std::string> targets;
+//   PopulatePathTargets(msg, targets);
+//   WatchItems::VersionAndPolicies versionAndPolicies =
+//     self->_watchItems->FindPolciesForPaths(targets);
+
+//   es_auth_result_t policyResult = ES_AUTH_RESULT_ALLOW;
+//   FileAccessPolicyDecision prevDecision = FileAccessPolicyDecision::kNoPolicy;
+
+//   for (size_t i = 0; i < targets.size(); i++) {
+//     FileAccessPolicyDecision curDecision = [self handleMessage:msg
+//                                                         target:targets[i]
+//                                                         policy:versionAndPolicies.second[i]
+//                                                  policyVersion:versionAndPolicies.first];
+
+//     policyResult = CombinePolicyResults(FileAccessPolicyDecisionToESAuthResult(prevDecision),
+//                                         FileAccessPolicyDecisionToESAuthResult(curDecision));
+
+//     prevDecision = curDecision;
+//   }
+
+//   [self respondToMessage:msg withAuthResult:policyResult cacheable:false];
+// }
+
 - (void)processMessage:(const Message &)msg {
   std::vector<std::string> targets;
   PopulatePathTargets(msg, targets);
@@ -371,7 +479,7 @@ void PopulatePathTargets(const Message &msg, std::vector<std::string> &targets) 
     self->_watchItems->FindPolciesForPaths(targets);
 
   es_auth_result_t policyResult = ES_AUTH_RESULT_ALLOW;
-  FileAccessPolicyDecision prevDecision = FileAccessPolicyDecision::kNoPolicy;
+  bool allow_read_access = false;
 
   for (size_t i = 0; i < targets.size(); i++) {
     FileAccessPolicyDecision curDecision = [self handleMessage:msg
@@ -379,13 +487,60 @@ void PopulatePathTargets(const Message &msg, std::vector<std::string> &targets) 
                                                         policy:versionAndPolicies.second[i]
                                                  policyVersion:versionAndPolicies.first];
 
-    policyResult = CombinePolicyResults(FileAccessPolicyDecisionToESAuthResult(prevDecision),
-                                        FileAccessPolicyDecisionToESAuthResult(curDecision));
-    prevDecision = curDecision;
+    policyResult =
+      CombinePolicyResults(policyResult, FileAccessPolicyDecisionToESAuthResult(curDecision));
+
+    // If the overall policy result is deny, then reset allow_read_access.
+    // Otherwise if the current decision would allow read access, set the flag.
+    if (policyResult == ES_AUTH_RESULT_DENY) {
+      allow_read_access = false;
+    } else if (curDecision == FileAccessPolicyDecision::kAllowedReadAccess) {
+      allow_read_access = true;
+    }
   }
 
-  [self respondToMessage:msg withAuthResult:policyResult cacheable:false];
+  // IMPORTANT: A response is only cacheable if the policy result was explicitly
+  // allowed. An "allow read access" result must not be cached to ensure a future
+  // non-read accesss can be evaluated. Similarly, denied results must never be
+  // cached so access attempts can be logged.
+  [self respondToMessage:msg
+          withAuthResult:policyResult
+               cacheable:(policyResult == ES_AUTH_RESULT_ALLOW && !allow_read_access)];
 }
+
+// - (void)processMessageNew:(const Message &)msg {
+//   std::vector<std::string> targets;
+//   PopulatePathTargets(msg, targets);
+//   WatchItems::VersionAndPolicies versionAndPolicies =
+//     self->_watchItems->FindPolciesForPaths(targets);
+
+//   FileAccessPolicyDecisionBasic policyResult = FileAccessPolicyDecisionBasic::kAllowed;
+
+//   for (size_t i = 0; i < targets.size(); i++) {
+//     FileAccessPolicyDecision curDecision = [self handleMessage:msg
+//                                                         target:targets[i]
+//                                                         policy:versionAndPolicies.second[i]
+//                                                  policyVersion:versionAndPolicies.first];
+
+//     policyResult =
+//       CombinePolicyResultsNewest(policyResult, FileAccessPolicyDecisionToBasic(curDecision));
+//   }
+
+//   // IMPORTANT: A response is only cacheable if the policy result was explicitly
+//   // allowed. An "allow read access" result must not be cached to ensure a future
+//   // non-read accesss can be evaluated. Similarly, denied results must never be
+//   // cached so access attempts can be logged.
+//   if (msg->event_type == ES_EVENT_TYPE_AUTH_OPEN) {
+//     [self respondToMessage:msg
+//            withFlagsResult:FileAccessPolicyDecisionBasicToESFlagsResult(policyResult)
+//                  cacheable:(policyResult == FileAccessPolicyDecisionBasic::kAllowed)];
+
+//   } else {
+//     [self respondToMessage:msg
+//             withAuthResult:FileAccessPolicyDecisionBasicToESAuthResult(policyResult)
+//                  cacheable:(policyResult == FileAccessPolicyDecisionBasic::kAllowed)];
+//   }
+// }
 
 - (void)handleMessage:(santa::santad::event_providers::endpoint_security::Message &&)esMsg
    recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -190,6 +190,7 @@ void SetExpectationsForFileAccessAuthorizerInit(
     {FileAccessPolicyDecision::kDenied, ES_AUTH_RESULT_DENY},
     {FileAccessPolicyDecision::kDeniedInvalidSignature, ES_AUTH_RESULT_DENY},
     {FileAccessPolicyDecision::kAllowed, ES_AUTH_RESULT_ALLOW},
+    {FileAccessPolicyDecision::kAllowedReadAccess, ES_AUTH_RESULT_ALLOW},
     {FileAccessPolicyDecision::kAllowedAuditOnly, ES_AUTH_RESULT_ALLOW},
   };
 
@@ -271,7 +272,7 @@ void SetExpectationsForFileAccessAuthorizerInit(
       esMsg.event.open.fflag = FREAD;
       Message msg(mockESApi, &esMsg);
       result = [accessClient specialCaseForPolicy:policy message:msg];
-      XCTAssertEqual(result, FileAccessPolicyDecision::kAllowed);
+      XCTAssertEqual(result, FileAccessPolicyDecision::kAllowedReadAccess);
     }
 
     // Read/Write policy, Read operation

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -207,6 +207,7 @@ void SetExpectationsForFileAccessAuthorizerInit(
     {FileAccessPolicyDecision::kDenied, true},
     {FileAccessPolicyDecision::kDeniedInvalidSignature, true},
     {FileAccessPolicyDecision::kAllowed, false},
+    {FileAccessPolicyDecision::kAllowedReadAccess, false},
     {FileAccessPolicyDecision::kAllowedAuditOnly, true},
     {(FileAccessPolicyDecision)5, false},
   };

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -130,6 +130,7 @@ std::string GetFileAccessPolicyDecisionString(FileAccessPolicyDecision decision)
     case FileAccessPolicyDecision::kDenied: return "DENIED";
     case FileAccessPolicyDecision::kDeniedInvalidSignature: return "DENIED_INVALID_SIGNATURE";
     case FileAccessPolicyDecision::kAllowed: return "ALLOWED";
+    case FileAccessPolicyDecision::kAllowedReadAccess: return "ALLOWED_READ_ACCESS";
     case FileAccessPolicyDecision::kAllowedAuditOnly: return "AUDIT_ONLY";
     default: return "UNKNOWN_DECISION_" + std::to_string((int)decision);
   }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -269,6 +269,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
     {FileAccessPolicyDecision::kDenied, "DENIED"},
     {FileAccessPolicyDecision::kDeniedInvalidSignature, "DENIED_INVALID_SIGNATURE"},
     {FileAccessPolicyDecision::kAllowed, "ALLOWED"},
+    {FileAccessPolicyDecision::kAllowedReadAccess, "ALLOWED_READ_ACCESS"},
     {FileAccessPolicyDecision::kAllowedAuditOnly, "AUDIT_ONLY"},
     {(FileAccessPolicyDecision)1234, "UNKNOWN_DECISION_1234"},
   };

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -559,6 +559,7 @@ void SerializeAndCheckNonESEvents(
       {FileAccessPolicyDecision::kDeniedInvalidSignature,
        ::pbv1::FileAccess::POLICY_DECISION_DENIED_INVALID_SIGNATURE},
       {FileAccessPolicyDecision::kAllowed, ::pbv1::FileAccess::POLICY_DECISION_UNKNOWN},
+      {FileAccessPolicyDecision::kAllowedReadAccess, ::pbv1::FileAccess::POLICY_DECISION_UNKNOWN},
       {FileAccessPolicyDecision::kAllowedAuditOnly,
        ::pbv1::FileAccess::POLICY_DECISION_ALLOWED_AUDIT_ONLY},
       {(FileAccessPolicyDecision)1234, ::pbv1::FileAccess::POLICY_DECISION_UNKNOWN},


### PR DESCRIPTION
This change makes it possible to make use of the ES cache when operations are completely allowed (not just for read access). 