### PR TITLE
Reduce calls into configurator

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1098,6 +1098,7 @@ santa_unit_test(
         ":MockEndpointSecurityAPI",
         ":SNTEndpointSecurityClient",
         ":WatchItemPolicy",
+        "//Source/common:SNTConfigurator",
         "//Source/common:TestUtils",
         "@OCMock",
         "@com_google_googletest//:gtest",

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -245,6 +245,9 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExec &msg) {
   const es_message_t &esm = msg.es_msg();
   std::string str = CreateDefaultString(1024);  // EXECs tend to be bigger, reserve more space.
 
+  // Only need to grab the shared instance once
+  static SNTConfigurator *configurator = [SNTConfigurator configurator];
+
   SNTCachedDecision *cd =
     [[SNTDecisionCache sharedCache] cachedDecisionForFile:esm.event.exec.target->executable->stat];
 
@@ -291,7 +294,7 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExec &msg) {
                   msg.instigator().real_group());
 
   str.append("|mode=");
-  str.append(GetModeString([[SNTConfigurator configurator] clientMode]));
+  str.append(GetModeString([configurator clientMode]));
   str.append("|path=");
   str.append(FilePath(esm.event.exec.target->executable).Sanitized());
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -422,6 +422,9 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg) {
   Arena arena;
   ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena, msg);
 
+  // Only need to grab the shared instance once
+  static SNTConfigurator *configurator = [SNTConfigurator configurator];
+
   SNTCachedDecision *cd = [[SNTDecisionCache sharedCache]
     cachedDecisionForFile:msg.es_msg().event.exec.target->executable->stat];
 
@@ -476,7 +479,7 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg) {
 
   pb_exec->set_decision(GetDecisionEnum(cd.decision));
   pb_exec->set_reason(GetReasonEnum(cd.decision));
-  pb_exec->set_mode(GetModeEnum([[SNTConfigurator configurator] clientMode]));
+  pb_exec->set_mode(GetModeEnum([configurator clientMode]));
 
   if (cd.certSHA256 || cd.certCommonName) {
     EncodeCertificateInfo(pb_exec->mutable_certificate_info(), cd.certSHA256, cd.certCommonName);


### PR DESCRIPTION
Nice little perf win here. In CPU traces, calls into the configurator (both to get the shared instance and looking up properties) constituted a large amount of time. This change reduces calls to get the shared instance, and also only calls to lookup some properties when necessary