### PR TITLE
Add policy version and name to basic string serializer

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -419,7 +419,11 @@ std::vector<uint8_t> BasicString::SerializeFileAccess(const std::string &policy_
                                                       FileAccessPolicyDecision decision) {
   std::string str = CreateDefaultString();
 
-  str.append("action=FILE_ACCESS|path=");
+  str.append("action=FILE_ACCESS|policy_version=");
+  str.append(policy_version);
+  str.append("|policy_name=");
+  str.append(policy_name);
+  str.append("|path=");
   str.append(target);
   str.append("|access_type=");
   str.append(GetAccessTypeString(msg->event_type));

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -295,7 +295,8 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
                             FileAccessPolicyDecision::kAllowedAuditOnly);
   std::string got(ret.begin(), ret.end());
   std::string want =
-    "action=FILE_ACCESS|path=file_target|access_type=OPEN|decision=AUDIT_ONLY|pid=12|ppid=56|"
+    "action=FILE_ACCESS|policy_version=v1.0|policy_name=pol_name|path=file_target|access_type=OPEN|"
+    "decision=AUDIT_ONLY|pid=12|ppid=56|"
     "process=foo|processpath=foo|uid=-2|user=nobody|gid=-1|group=nogroup|machineid=my_id\n";
   XCTAssertCppStringEqual(got, want);
 }


### PR DESCRIPTION
Adds the missing policy name and version to the serialized output from the basic string serializer.