### PR TITLE
Add watch item state to santactl status

### DIFF
--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -63,6 +63,7 @@
 ///  Config ops
 ///
 - (void)watchdogInfo:(void (^)(uint64_t, uint64_t, double, double))reply;
+- (void)watchItemsState:(void (^)(BOOL, uint64_t, NSString *, NSString *, NSTimeInterval))reply;
 - (void)clientMode:(void (^)(SNTClientMode))reply;
 - (void)fullSyncLastSuccess:(void (^)(NSDate *))reply;
 - (void)ruleSyncLastSuccess:(void (^)(NSDate *))reply;

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -289,7 +289,7 @@ REGISTER_COMMAND_NAME(@"status")
       printf("  %-25s | %lld\n", "Rules", staticRuleCount);
     }
 
-    printf(">>> Watch Items State\n");
+    printf(">>> Watch Items\n");
     printf("  %-25s | %s\n", "Enabled", (watchItemsEnabled ? "Yes" : "No"));
     if (watchItemsEnabled) {
       printf("  %-25s | %s\n", "Policy Version", watchItemsPolicyVersion.UTF8String);

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -174,6 +174,8 @@ REGISTER_COMMAND_NAME(@"status")
         watchItemsConfigPath = configPath;
         watchItemsLastUpdateEpoch = lastUpdateEpoch;
       }
+
+      dispatch_group_leave(group);
     }];
 
   // Wait a maximum of 5s for stats collected from daemon to arrive.

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -158,6 +158,24 @@ REGISTER_COMMAND_NAME(@"status")
     dispatch_group_leave(group);
   }];
 
+  __block BOOL watchItemsEnabled = NO;
+  __block uint64_t watchItemsRuleCount = 0;
+  __block NSString *watchItemsPolicyVersion = nil;
+  __block NSString *watchItemsConfigPath = nil;
+  __block NSTimeInterval watchItemsLastUpdateEpoch = 0;
+  dispatch_group_enter(group);
+  [[self.daemonConn remoteObjectProxy]
+    watchItemsState:^(BOOL enabled, uint64_t ruleCount, NSString *policyVersion,
+                      NSString *configPath, NSTimeInterval lastUpdateEpoch) {
+      watchItemsEnabled = enabled;
+      if (enabled) {
+        watchItemsRuleCount = ruleCount;
+        watchItemsPolicyVersion = policyVersion;
+        watchItemsConfigPath = configPath;
+        watchItemsLastUpdateEpoch = lastUpdateEpoch;
+      }
+    }];
+
   // Wait a maximum of 5s for stats collected from daemon to arrive.
   if (dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5))) {
     fprintf(stderr, "Failed to retrieve some stats from daemon\n\n");
@@ -169,6 +187,10 @@ REGISTER_COMMAND_NAME(@"status")
   NSString *fullSyncLastSuccessStr = [dateFormatter stringFromDate:fullSyncLastSuccess] ?: @"Never";
   NSString *ruleSyncLastSuccessStr =
     [dateFormatter stringFromDate:ruleSyncLastSuccess] ?: fullSyncLastSuccessStr;
+
+  NSString *watchItemsLastUpdateStr =
+    [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:watchItemsLastUpdateEpoch]]
+      ?: @"Never";
 
   NSString *syncURLStr = configurator.syncBaseURL.absoluteString;
 
@@ -212,6 +234,22 @@ REGISTER_COMMAND_NAME(@"status")
       },
     } mutableCopy];
 
+    NSDictionary *watchItems;
+    if (watchItemsEnabled) {
+      watchItems = @{
+        @"enabled" : @(watchItemsEnabled),
+        @"rule_count" : @(watchItemsRuleCount),
+        @"policy_version" : watchItemsPolicyVersion,
+        @"config_path" : watchItemsConfigPath,
+        @"last_policy_update" : watchItemsLastUpdateStr ?: @"null",
+      };
+    } else {
+      watchItems = @{
+        @"enabled" : @(watchItemsEnabled),
+      };
+    }
+    stats[@"watch_items"] = watchItems;
+
     stats[@"cache"] = @{
       @"root_cache_count" : @(rootCacheCount),
       @"non_root_cache_count" : @(nonRootCacheCount),
@@ -249,6 +287,15 @@ REGISTER_COMMAND_NAME(@"status")
     if ([SNTConfigurator configurator].staticRules.count) {
       printf(">>> Static Rules\n");
       printf("  %-25s | %lld\n", "Rules", staticRuleCount);
+    }
+
+    printf(">>> Watch Items State\n");
+    printf("  %-25s | %s\n", "Enabled", (watchItemsEnabled ? "Yes" : "No"));
+    if (watchItemsEnabled) {
+      printf("  %-25s | %s\n", "Policy Version", watchItemsPolicyVersion.UTF8String);
+      printf("  %-25s | %llu\n", "Rule Count", watchItemsRuleCount);
+      printf("  %-25s | %s\n", "Config Path", watchItemsConfigPath.UTF8String);
+      printf("  %-25s | %s\n", "Last Policy Update", watchItemsLastUpdateStr.UTF8String);
     }
 
     if (syncURLStr) {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -595,6 +595,7 @@ objc_library(
         ":SNTPolicyProcessor",
         ":SNTRuleTable",
         ":SNTSyncdQueue",
+        ":WatchItems",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -53,6 +53,13 @@ class WatchItemsPeer;
 
 namespace santa::santad::data_layer {
 
+struct WatchItemsState {
+  uint64_t rule_count;
+  NSString *policy_version;
+  NSString *config_path;
+  NSTimeInterval last_config_load_epoch;
+};
+
 class WatchItems : public std::enable_shared_from_this<WatchItems> {
  public:
   using VersionAndPolicies =
@@ -73,7 +80,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   void SetConfigPath(NSString *config_path);
   VersionAndPolicies FindPolciesForPaths(const std::vector<std::string_view> &paths);
-  std::string PolicyVersion();
+
+  std::optional<WatchItemsState> State();
 
   friend class santa::santad::data_layer::WatchItemsPeer;
 
@@ -97,6 +105,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   std::unique_ptr<WatchItemsTree> watch_items_ ABSL_GUARDED_BY(lock_);
   NSDictionary *current_config_ ABSL_GUARDED_BY(lock_);
+  NSTimeInterval last_update_time_ ABSL_GUARDED_BY(lock_);
   std::set<std::pair<std::string, WatchItemPathType>> currently_monitored_paths_
     ABSL_GUARDED_BY(lock_);
   std::string policy_version_ ABSL_GUARDED_BY(lock_);

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -1,4 +1,4 @@
-/// Copyright 2022 Google LLC
+Source/santad/DataLayer/WatchItemsTest.mm/// Copyright 2022 Google LLC
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ using santa::santad::data_layer::kWatchItemPolicyDefaultPathType;
 using santa::santad::data_layer::WatchItemPathType;
 using santa::santad::data_layer::WatchItemPolicy;
 using santa::santad::data_layer::WatchItems;
+using santa::santad::data_layer::WatchItemsState;
 
 namespace santatest {
 using PathAndTypePair = std::pair<std::string, WatchItemPathType>;
@@ -776,13 +777,31 @@ static NSString *RepeatedString(NSString *str, NSUInteger len) {
                  WatchItemPolicy("rule", "b", WatchItemPathType::kPrefix, true, false, procs));
 }
 
-- (void)testPolicyVersion {
-  NSMutableDictionary *config = WrapWatchItemsConfig(@{});
+- (void)testState {
+  NSString *configPath = @"my_config_path";
+  NSTimeInterval startTime = [[NSDate date] timeIntervalSince1970];
 
-  WatchItemsPeer watchItems(nil, NULL, NULL);
+  NSMutableDictionary *config = WrapWatchItemsConfig(@{
+    @"rule1" : @{kWatchItemConfigKeyPaths : @[ @"abc" ]},
+    @"rule2" : @{kWatchItemConfigKeyPaths : @[ @"xyz" ]}
+  });
+
+  WatchItemsPeer watchItems(configPath, NULL, NULL);
+
+  // If no policy yet exists, nullopt is returned
+  std::optional<WatchItemsState> optionalState = watchItems.State();
+  XCTAssertFalse(optionalState.has_value());
+
   watchItems.ReloadConfig(config);
 
-  XCTAssertCStringEqual(watchItems.PolicyVersion().c_str(), kVersion.data());
+  optionalState = watchItems.State();
+  XCTAssertTrue(optionalState.has_value());
+  WatchItemsState state = optionalState.value();
+
+  XCTAssertEqual(state.rule_count, [config[kWatchItemConfigKeyWatchItems] count]);
+  XCTAssertCStringEqual(state.policy_version.UTF8String, kVersion.data());
+  XCTAssertEqual(state.config_path, configPath);
+  XCTAssertGreaterThanOrEqual(state.last_config_load_epoch, startTime);
 }
 
 @end

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -1,4 +1,4 @@
-Source/santad/DataLayer/WatchItemsTest.mm/// Copyright 2022 Google LLC
+/// Copyright 2022 Google LLC
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -17,6 +17,7 @@
 #include <memory>
 
 #import "Source/common/SNTXPCControlInterface.h"
+#include "Source/santad/DataLayer/WatchItems.h"
 #include "Source/santad/EventProviders/AuthResultCache.h"
 #import "Source/santad/Logs/EndpointSecurity/Logger.h"
 
@@ -33,5 +34,6 @@
     (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
         notificationQueue:(SNTNotificationQueue *)notQueue
                syncdQueue:(SNTSyncdQueue *)syncdQueue
-                   logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger;
+                   logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
+               watchItems:(std::shared_ptr<santa::santad::data_layer::WatchItems>)watchItems;
 @end

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -83,7 +83,8 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
     [[SNTDaemonControlController alloc] initWithAuthResultCache:auth_result_cache
                                               notificationQueue:notifier_queue
                                                      syncdQueue:syncd_queue
-                                                         logger:logger];
+                                                         logger:logger
+                                                     watchItems:watch_items];
 
   control_connection.exportedObject = dc;
   [control_connection resume];


### PR DESCRIPTION
When there is not a valid config:
```
>>> Watch Items
  Enabled                   | No
```
When there is a valid config:
```
>>> Watch Items
  Enabled                   | Yes
  Policy Version            | v0.1-experimental
  Rule Count                | 1
  Config Path               | /var/db/santa/file_access_config.plist
  Last Policy Update        | 2023/01/11 16:36:08 -0500
```