### PR TITLE
Revert "Configurator: Apply config updates in non-daemon processes"

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1040,6 +1040,9 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 }
 
 - (void)startWatchingDefaults {
+  // Only com.google.santa.daemon should listen.
+  NSString *processName = [[NSProcessInfo processInfo] processName];
+  if (![processName isEqualToString:@"com.google.santa.daemon"]) return;
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(defaultsChanged:)
                                                name:NSUserDefaultsDidChangeNotification


### PR DESCRIPTION
There's a chance this is causing issues with `santactl sync` not picking up the SyncBaseURL.

Reverts google/santa#1003