### PR TITLE
Prevent recursive reconnect attempts

### DIFF
--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -173,8 +173,10 @@ Metrics::~Metrics() {
 void Metrics::EstablishConnection() {
   MOLXPCConnection *metrics_connection = [SNTXPCMetricServiceInterface configuredConnection];
   metrics_connection.invalidationHandler = ^{
-    LOGW(@"Metrics service connection invalidated. Reconnecting...");
-    EstablishConnection();
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      LOGW(@"Metrics service connection invalidated. Reconnecting...");
+      EstablishConnection();
+    });
   };
   [metrics_connection resume];
   metrics_connection_ = metrics_connection;


### PR DESCRIPTION
Wrap reconnection attempts in a `dispatch_sync` block to prevent a case where a flood of attempts could be made recursively. (This fix puts this in line with how the sync service connection is reestablished.https://github.com/google/santa/blob/main/Source/santad/Santad.mm#L63) 