### PR TITLE
Fuzz embedded plist reading

### DIFF
--- a/Fuzzing/common/MachOParse.mm
+++ b/Fuzzing/common/MachOParse.mm
@@ -29,6 +29,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     // Mach-O Parsing
     [fi architectures];
     [fi isMissingPageZero];
+
+    [fi infoPlist];
   }
 
   if (num_fds_pre != get_num_fds()) {

--- a/Fuzzing/common/MachOParse.mm
+++ b/Fuzzing/common/MachOParse.mm
@@ -29,7 +29,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     // Mach-O Parsing
     [fi architectures];
     [fi isMissingPageZero];
-
     [fi infoPlist];
   }
 

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -572,10 +572,8 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
     NSData *cmdData = [self safeSubdataWithRange:NSMakeRange(offset, sz_segment)];
     if (!cmdData) return nil;
 
-    struct load_command *lc = (struct load_command *)[cmdData bytes];
-    if (lc->cmdsize < sizeof(struct load_command)) {
+    if (((struct load_command *)[cmdData bytes])->cmdsize < sizeof(struct load_command))
       return nil;
-    }
 
     if (is64) {
       struct segment_command_64 *lc = (struct segment_command_64 *)[cmdData bytes];

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -572,8 +572,9 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
     NSData *cmdData = [self safeSubdataWithRange:NSMakeRange(offset, sz_segment)];
     if (!cmdData) return nil;
 
-    if (((struct load_command *)[cmdData bytes])->cmdsize < sizeof(struct load_command))
+    if (((struct load_command *)[cmdData bytes])->cmdsize < sizeof(struct load_command)) {
       return nil;
+    }
 
     if (is64) {
       struct segment_command_64 *lc = (struct segment_command_64 *)[cmdData bytes];

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -572,6 +572,11 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
     NSData *cmdData = [self safeSubdataWithRange:NSMakeRange(offset, sz_segment)];
     if (!cmdData) return nil;
 
+    struct load_command *lc = (struct load_command *)[cmdData bytes];
+    if (lc->cmdsize < sizeof(struct load_command)) {
+      return nil;
+    }
+
     if (is64) {
       struct segment_command_64 *lc = (struct segment_command_64 *)[cmdData bytes];
       if (lc->cmd == LC_SEGMENT_64 && memcmp(lc->segname, "__TEXT", 6) == 0) {


### PR DESCRIPTION
This also includes a guard around MachO command size to ensure the fuzzer doesn't infinite loop. `cmdsize` is checked by the OS during loading, so it would never be an issue in real event processing.