### PR TITLE
lower fuzz case timeout to 5s

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Fuzz
         run: |
           for target in $(bazel query 'kind(fuzzing_launcher, //Fuzzing:all)'); do
-            bazel run --config=fuzz $target -- -- -max_len=32768 -runs=1000000
+            bazel run --config=fuzz $target -- -- -max_len=32768 -runs=1000000 -timeout=5
           done
       - name: Upload crashes
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Got an email about https://github.com/google/santa/actions/runs/3871168437/jobs/6598695596 failing over the weekend, thinking maybe it found something but the VM timed out killing the run before libfuzzer timed out.