### PR TITLE
Small test fixes to make sanitizers happy

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -20,7 +20,7 @@ jobs:
           bazel test --config=${{ matrix.sanitizer }} \
             --test_strategy=exclusive --test_output=errors \
             --test_env=DYLD_INSERT_LIBRARIES=${DYLIB_PATH} \
-            --runs_per_test 10 -t- :unit_tests \
+            --runs_per_test 5 -t- :unit_tests \
             --define=SANTA_BUILD_TYPE=adhoc
       - name: Upload logs
         uses: actions/upload-artifact@v1

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -117,10 +117,10 @@ class MockAuthResultCache : public AuthResultCache {
   {
     SNTEndpointSecurityAuthorizer *authClient =
       [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
-                                                  metrics:nullptr
+                                                   metrics:nullptr
                                             execController:self.mockExecController
                                         compilerController:nil
-                                          authResultCache:nullptr];
+                                           authResultCache:nullptr];
 
     id mockAuthClient = OCMPartialMock(authClient);
 
@@ -154,10 +154,10 @@ class MockAuthResultCache : public AuthResultCache {
   {
     SNTEndpointSecurityAuthorizer *authClient =
       [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
-                                                  metrics:nullptr
+                                                   metrics:nullptr
                                             execController:self.mockExecController
                                         compilerController:nil
-                                          authResultCache:nullptr];
+                                           authResultCache:nullptr];
 
     id mockAuthClient = OCMPartialMock(authClient);
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -104,6 +104,13 @@ class MockAuthResultCache : public AuthResultCache {
 
   // Test unhandled event type
   {
+    SNTEndpointSecurityAuthorizer *authClient =
+      [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
+                                                   metrics:nullptr
+                                            execController:self.mockExecController
+                                        compilerController:nil
+                                           authResultCache:nullptr];
+
     // Temporarily change the event type
     esMsg.event_type = ES_EVENT_TYPE_NOTIFY_EXEC;
     XCTAssertThrows([authClient handleMessage:Message(mockESApi, &esMsg)

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -102,15 +102,6 @@ class MockAuthResultCache : public AuthResultCache {
 
   dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
 
-  SNTEndpointSecurityAuthorizer *authClient =
-    [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
-                                                 metrics:nullptr
-                                          execController:self.mockExecController
-                                      compilerController:nil
-                                         authResultCache:nullptr];
-
-  id mockAuthClient = OCMPartialMock(authClient);
-
   // Test unhandled event type
   {
     // Temporarily change the event type
@@ -124,6 +115,15 @@ class MockAuthResultCache : public AuthResultCache {
 
   // Test SNTExecutionController determines the event shouldn't be processed
   {
+    SNTEndpointSecurityAuthorizer *authClient =
+      [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
+                                                  metrics:nullptr
+                                            execController:self.mockExecController
+                                        compilerController:nil
+                                          authResultCache:nullptr];
+
+    id mockAuthClient = OCMPartialMock(authClient);
+
     Message msg(mockESApi, &esMsg);
 
     OCMExpect([self.mockExecController synchronousShouldProcessExecEvent:msg])
@@ -145,11 +145,22 @@ class MockAuthResultCache : public AuthResultCache {
 
     XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
     XCTAssertTrue(OCMVerifyAll(mockAuthClient));
+
+    [mockAuthClient stopMocking];
   }
 
   // Test SNTExecutionController determines the event should be processed and
   // processMessage:handler: is called.
   {
+    SNTEndpointSecurityAuthorizer *authClient =
+      [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
+                                                  metrics:nullptr
+                                            execController:self.mockExecController
+                                        compilerController:nil
+                                          authResultCache:nullptr];
+
+    id mockAuthClient = OCMPartialMock(authClient);
+
     Message msg(mockESApi, &esMsg);
 
     OCMExpect([self.mockExecController synchronousShouldProcessExecEvent:msg])
@@ -169,11 +180,11 @@ class MockAuthResultCache : public AuthResultCache {
 
     XCTAssertSemaTrue(semaMetrics, 5, "Metrics not recorded within expected window");
     XCTAssertTrue(OCMVerifyAll(mockAuthClient));
+
+    [mockAuthClient stopMocking];
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
-
-  [mockAuthClient stopMocking];
 }
 
 - (void)testProcessMessageWaitThenAllow {

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -369,6 +369,8 @@ using santa::santad::event_providers::endpoint_security::Message;
 
 - (void)testRespondToMessageWithAuthResultCacheable {
   es_message_t esMsg;
+  esMsg.event_type = ES_EVENT_TYPE_AUTH_EXEC;
+
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   mockESApi->SetExpectationsRetainReleaseMessage();
 


### PR DESCRIPTION
* Lower the test count from 10->5 since we're running _just_ over 1 hour and getting killed sometimes
* Set the `event_type` of an `es_message` which was uninitialized causing us to sporadically call `RespondAuthFlags` instead of `RespondAuthResult`. No MSAN for macOS which would have caught this directly :(
* Reinstantiate `mockAuthClient` in each "sub-test" since TSAN sees a data race in mock recording