### PR TITLE
Fix team ID and signing ID checks

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -319,14 +319,18 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
   // configured process exception while the check for a valid code signature
   // is more broad and applies whether or not process exceptions exist.
   if (esProc->codesigning_flags & CS_SIGNED) {
-    // Check if the instigating process has an allowed TeamID
-    if (!policyProc.team_id.empty() && esProc->team_id.data &&
-        policyProc.team_id != esProc->team_id.data) {
+    // If the policy contains a team ID, check that the instigating process
+    // also has a team ID and matches the policy.
+    if (!policyProc.team_id.empty() &&
+        (!esProc->team_id.data || (policyProc.team_id != esProc->team_id.data))) {
+      // We expected a team ID to match against, but the process didn't have one.
       return false;
     }
 
-    if (!policyProc.signing_id.empty() && esProc->signing_id.data &&
-        policyProc.signing_id != esProc->signing_id.data) {
+    // If the policy contains a signing ID, check that the instigating process
+    // also has a signing ID and matches the policy.
+    if (!policyProc.signing_id.empty() &&
+        (!esProc->signing_id.data || (policyProc.signing_id != esProc->signing_id.data))) {
       return false;
     }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -423,6 +423,11 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
     XCTAssertTrue([accessClient policyProcess:policyProc matchesESProcess:&esProc]);
     policyProc.signing_id = "badid";
     XCTAssertFalse([accessClient policyProcess:policyProc matchesESProcess:&esProc]);
+    es_process_t esProcEmptySigningID = MakeESProcess(&esFile);
+    esProcEmptySigningID.codesigning_flags = CS_SIGNED;
+    esProcEmptySigningID.team_id.data = NULL;
+    esProcEmptySigningID.team_id.length = 0;
+    XCTAssertFalse([accessClient policyProcess:policyProc matchesESProcess:&esProcEmptySigningID]);
   }
 
   {
@@ -432,6 +437,11 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
     XCTAssertTrue([accessClient policyProcess:policyProc matchesESProcess:&esProc]);
     policyProc.team_id = "badid";
     XCTAssertFalse([accessClient policyProcess:policyProc matchesESProcess:&esProc]);
+    es_process_t esProcEmptyTeamID = MakeESProcess(&esFile);
+    esProcEmptyTeamID.codesigning_flags = CS_SIGNED;
+    esProcEmptyTeamID.signing_id.data = NULL;
+    esProcEmptyTeamID.signing_id.length = 0;
+    XCTAssertFalse([accessClient policyProcess:policyProc matchesESProcess:&esProcEmptyTeamID]);
   }
 
   {

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -22,7 +22,7 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 | ------------------- | ------------ | ---------- | -------- | ----------- |
 | `Version`           | `<Root>`     | String     | Yes      | Version of the configuration. Will be reported in events. |
 | `WatchItems`        | `<Root>`     | Dictionary | No       | The set of configuration items that will be monitored by Santa. |
-| `<Name>`            | `WatchItems` | Dictionary | No       | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (e.g., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
+| `<Name>`            | `WatchItems` | Dictionary | No       | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (i.e., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
 | `Paths`             | `<Name>`     | Array      | Yes      | A list of either String or Dictionary types that contain path globs to monitor. String type entires will have default values applied for the attributes that can be manually set with the Dictionary type. |
 | `Path`              | `Paths`      | String     | Yes      | The path glob to monitor. |
 | `IsPrefix`          | `Paths`      | Boolean    | No       | Whether or not the path glob represents a prefix path. (Default = `false`) |
@@ -146,6 +146,17 @@ All configured paths are case sensitive (i.e., paths specified in both the `Path
 ### Hard Links
 
 Due to platform limitations, it is not feasible for Santa to know all links for a given path. To help mitigate bypasses to this feature, Santa will not allow hard links to be created for monitored paths. If hard links previously existed to monitored paths, Santa cannot guarantee that access to watched resources via these other links will be monitored.
+
+### Symbolic Links
+
+Configured path globs must refer to resolved paths only. It is not supported to monitor access on symbolic links. For example, consider the configured path globs:
+
+```
+PG_1: /var/audit/          [IsPrefix = true]
+PG_2: /private/var/audit/  [IsPrefix = true]
+```
+
+`PG_1` will not match any operations because `/var` is a symbolic link. `PG_2` however is properly configured and will match on access to items in the configured directory.
 
 ## Logging
 


### PR DESCRIPTION
This fixes an issue in 2023.1 related to the new file access monitoring feature. If a rule had a process exception configured with only a Team ID attribute, and a signed instigating process didn't have a Team ID, the process would mistakenly be marked as allowed. (Missing Team IDs are most common on Apple-signed and adhoc-signed binaries.)