### PR TITLE
Reconnect to santametrics service on failure

### DIFF
--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -47,12 +47,13 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
  public:
   static std::shared_ptr<Metrics> Create(SNTMetricSet *metricSet, uint64_t interval);
 
-  Metrics(MOLXPCConnection *metrics_connection, dispatch_queue_t q, dispatch_source_t timer_source,
-          uint64_t interval, SNTMetricInt64Gauge *event_processing_times,
-          SNTMetricCounter *event_counts, void (^run_on_first_start)(void));
+  Metrics(dispatch_queue_t q, dispatch_source_t timer_source, uint64_t interval,
+          SNTMetricInt64Gauge *event_processing_times, SNTMetricCounter *event_counts,
+          void (^run_on_first_start)(Metrics *));
 
   ~Metrics();
 
+  void EstablishConnection();
   void StartPoll();
   void StopPoll();
   void SetInterval(uint64_t interval);
@@ -73,7 +74,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   // This helps manage dispatch source state to ensure the source is not
   // suspended, resumed, or cancelled while in an improper state.
   bool running_;
-  void (^run_on_first_start_)(void);
+  void (^run_on_first_start_)(Metrics *);
 
   // Separate queue used for setting event metrics
   // Mitigate issues where capturing metrics could be blocked on exporting

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -173,7 +173,7 @@ Metrics::~Metrics() {
 void Metrics::EstablishConnection() {
   MOLXPCConnection *metrics_connection = [SNTXPCMetricServiceInterface configuredConnection];
   metrics_connection.invalidationHandler = ^{
-    NSLog(@"Metrics service connection invalidated. Reconnecting...");
+    LOGW(@"Metrics service connection invalidated. Reconnecting...");
     EstablishConnection();
   };
   [metrics_connection resume];

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -65,9 +65,10 @@ using santa::santad::ProcessorToString;
 
 - (void)testStartStop {
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  auto metrics = std::make_shared<MetricsPeer>(nil, self.q, timer, 100, nil, nil, ^{
-    dispatch_semaphore_signal(self.sema);
-  });
+  auto metrics =
+    std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil, ^(santa::santad::Metrics *m) {
+      dispatch_semaphore_signal(self.sema);
+    });
 
   XCTAssertFalse(metrics->IsRunning());
 
@@ -100,8 +101,8 @@ using santa::santad::ProcessorToString;
 
 - (void)testSetInterval {
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  auto metrics = std::make_shared<MetricsPeer>(nil, self.q, timer, 100, nil, nil,
-                                               ^{
+  auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil,
+                                               ^(santa::santad::Metrics *m){
                                                });
 
   XCTAssertEqual(100, metrics->Interval());
@@ -186,11 +187,11 @@ using santa::santad::ProcessorToString;
     });
 
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  auto metrics = std::make_shared<MetricsPeer>(nil, self.q, timer, 100, mockEventProcessingTimes,
-                                               mockEventCounts,
-                                               ^{
-                                                 // This block intentionally left blank
-                                               });
+  auto metrics =
+    std::make_shared<MetricsPeer>(self.q, timer, 100, mockEventProcessingTimes, mockEventCounts,
+                                  ^(santa::santad::Metrics *m){
+                                    // This block intentionally left blank
+                                  });
 
   metrics->SetEventMetrics(Processor::kAuthorizer, ES_EVENT_TYPE_AUTH_EXEC,
                            EventDisposition::kProcessed, nanos);


### PR DESCRIPTION
The XPC wrapper Santa uses (MOLXPCConnection) does its own internal handshake to validate code signatures before switching to the desired XPC interface. The metrics client in santad however isn't subscribed to XPC connection invalidation events, so when metrics service dies XPC itself (not the macops wrapper) tries to be helpful and reconnects the connection using the metrics exporting interface. However the newly restarted metrics service server sees this as a new connection and exposes the interface it's expecting for the handshake. Because of this mismatch, we end up continuously sending export metrics requests which are never handled.