### PR TITLE
Restart daemon on log type change

### DIFF
--- a/Source/santad/Logs/EndpointSecurity/Logger.h
+++ b/Source/santad/Logs/EndpointSecurity/Logger.h
@@ -65,6 +65,8 @@ class Logger {
     const santa::santad::event_providers::endpoint_security::EnrichedProcess &enriched_process,
     const std::string &target, FileAccessPolicyDecision decision);
 
+  void Flush();
+
   friend class santa::santad::logs::endpoint_security::LoggerPeer;
 
  private:

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -107,4 +107,8 @@ void Logger::LogFileAccess(
                                                   enriched_process, target, decision));
 }
 
+void Logger::Flush() {
+  writer_->Flush();
+}
+
 }  // namespace santa::santad::logs::endpoint_security

--- a/Source/santad/Logs/EndpointSecurity/Writers/File.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.h
@@ -42,13 +42,14 @@ class File : public Writer, public std::enable_shared_from_this<File> {
   ~File();
 
   void Write(std::vector<uint8_t> &&bytes) override;
+  void Flush() override;
 
   friend class santa::santad::logs::endpoint_security::writers::FilePeer;
 
  private:
   void OpenFileHandle();
   void WatchLogFile();
-  void FlushBuffer();
+  void FlushLocked();
   bool ShouldFlush();
 
   void EnsureCapacity(size_t additional_bytes);

--- a/Source/santad/Logs/EndpointSecurity/Writers/File.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.h
@@ -47,13 +47,13 @@ class File : public Writer, public std::enable_shared_from_this<File> {
   friend class santa::santad::logs::endpoint_security::writers::FilePeer;
 
  private:
-  void OpenFileHandle();
+  void OpenFileHandleLocked();
   void WatchLogFile();
   void FlushLocked();
   bool ShouldFlush();
 
-  void EnsureCapacity(size_t additional_bytes);
-  void CopyData(const std::vector<uint8_t> &bytes);
+  void EnsureCapacityLocked(size_t additional_bytes);
+  void CopyDataLocked(const std::vector<uint8_t> &bytes);
 
   std::vector<uint8_t> buffer_;
   size_t batch_size_bytes_;

--- a/Source/santad/Logs/EndpointSecurity/Writers/File.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.mm
@@ -55,7 +55,7 @@ File::File(NSString *path, size_t batch_size_bytes, size_t max_expected_write_si
       timer_source_(timer_source),
       watch_source_(nullptr) {
   path_ = path;
-  OpenFileHandle();
+  OpenFileHandleLocked();
 }
 
 void File::WatchLogFile() {
@@ -69,7 +69,7 @@ void File::WatchLogFile() {
   auto shared_this = shared_from_this();
   dispatch_source_set_event_handler(watch_source_, ^{
     [shared_this->file_handle_ closeFile];
-    shared_this->OpenFileHandle();
+    shared_this->OpenFileHandleLocked();
     shared_this->WatchLogFile();
   });
 
@@ -83,7 +83,7 @@ File::~File() {
 }
 
 // IMPORTANT: Not thread safe.
-void File::OpenFileHandle() {
+void File::OpenFileHandleLocked() {
   NSFileManager *fm = [NSFileManager defaultManager];
   if (![fm fileExistsAtPath:path_]) {
     [fm createFileAtPath:path_ contents:nil attributes:nil];
@@ -101,7 +101,7 @@ void File::Write(std::vector<uint8_t> &&bytes) {
   dispatch_async(q_, ^{
     std::vector<uint8_t> moved_bytes = std::move(temp_bytes);
 
-    shared_this->CopyData(moved_bytes);
+    shared_this->CopyDataLocked(moved_bytes);
 
     if (shared_this->ShouldFlush()) {
       shared_this->FlushLocked();
@@ -120,15 +120,15 @@ void File::Flush() {
 }
 
 // IMPORTANT: Not thread safe.
-void File::EnsureCapacity(size_t additional_bytes) {
+void File::EnsureCapacityLocked(size_t additional_bytes) {
   if ((buffer_offset_ + additional_bytes) > buffer_.capacity()) {
     buffer_.resize(buffer_.capacity() * 2);
   }
 }
 
 // IMPORTANT: Not thread safe.
-void File::CopyData(const std::vector<uint8_t> &bytes) {
-  EnsureCapacity(bytes.size());
+void File::CopyDataLocked(const std::vector<uint8_t> &bytes) {
+  EnsureCapacityLocked(bytes.size());
   std::copy(bytes.begin(), bytes.end(), buffer_.begin() + buffer_offset_);
   buffer_offset_ += bytes.size();
 }

--- a/Source/santad/Logs/EndpointSecurity/Writers/Null.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Null.h
@@ -28,6 +28,7 @@ class Null : public Writer {
   static std::shared_ptr<Null> Create();
 
   void Write(std::vector<uint8_t>&& bytes) override;
+  void Flush() override;
 };
 
 }  // namespace santa::santad::logs::endpoint_security::writers

--- a/Source/santad/Logs/EndpointSecurity/Writers/Null.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Null.mm
@@ -24,4 +24,8 @@ void Null::Write(std::vector<uint8_t> &&bytes) {
   // Intentionally do nothing
 }
 
+void Null::Flush() {
+  // Intentionally do nothing
+}
+
 }  // namespace santa::santad::logs::endpoint_security::writers

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
@@ -46,7 +46,7 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   ~Spool();
 
   void Write(std::vector<uint8_t> &&bytes) override;
-  bool Flush();
+  void Flush() override;
 
   void BeginFlushTask();
 
@@ -54,6 +54,8 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   friend class santa::santad::logs::endpoint_security::writers::SpoolPeer;
 
  private:
+  bool FlushLocked();
+
   dispatch_queue_t q_ = NULL;
   dispatch_source_t timer_source_ = NULL;
   ::fsspool::FsSpoolWriter spool_writer_;

--- a/Source/santad/Logs/EndpointSecurity/Writers/SpoolTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/SpoolTest.mm
@@ -28,6 +28,7 @@ namespace santa::santad::logs::endpoint_security::writers {
 class SpoolPeer : public Spool {
  public:
   // Make constructors visible
+  using Spool::FlushLocked;
   using Spool::Spool;
 
   std::string GetTypeUrl() { return type_url_; }
@@ -123,7 +124,7 @@ using santa::santad::logs::endpoint_security::writers::SpoolPeer;
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:&err] count], 0);
 
   // Manual Flush
-  XCTAssertTrue(spool->Flush());
+  XCTAssertTrue(spool->FlushLocked());
 
   // A new log entry should exist
   XCTAssertEqual([[self.fileMgr contentsOfDirectoryAtPath:self.spoolDir error:&err] count], 1);

--- a/Source/santad/Logs/EndpointSecurity/Writers/Syslog.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Syslog.h
@@ -26,6 +26,7 @@ class Syslog : public Writer {
   static std::shared_ptr<Syslog> Create();
 
   void Write(std::vector<uint8_t>&& bytes) override;
+  void Flush() override;
 };
 
 }  // namespace santa::santad::logs::endpoint_security::writers

--- a/Source/santad/Logs/EndpointSecurity/Writers/Syslog.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Syslog.mm
@@ -26,4 +26,8 @@ void Syslog::Write(std::vector<uint8_t> &&bytes) {
   os_log(OS_LOG_DEFAULT, "%{public}s", bytes.data());
 }
 
+void Syslog::Flush() {
+  // Nothing to do here
+}
+
 }  // namespace santa::santad::logs::endpoint_security::writers

--- a/Source/santad/Logs/EndpointSecurity/Writers/Writer.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Writer.h
@@ -24,6 +24,7 @@ class Writer {
   virtual ~Writer() = default;
 
   virtual void Write(std::vector<uint8_t>&& bytes) = 0;
+  virtual void Flush() = 0;
 };
 
 }  // namespace santa::santad::logs::endpoint_security::writers

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -39,6 +39,7 @@ extern NSString *const EventDispositionToString(EventDisposition d);
 class MetricsPeer : public Metrics {
  public:
   // Make base class constructors visible
+  using Metrics::FlushMetrics;
   using Metrics::Metrics;
 
   bool IsRunning() { return running_; }
@@ -72,7 +73,7 @@ using santa::santad::ProcessorToString;
 - (void)testStartStop {
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
   auto metrics =
-    std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil, ^(santa::santad::Metrics *m) {
+    std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil, nil, ^(santa::santad::Metrics *m) {
       dispatch_semaphore_signal(self.sema);
     });
 
@@ -107,7 +108,7 @@ using santa::santad::ProcessorToString;
 
 - (void)testSetInterval {
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil,
+  auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil, nil,
                                                ^(santa::santad::Metrics *m){
                                                });
 
@@ -181,7 +182,7 @@ using santa::santad::ProcessorToString;
   int64_t nanos = 1234;
 
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil,
+  auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, nil, nil, nil,
                                                ^(santa::santad::Metrics *m){
                                                  // This block intentionally left blank
                                                });
@@ -238,11 +239,11 @@ using santa::santad::ProcessorToString;
     });
 
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.q);
-  auto metrics =
-    std::make_shared<MetricsPeer>(self.q, timer, 100, mockEventProcessingTimes, mockEventCounts,
-                                  ^(santa::santad::Metrics *m){
-                                    // This block intentionally left blank
-                                  });
+  auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, mockEventProcessingTimes,
+                                               mockEventCounts, nil,
+                                               ^(santa::santad::Metrics *m){
+                                                 // This block intentionally left blank
+                                               });
 
   metrics->SetEventMetrics(Processor::kAuthorizer, ES_EVENT_TYPE_AUTH_EXEC,
                            EventDisposition::kProcessed, nanos);

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -310,6 +310,22 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                    LOGI(@"StaticRules set has changed, flushing cache.");
                                    auth_result_cache->FlushCache(FlushCacheMode::kAllCaches);
                                  }],
+    [[SNTKVOManager alloc] initWithObject:configurator
+                                 selector:@selector(eventLogType)
+                                     type:[NSNumber class]
+                                 callback:^(NSNumber *oldValue, NSNumber *newValue) {
+                                   NSInteger oldLogType = [oldValue integerValue];
+                                   NSInteger newLogType = [newValue integerValue];
+
+                                   if (oldLogType == newLogType) {
+                                     return;
+                                   }
+
+                                   LOGW(@"EventLogType config changed (%ld --> %ld). Restarting...",
+                                        oldLogType, newLogType);
+
+                                   metrics->Export();
+                                 }],
   ];
 
   // Make the compiler happy. The variable is only used to ensure proper lifetime

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -14,6 +14,7 @@
 
 #include "Source/santad/Santad.h"
 
+#include <cstdlib>
 #include <memory>
 
 #include "Source/common/PrefixTree.h"
@@ -310,22 +311,36 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
                                    LOGI(@"StaticRules set has changed, flushing cache.");
                                    auth_result_cache->FlushCache(FlushCacheMode::kAllCaches);
                                  }],
-    [[SNTKVOManager alloc] initWithObject:configurator
-                                 selector:@selector(eventLogType)
-                                     type:[NSNumber class]
-                                 callback:^(NSNumber *oldValue, NSNumber *newValue) {
-                                   NSInteger oldLogType = [oldValue integerValue];
-                                   NSInteger newLogType = [newValue integerValue];
+    [[SNTKVOManager alloc]
+      initWithObject:configurator
+            selector:@selector(eventLogType)
+                type:[NSNumber class]
+            callback:^(NSNumber *oldValue, NSNumber *newValue) {
+              NSInteger oldLogType = [oldValue integerValue];
+              NSInteger newLogType = [newValue integerValue];
 
-                                   if (oldLogType == newLogType) {
-                                     return;
-                                   }
+              if (oldLogType == newLogType) {
+                return;
+              }
 
-                                   LOGW(@"EventLogType config changed (%ld --> %ld). Restarting...",
-                                        oldLogType, newLogType);
+              LOGW(@"EventLogType config changed (%ld --> %ld). Restarting...", oldLogType,
+                   newLogType);
 
-                                   metrics->Export();
-                                 }],
+              dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+              dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                logger->Flush();
+                metrics->Export();
+
+                dispatch_semaphore_signal(sema);
+              });
+
+              // Wait for a short amount of time for outstanding data to flush
+              dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+
+              // Forcefully exit. The daemon will be restarted immediately.
+              exit(EXIT_SUCCESS);
+            }],
   ];
 
   // Make the compiler happy. The variable is only used to ensure proper lifetime


### PR DESCRIPTION
This change adds basic support for handling a change to the `EventLogType` configuration key. This change does not attempt to change the logger on a live instance due to complexities of swapping out the components in a memory-safe manner. However an attempt is made to flush any outstanding log data and metrics before exiting/restarting.