### PR TITLE
Fix: Rewrite the SNTMetricHTTPWriter to avoid potential stack corruption

### DIFF
--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -37,6 +37,9 @@
 - (BOOL)write:(NSArray<NSData *> *)metrics toURL:(NSURL *)url error:(NSError **)error {
   __block NSError *_blockError = nil;
 
+  SNTConfigurator *config = [SNTConfigurator configurator];
+  int64_t timeout = (int64_t)config.metricExportTimeout;
+
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
   request.HTTPMethod = @"POST";
   [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
@@ -82,9 +85,6 @@
         }];
 
     [task resume];
-
-    SNTConfigurator *config = [SNTConfigurator configurator];
-    int64_t timeout = (int64_t)config.metricExportTimeout;
 
     // Wait up to timeout seconds for the request to complete.
     if (dispatch_group_wait(requests, dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_SEC)) !=

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -55,8 +55,11 @@
         completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
                             NSError *_Nullable err) {
           if (err != nil) {
+            LOGD(@"SNTMetricHTTPWriter: %@", err);
             _blockError = err;
           } else if (response == nil) {
+            // Overwrite the last error as any previous error should show up in
+            // logs if making multiple requests.
             _blockError = nil;
           } else if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
@@ -71,6 +74,7 @@
                           [NSString stringWithFormat:@"received http status code %ld from %@",
                                                      httpResponse.statusCode, url]
                       }];
+            LOGD(@"SNTMetricHTTPWriter: %@", err);
             }
           }
           dispatch_group_leave(requests);

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -37,7 +37,13 @@
 - (BOOL)write:(NSArray<NSData *> *)metrics toURL:(NSURL *)url error:(NSError **)error {
   __block NSError *_blockError = nil;
 
-  SNTConfigurator *config = [SNTConfigurator configurator];
+  static SNTConfigurator *config;
+  static dispatch_once_t onceToken;
+
+  dispatch_once(&onceToken, ^{
+    config = [SNTConfigurator configurator];
+  });
+
   int64_t timeout = (int64_t)config.metricExportTimeout;
 
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];


### PR DESCRIPTION
We've seen some intermittent crashes when logging metrics via the SNTMetricHTTPWriter.