### PR TITLE
Adopt new FS Access Auth config format and policy application logic

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -61,6 +61,7 @@ santa_unit_test(
         ":WatchItems",
         "//Source/common:PrefixTree",
         "//Source/common:TestUtils",
+        "//Source/common:Unit",
         "@OCMock",
     ],
 )

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -49,6 +49,7 @@ objc_library(
         ":WatchItemPolicy",
         "//Source/common:PrefixTree",
         "//Source/common:SNTLogging",
+        "//Source/common:Unit",
     ],
 )
 

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -30,12 +30,13 @@ enum class WatchItemPathType {
 };
 
 struct WatchItemPolicy {
+  // TODO: Flip order: make path and path_type next to each other
   WatchItemPolicy(std::string_view n, std::string_view p, bool wo = false,
                   WatchItemPathType pt = WatchItemPathType::kLiteral,
-                  bool ao = true, std::set<std::string> &&abp = {},
-                  std::set<std::string> &&ati = {},
-                  std::set<std::array<uint8_t, CS_CDHASH_LEN>> &&ach = {},
-                  std::set<std::string> &&acs = {})
+                  bool ao = true, std::set<std::string> abp = {},
+                  std::set<std::string> ati = {},
+                  std::set<std::array<uint8_t, CS_CDHASH_LEN>> ach = {},
+                  std::set<std::string> acs = {})
       : name(n),
         path(p),
         write_only(wo),

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -35,10 +35,9 @@ static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
 
 struct WatchItemPolicy {
-  // TODO: Flip order: make path and path_type next to each other
   WatchItemPolicy(std::string_view n, std::string_view p,
                   WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
-                  bool wo = kWatchItemPolicyDefaultAllowReadAccess,
+                  bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                   bool ao = kWatchItemPolicyDefaultAuditOnly,
                   std::set<std::string> abp = {},
                   std::set<std::string> ati = {},
@@ -47,7 +46,7 @@ struct WatchItemPolicy {
       : name(n),
         path(p),
         path_type(pt),
-        write_only(wo),
+        allow_read_access(ara),
         audit_only(ao),
         allowed_binary_paths(std::move(abp)),
         allowed_team_ids(std::move(ati)),
@@ -57,7 +56,7 @@ struct WatchItemPolicy {
   std::string name;
   std::string path;
   WatchItemPathType path_type;
-  bool write_only;
+  bool allow_read_access;
   bool audit_only;
   std::set<std::string> allowed_binary_paths;
   std::set<std::string> allowed_team_ids;

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -17,10 +17,9 @@
 
 #include <Kernel/kern/cs_blobs.h>
 
-#include <array>
-#include <set>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace santa::santad::data_layer {
 
@@ -35,33 +34,37 @@ static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
 
 struct WatchItemPolicy {
+  struct Process {
+    Process(std::string bp, std::string ti, std::vector<uint8_t> cdh,
+            std::string ch)
+        : binary_path(bp),
+          team_id(ti),
+          cdhash(std::move(cdh)),
+          certificate_sha256(ch) {}
+    std::string binary_path;
+    std::string team_id;
+    std::vector<uint8_t> cdhash;
+    std::string certificate_sha256;
+  };
+
   WatchItemPolicy(std::string_view n, std::string_view p,
                   WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
                   bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                   bool ao = kWatchItemPolicyDefaultAuditOnly,
-                  std::set<std::string> abp = {},
-                  std::set<std::string> ati = {},
-                  std::set<std::array<uint8_t, CS_CDHASH_LEN>> ach = {},
-                  std::set<std::string> acs = {})
+                  std::vector<Process> procs = {})
       : name(n),
         path(p),
         path_type(pt),
         allow_read_access(ara),
         audit_only(ao),
-        allowed_binary_paths(std::move(abp)),
-        allowed_team_ids(std::move(ati)),
-        allowed_cdhashes(std::move(ach)),
-        allowed_certificates_sha256(std::move(acs)) {}
+        processes(std::move(procs)) {}
 
   std::string name;
   std::string path;
   WatchItemPathType path_type;
   bool allow_read_access;
   bool audit_only;
-  std::set<std::string> allowed_binary_paths;
-  std::set<std::string> allowed_team_ids;
-  std::set<std::array<uint8_t, CS_CDHASH_LEN>> allowed_cdhashes;
-  std::set<std::string> allowed_certificates_sha256;
+  std::vector<Process> processes;
 };
 
 }  // namespace santa::santad::data_layer

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -68,6 +68,17 @@ struct WatchItemPolicy {
         audit_only(ao),
         processes(std::move(procs)) {}
 
+  bool operator==(const WatchItemPolicy &other) const {
+    return name == other.name && path == other.path &&
+           path_type == other.path_type &&
+           allow_read_access == other.allow_read_access &&
+           audit_only == other.audit_only && processes == other.processes;
+  }
+
+  bool operator!=(const WatchItemPolicy &other) const {
+    return !(*this == other);
+  }
+
   std::string name;
   std::string path;
   WatchItemPathType path_type;

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -29,18 +29,25 @@ enum class WatchItemPathType {
   kLiteral,
 };
 
+static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType =
+    WatchItemPathType::kLiteral;
+static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
+static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
+
 struct WatchItemPolicy {
   // TODO: Flip order: make path and path_type next to each other
-  WatchItemPolicy(std::string_view n, std::string_view p, bool wo = false,
-                  WatchItemPathType pt = WatchItemPathType::kLiteral,
-                  bool ao = true, std::set<std::string> abp = {},
+  WatchItemPolicy(std::string_view n, std::string_view p,
+                  WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
+                  bool wo = kWatchItemPolicyDefaultAllowReadAccess,
+                  bool ao = kWatchItemPolicyDefaultAuditOnly,
+                  std::set<std::string> abp = {},
                   std::set<std::string> ati = {},
                   std::set<std::array<uint8_t, CS_CDHASH_LEN>> ach = {},
                   std::set<std::string> acs = {})
       : name(n),
         path(p),
-        write_only(wo),
         path_type(pt),
+        write_only(wo),
         audit_only(ao),
         allowed_binary_paths(std::move(abp)),
         allowed_team_ids(std::move(ati)),
@@ -49,8 +56,8 @@ struct WatchItemPolicy {
 
   std::string name;
   std::string path;
-  bool write_only;
   WatchItemPathType path_type;
+  bool write_only;
   bool audit_only;
   std::set<std::string> allowed_binary_paths;
   std::set<std::string> allowed_team_ids;

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -41,6 +41,15 @@ struct WatchItemPolicy {
           team_id(ti),
           cdhash(std::move(cdh)),
           certificate_sha256(ch) {}
+
+    bool operator==(const Process &other) const {
+      return binary_path == other.binary_path && team_id == other.team_id &&
+             cdhash == other.cdhash &&
+             certificate_sha256 == other.certificate_sha256;
+    }
+
+    bool operator!=(const Process &other) const { return !(*this == other); }
+
     std::string binary_path;
     std::string team_id;
     std::vector<uint8_t> cdhash;

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -31,14 +31,14 @@
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 
-extern const NSString *kWatchItemConfigKeyPath;
-extern const NSString *kWatchItemConfigKeyWriteOnly;
-extern const NSString *kWatchItemConfigKeyIsPrefix;
-extern const NSString *kWatchItemConfigKeyAuditOnly;
-extern const NSString *kWatchItemConfigKeyAllowedBinaryPaths;
-extern const NSString *kWatchItemConfigKeyAllowedCertificatesSha256;
-extern const NSString *kWatchItemConfigKeyAllowedTeamIDs;
-extern const NSString *kWatchItemConfigKeyAllowedCDHashes;
+extern NSString *const kWatchItemConfigKeyPath;
+extern NSString *const kWatchItemConfigKeyWriteOnly;
+extern NSString *const kWatchItemConfigKeyIsPrefix;
+extern NSString *const kWatchItemConfigKeyAuditOnly;
+extern NSString *const kWatchItemConfigKeyAllowedBinaryPaths;
+extern NSString *const kWatchItemConfigKeyAllowedCertificatesSha256;
+extern NSString *const kWatchItemConfigKeyAllowedTeamIDs;
+extern NSString *const kWatchItemConfigKeyAllowedCDHashes;
 
 // Forward declarations
 namespace santa::santad::data_layer {
@@ -78,7 +78,6 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   void UpdateCurrentState(std::unique_ptr<WatchItemsTree> new_tree,
                           std::set<std::pair<std::string, WatchItemPathType>> &&new_monitored_paths,
                           NSDictionary *new_config);
-  bool ParseConfig(NSDictionary *config, std::vector<std::shared_ptr<WatchItemPolicy>> &policies);
   bool BuildPolicyTree(const std::vector<std::shared_ptr<WatchItemPolicy>> &watch_items,
                        WatchItemsTree &tree,
                        std::set<std::pair<std::string, WatchItemPathType>> &paths);

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -31,14 +31,19 @@
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #import "Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h"
 
-extern NSString *const kWatchItemConfigKeyPath;
-extern NSString *const kWatchItemConfigKeyWriteOnly;
-extern NSString *const kWatchItemConfigKeyIsPrefix;
-extern NSString *const kWatchItemConfigKeyAuditOnly;
-extern NSString *const kWatchItemConfigKeyAllowedBinaryPaths;
-extern NSString *const kWatchItemConfigKeyAllowedCertificatesSha256;
-extern NSString *const kWatchItemConfigKeyAllowedTeamIDs;
-extern NSString *const kWatchItemConfigKeyAllowedCDHashes;
+extern NSString *const kWatchItemConfigKeyVersion;
+extern NSString *const kWatchItemConfigKeyWatchItems;
+extern NSString *const kWatchItemConfigKeyPaths;
+extern NSString *const kWatchItemConfigKeyPathsPath;
+extern NSString *const kWatchItemConfigKeyPathsIsPrefix;
+extern NSString *const kWatchItemConfigKeyOptions;
+extern NSString *const kWatchItemConfigKeyOptionsAllowReadAccess;
+extern NSString *const kWatchItemConfigKeyOptionsAuditOnly;
+extern NSString *const kWatchItemConfigKeyProcesses;
+extern NSString *const kWatchItemConfigKeyProcessesBinaryPath;
+extern NSString *const kWatchItemConfigKeyProcessesCertificateSha256;
+extern NSString *const kWatchItemConfigKeyProcessesTeamID;
+extern NSString *const kWatchItemConfigKeyProcessesCDHash;
 
 // Forward declarations
 namespace santa::santad::data_layer {

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -106,7 +106,7 @@ static std::vector<uint8_t> HexStringToBytes(NSString *str) {
   char cur_byte[3];
   cur_byte[2] = '\0';
 
-  for (int i = 0; i < [str length] / 2; i++) {
+  for (int i = 0; i < str.length / 2; i++) {
     cur_byte[0] = [str characterAtIndex:(i * 2)];
     cur_byte[1] = [str characterAtIndex:(i * 2 + 1)];
 

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -144,7 +144,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     },
   ]];
 
-  NSDictionary *allFilesPolicy = @{kWatchItemConfigKeyPath : @"*"};
+  NSDictionary *allFilesPolicy = @{kWatchItemConfigKeyPaths : @[ @"*" ]};
   NSDictionary *configAllFilesOriginal =
     WrapWatchItemsConfig(@{@"all_files_orig" : allFilesPolicy});
   NSDictionary *configAllFilesRename =
@@ -202,12 +202,16 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   [self createTestDirStructure:@[ @"f1", @"f2", @"weird1" ]];
 
   NSDictionary *fFiles = @{
-    kWatchItemConfigKeyPath : @"f?",
-    kWatchItemConfigKeyIsPrefix : @(NO),
+    kWatchItemConfigKeyPaths : @[ @{
+      kWatchItemConfigKeyPathsPath : @"f?",
+      kWatchItemConfigKeyPathsIsPrefix : @(NO),
+    } ]
   };
   NSDictionary *weirdFiles = @{
-    kWatchItemConfigKeyPath : @"weird?",
-    kWatchItemConfigKeyIsPrefix : @(NO),
+    kWatchItemConfigKeyPaths : @[ @{
+      kWatchItemConfigKeyPathsPath : @"weird?",
+      kWatchItemConfigKeyPathsIsPrefix : @(NO),
+    } ]
   };
 
   NSString *configFile = @"config.plist";
@@ -215,10 +219,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   NSDictionary *secondConfig =
     WrapWatchItemsConfig(@{@"f_files" : fFiles, @"weird_files" : weirdFiles});
 
-  // std::optional<std::shared_ptr<WatchItemPolicy>> policy;
-
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  (void)timer;
 
   const uint64 periodicFlushMS = 1000;
   dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, 0),
@@ -272,8 +273,10 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 
   NSMutableDictionary *config = WrapWatchItemsConfig(@{
     @"foo_subdir" : @{
-      kWatchItemConfigKeyPath : @"./foo",
-      kWatchItemConfigKeyIsPrefix : @(YES),
+      kWatchItemConfigKeyPaths : @[ @{
+        kWatchItemConfigKeyPathsPath : @"./foo",
+        kWatchItemConfigKeyPathsIsPrefix : @(YES),
+      } ]
     }
   });
 
@@ -319,8 +322,10 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 
   // Add a new policy and reload the config
   NSDictionary *barTxtFilePolicy = @{
-    kWatchItemConfigKeyPath : @"./foo/bar.txt",
-    kWatchItemConfigKeyIsPrefix : @(NO),
+    kWatchItemConfigKeyPaths : @[ @{
+      kWatchItemConfigKeyPathsPath : @"./foo/bar.txt",
+      kWatchItemConfigKeyPathsIsPrefix : @(NO),
+    } ]
   };
   [config[@"WatchItems"] setObject:barTxtFilePolicy forKey:@"bar_txt"];
 
@@ -347,8 +352,10 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 
   // Add a catch-all policy that should only affect the previously non-matching path
   NSDictionary *catchAllFilePolicy = @{
-    kWatchItemConfigKeyPath : @".",
-    kWatchItemConfigKeyIsPrefix : @(YES),
+    kWatchItemConfigKeyPaths : @[ @{
+      kWatchItemConfigKeyPathsPath : @".",
+      kWatchItemConfigKeyPathsIsPrefix : @(YES),
+    } ]
   };
   [config[@"WatchItems"] setObject:catchAllFilePolicy forKey:@"dot_everything"];
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -314,6 +314,10 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
 /// WatchItemPolicy::Process to be considered a match.
 - (bool)policyProcess:(const WatchItemPolicy::Process &)policyProc
      matchesESProcess:(const es_process_t *)esProc {
+  // Note: Intentionally not checking `CS_VALID` here - this check must happen
+  // outside of this method. This method is used to individually check each
+  // configured process exception while the check for a valid code signature
+  // is more broad and applies whether or not process exceptions exist.
   if (esProc->codesigning_flags & CS_SIGNED) {
     // Check if the instigating process has an allowed TeamID
     if (policyProc.team_id.length() > 0 && esProc->team_id.data &&

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -270,14 +270,14 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
   switch (msg->event_type) {
     case ES_EVENT_TYPE_AUTH_OPEN:
       // If the policy is write-only, but the operation isn't a write action, it's allowed
-      if (policy->write_only && !(msg->event.open.fflag & kOpenFlagsIndicatingWrite)) {
+      if (policy->allow_read_access && !(msg->event.open.fflag & kOpenFlagsIndicatingWrite)) {
         return FileAccessPolicyDecision::kAllowedReadAccess;
       }
       break;
 
     case ES_EVENT_TYPE_AUTH_CLONE:
       // If policy is write-only, readable targets are allowed (e.g. source file)
-      if (policy->write_only && target.isReadable) {
+      if (policy->allow_read_access && target.isReadable) {
         return FileAccessPolicyDecision::kAllowedReadAccess;
       }
       break;
@@ -286,7 +286,7 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
       // Note: Flags for the copyfile event represent the kernel view, not the usersapce
       // copyfile(3) implementation. This means if a `copyfile(3)` flag like `COPYFILE_MOVE`
       // is specified, it will come as a separate `unlink(2)` event, not a flag here.
-      if (policy->write_only && target.isReadable) {
+      if (policy->allow_read_access && target.isReadable) {
         return FileAccessPolicyDecision::kAllowedReadAccess;
       }
       break;

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -270,7 +270,7 @@ void SetExpectationsForFileAccessAuthorizerInit(
 
     // Write-only policy, Write operation
     {
-      policy->write_only = true;
+      policy->allow_read_access = true;
       esMsg.event.open.fflag = FWRITE | FREAD;
       Message msg(mockESApi, &esMsg);
       result = [accessClient specialCaseForPolicy:policy target:target message:msg];
@@ -279,7 +279,7 @@ void SetExpectationsForFileAccessAuthorizerInit(
 
     // Write-only policy, Read operation
     {
-      policy->write_only = true;
+      policy->allow_read_access = true;
       esMsg.event.open.fflag = FREAD;
       Message msg(mockESApi, &esMsg);
       result = [accessClient specialCaseForPolicy:policy target:target message:msg];
@@ -288,7 +288,7 @@ void SetExpectationsForFileAccessAuthorizerInit(
 
     // Read/Write policy, Read operation
     {
-      policy->write_only = false;
+      policy->allow_read_access = false;
       esMsg.event.open.fflag = FREAD;
       Message msg(mockESApi, &esMsg);
       result = [accessClient specialCaseForPolicy:policy target:target message:msg];


### PR DESCRIPTION
This change adopts the new config file format proposed here: https://github.com/google/santa/pull/988

This change also adopts the new logic associated with matching instigating processes to matching process configurations - namely that ALL attributes of a configured process must match an instigating process for the policy to apply. (E.g., attributes are AND'd together).

This change also standardizes error handling while parsing the config file to attempt to make error messages more standard and actionable.