### PR TITLE
Rework timeout handling in metrics HTTP writer

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -25,9 +25,7 @@ namespace es = santa::santad::event_providers::endpoint_security;
 namespace santa::santad::logs::endpoint_security::serializers {
 
 Serializer::Serializer() {
-  static SNTConfigurator *configurator = [SNTConfigurator configurator];
-
-  if ([configurator enableMachineIDDecoration]) {
+  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
     enabled_machine_id_ = true;
     machine_id_ = [[[SNTConfigurator configurator] machineID] UTF8String] ?: "";
   }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -25,7 +25,9 @@ namespace es = santa::santad::event_providers::endpoint_security;
 namespace santa::santad::logs::endpoint_security::serializers {
 
 Serializer::Serializer() {
-  if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
+  static SNTConfigurator *configurator = [SNTConfigurator configurator];
+
+  if ([configurator enableMachineIDDecoration]) {
     enabled_machine_id_ = true;
     machine_id_ = [[[SNTConfigurator configurator] machineID] UTF8String] ?: "";
   }

--- a/Source/santametricservice/SNTMetricServiceTest.m
+++ b/Source/santametricservice/SNTMetricServiceTest.m
@@ -129,6 +129,8 @@ NSDictionary *validMetricsDict = nil;
 
   OCMStub([self.mockMOLAuthenticatingURLSession alloc])
     .andReturn(self.mockMOLAuthenticatingURLSession);
+  OCMStub([self.mockMOLAuthenticatingURLSession initWithSessionConfiguration:[OCMArg any]])
+    .andReturn(self.mockMOLAuthenticatingURLSession);
   OCMStub([self.mockMOLAuthenticatingURLSession session]).andReturn(self.mockSession);
 
   NSHTTPURLResponse *response =

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriter.m
@@ -37,8 +37,6 @@
   NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
   config.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
   config.HTTPShouldUsePipelining = YES;
-
-  config.timeoutIntervalForRequest = timeout;
   config.timeoutIntervalForResource = timeout;
 
   MOLAuthenticatingURLSession *session =

--- a/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
+++ b/Source/santametricservice/Writers/SNTMetricHTTPWriterTest.m
@@ -25,6 +25,8 @@
 
   OCMStub([self.mockMOLAuthenticatingURLSession alloc])
     .andReturn(self.mockMOLAuthenticatingURLSession);
+  OCMStub([self.mockMOLAuthenticatingURLSession initWithSessionConfiguration:[OCMArg any]])
+    .andReturn(self.mockMOLAuthenticatingURLSession);
   OCMStub([self.mockMOLAuthenticatingURLSession session]).andReturn(self.mockSession);
 
   self.httpWriter = [[SNTMetricHTTPWriter alloc] init];
@@ -46,6 +48,15 @@
 
   void (^callCompletionHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
     NSDictionary *responseValue = self.mockResponses[0];
+
+    if (responseValue[@"error"] != nil) {
+      OCMExpect([(NSURLSessionDataTask *)self.mockSessionDataTask error])
+        .andReturn(responseValue[@"error"]);
+    } else if (((NSHTTPURLResponse *)responseValue[@"response"]).statusCode != 200) {
+      OCMExpect([(NSURLSessionDataTask *)self.mockSessionDataTask response])
+        .andReturn(responseValue[@"response"]);
+    }
+
     if (responseValue != nil && completionHandler != nil) {
       completionHandler(responseValue[@"data"], responseValue[@"response"],
                         responseValue[@"error"]);


### PR DESCRIPTION
This change reworks how timeouts are enforced to remove the need for any `__block` variables.