### PR TITLE
santactl & syncservice: Use synchronousRemoteObjectProxy where it makes sense

### DIFF
--- a/Source/santactl/Commands/SNTCommandCheckCache.m
+++ b/Source/santactl/Commands/SNTCommandCheckCache.m
@@ -40,27 +40,27 @@ REGISTER_COMMAND_NAME(@"checkcache")
 }
 
 + (NSString *)shortHelpText {
-  return @"Prints the status of a file in the kernel cache.";
+  return @"Prints the status of a file in the cache.";
 }
 
 + (NSString *)longHelpText {
-  return (@"Checks the in-kernel cache for desired file.\n"
+  return (@"Checks the cache for desired file.\n"
           @"Returns 0 if successful, 1 otherwise");
 }
 
 - (void)runWithArguments:(NSArray *)arguments {
   SantaVnode vnodeID = [self vnodeIDForFile:arguments.firstObject];
-  [[self.daemonConn remoteObjectProxy]
+  [[self.daemonConn synchronousRemoteObjectProxy]
     checkCacheForVnodeID:vnodeID
                withReply:^(SNTAction action) {
                  if (action == SNTActionRespondAllow) {
-                   LOGI(@"File exists in [allowlist] kernel cache");
+                   LOGI(@"File exists in [allowlist] cache");
                    exit(0);
                  } else if (action == SNTActionRespondDeny) {
-                   LOGI(@"File exists in [blocklist] kernel cache");
+                   LOGI(@"File exists in [blocklist] cache");
                    exit(0);
                  } else if (action == SNTActionRespondAllowCompiler) {
-                   LOGI(@"File exists in [allowlist compiler] kernel cache");
+                   LOGI(@"File exists in [allowlist compiler] cache");
                    exit(0);
                  } else if (action == SNTActionUnset) {
                    LOGE(@"File does not exist in cache");

--- a/Source/santactl/Commands/SNTCommandMetrics.m
+++ b/Source/santactl/Commands/SNTCommandMetrics.m
@@ -166,18 +166,9 @@ REGISTER_COMMAND_NAME(@"metrics")
 - (void)runWithArguments:(NSArray *)arguments {
   __block NSDictionary *metrics;
 
-  dispatch_group_t group = dispatch_group_create();
-  dispatch_group_enter(group);
-
-  [[self.daemonConn remoteObjectProxy] metrics:^(NSDictionary *exportedMetrics) {
+  [[self.daemonConn synchronousRemoteObjectProxy] metrics:^(NSDictionary *exportedMetrics) {
     metrics = exportedMetrics;
-    dispatch_group_leave(group);
   }];
-
-  // Wait a maximum of 5s for metrics collected from daemon to arrive.
-  if (dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5))) {
-    fprintf(stderr, "Failed to retrieve metrics from daemon\n\n");
-  }
 
   metrics = [self filterMetrics:metrics withArguments:arguments];
 

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -46,28 +46,26 @@ REGISTER_COMMAND_NAME(@"status")
 
 - (void)runWithArguments:(NSArray *)arguments {
   dispatch_group_t group = dispatch_group_create();
+  id<SNTDaemonControlXPC> rop = [self.daemonConn synchronousRemoteObjectProxy];
 
   // Daemon status
   __block NSString *clientMode;
   __block uint64_t cpuEvents, ramEvents;
   __block double cpuPeak, ramPeak;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] clientMode:^(SNTClientMode cm) {
+  [rop clientMode:^(SNTClientMode cm) {
     switch (cm) {
       case SNTClientModeMonitor: clientMode = @"Monitor"; break;
       case SNTClientModeLockdown: clientMode = @"Lockdown"; break;
       default: clientMode = [NSString stringWithFormat:@"Unknown (%ld)", cm]; break;
     }
-    dispatch_group_leave(group);
   }];
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] watchdogInfo:^(uint64_t wd_cpuEvents, uint64_t wd_ramEvents,
-                                                      double wd_cpuPeak, double wd_ramPeak) {
+
+  [rop watchdogInfo:^(uint64_t wd_cpuEvents, uint64_t wd_ramEvents, double wd_cpuPeak,
+                      double wd_ramPeak) {
     cpuEvents = wd_cpuEvents;
     cpuPeak = wd_cpuPeak;
     ramEvents = wd_ramEvents;
     ramPeak = wd_ramPeak;
-    dispatch_group_leave(group);
   }];
 
   BOOL fileLogging = ([[SNTConfigurator configurator] fileChangesRegex] != nil);
@@ -76,86 +74,65 @@ REGISTER_COMMAND_NAME(@"status")
 
   // Cache status
   __block uint64_t rootCacheCount = -1, nonRootCacheCount = -1;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] cacheCounts:^(uint64_t rootCache, uint64_t nonRootCache) {
+  [rop cacheCounts:^(uint64_t rootCache, uint64_t nonRootCache) {
     rootCacheCount = rootCache;
     nonRootCacheCount = nonRootCache;
-    dispatch_group_leave(group);
   }];
 
   // Database counts
   __block int64_t eventCount = -1, binaryRuleCount = -1, certRuleCount = -1, teamIDRuleCount = -1;
   __block int64_t compilerRuleCount = -1, transitiveRuleCount = -1;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy]
-    databaseRuleCounts:^(int64_t binary, int64_t certificate, int64_t compiler, int64_t transitive,
-                         int64_t teamID) {
-      binaryRuleCount = binary;
-      certRuleCount = certificate;
-      teamIDRuleCount = teamID;
-      compilerRuleCount = compiler;
-      transitiveRuleCount = transitive;
-      dispatch_group_leave(group);
-    }];
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] databaseEventCount:^(int64_t count) {
+  [rop databaseRuleCounts:^(int64_t binary, int64_t certificate, int64_t compiler,
+                            int64_t transitive, int64_t teamID) {
+    binaryRuleCount = binary;
+    certRuleCount = certificate;
+    teamIDRuleCount = teamID;
+    compilerRuleCount = compiler;
+    transitiveRuleCount = transitive;
+  }];
+  [rop databaseEventCount:^(int64_t count) {
     eventCount = count;
-    dispatch_group_leave(group);
   }];
 
   // Static rule count
   __block int64_t staticRuleCount = -1;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] staticRuleCount:^(int64_t count) {
+  [rop staticRuleCount:^(int64_t count) {
     staticRuleCount = count;
-    dispatch_group_leave(group);
   }];
 
   // Sync status
   __block NSDate *fullSyncLastSuccess;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] fullSyncLastSuccess:^(NSDate *date) {
+  [rop fullSyncLastSuccess:^(NSDate *date) {
     fullSyncLastSuccess = date;
-    dispatch_group_leave(group);
   }];
 
   __block NSDate *ruleSyncLastSuccess;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] ruleSyncLastSuccess:^(NSDate *date) {
+  [rop ruleSyncLastSuccess:^(NSDate *date) {
     ruleSyncLastSuccess = date;
-    dispatch_group_leave(group);
   }];
 
   __block BOOL syncCleanReqd = NO;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] syncCleanRequired:^(BOOL clean) {
+  [rop syncCleanRequired:^(BOOL clean) {
     syncCleanReqd = clean;
-    dispatch_group_leave(group);
   }];
 
   __block BOOL pushNotifications = NO;
   if ([[SNTConfigurator configurator] syncBaseURL]) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] pushNotifications:^(BOOL response) {
+    [rop pushNotifications:^(BOOL response) {
       pushNotifications = response;
-      dispatch_group_leave(group);
     }];
   }
 
   __block BOOL enableBundles = NO;
   if ([[SNTConfigurator configurator] syncBaseURL]) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] enableBundles:^(BOOL response) {
+    [rop enableBundles:^(BOOL response) {
       enableBundles = response;
-      dispatch_group_leave(group);
     }];
   }
 
   __block BOOL enableTransitiveRules = NO;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] enableTransitiveRules:^(BOOL response) {
+  [rop enableTransitiveRules:^(BOOL response) {
     enableTransitiveRules = response;
-    dispatch_group_leave(group);
   }];
 
   __block BOOL watchItemsEnabled = NO;
@@ -163,20 +140,16 @@ REGISTER_COMMAND_NAME(@"status")
   __block NSString *watchItemsPolicyVersion = nil;
   __block NSString *watchItemsConfigPath = nil;
   __block NSTimeInterval watchItemsLastUpdateEpoch = 0;
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy]
-    watchItemsState:^(BOOL enabled, uint64_t ruleCount, NSString *policyVersion,
-                      NSString *configPath, NSTimeInterval lastUpdateEpoch) {
-      watchItemsEnabled = enabled;
-      if (enabled) {
-        watchItemsRuleCount = ruleCount;
-        watchItemsPolicyVersion = policyVersion;
-        watchItemsConfigPath = configPath;
-        watchItemsLastUpdateEpoch = lastUpdateEpoch;
-      }
-
-      dispatch_group_leave(group);
-    }];
+  [rop watchItemsState:^(BOOL enabled, uint64_t ruleCount, NSString *policyVersion,
+                         NSString *configPath, NSTimeInterval lastUpdateEpoch) {
+    watchItemsEnabled = enabled;
+    if (enabled) {
+      watchItemsRuleCount = ruleCount;
+      watchItemsPolicyVersion = policyVersion;
+      watchItemsConfigPath = configPath;
+      watchItemsLastUpdateEpoch = lastUpdateEpoch;
+    }
+  }];
 
   // Wait a maximum of 5s for stats collected from daemon to arrive.
   if (dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5))) {

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -77,7 +77,7 @@ double watchdogRAMPeak = 0;
   return self;
 }
 
-#pragma mark Kernel ops
+#pragma mark Cache ops
 
 - (void)cacheCounts:(void (^)(uint64_t, uint64_t))reply {
   NSArray<NSNumber *> *counts = self->_authResultCache->CacheCounts();

--- a/Source/santasyncservice/SNTSyncPostflight.m
+++ b/Source/santasyncservice/SNTSyncPostflight.m
@@ -30,52 +30,49 @@
 - (BOOL)sync {
   [self performRequest:[self requestWithDictionary:nil]];
 
-  dispatch_group_t group = dispatch_group_create();
-  void (^replyBlock)(void) = ^{
-    dispatch_group_leave(group);
-  };
+  id<SNTDaemonControlXPC> rop = [self.daemonConn synchronousRemoteObjectProxy];
 
   // Set client mode if it changed
   if (self.syncState.clientMode) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setClientMode:self.syncState.clientMode reply:replyBlock];
+    [rop setClientMode:self.syncState.clientMode
+                 reply:^{
+                 }];
   }
 
   // Remove clean sync flag if we did a clean sync
   if (self.syncState.cleanSync) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setSyncCleanRequired:NO reply:replyBlock];
+    [rop setSyncCleanRequired:NO
+                        reply:^{
+                        }];
   }
 
   // Update allowlist/blocklist regexes
   if (self.syncState.allowlistRegex) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setAllowedPathRegex:self.syncState.allowlistRegex
-                                                       reply:replyBlock];
+    [rop setAllowedPathRegex:self.syncState.allowlistRegex
+                       reply:^{
+                       }];
   }
   if (self.syncState.blocklistRegex) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setBlockedPathRegex:self.syncState.blocklistRegex
-                                                       reply:replyBlock];
+    [rop setBlockedPathRegex:self.syncState.blocklistRegex
+                       reply:^{
+                       }];
   }
 
   if (self.syncState.blockUSBMount != nil) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setBlockUSBMount:[self.syncState.blockUSBMount boolValue]
-                                                    reply:replyBlock];
+    [rop setBlockUSBMount:[self.syncState.blockUSBMount boolValue]
+                    reply:^{
+                    }];
   }
   if (self.syncState.remountUSBMode) {
-    dispatch_group_enter(group);
-    [[self.daemonConn remoteObjectProxy] setRemountUSBMode:self.syncState.remountUSBMode
-                                                     reply:replyBlock];
+    [rop setRemountUSBMode:self.syncState.remountUSBMode
+                     reply:^{
+                     }];
   }
 
   // Update last sync success
-  dispatch_group_enter(group);
-  [[self.daemonConn remoteObjectProxy] setFullSyncLastSuccess:[NSDate date] reply:replyBlock];
-
-  // Wait for dispatch group
-  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+  [rop setFullSyncLastSuccess:[NSDate date]
+                        reply:^{
+                        }];
 
   return YES;
 }

--- a/Source/santasyncservice/SNTSyncTest.m
+++ b/Source/santasyncservice/SNTSyncTest.m
@@ -53,6 +53,7 @@
   self.syncState.daemonConn = OCMClassMock([MOLXPCConnection class]);
   self.daemonConnRop = OCMProtocolMock(@protocol(SNTDaemonControlXPC));
   OCMStub([self.syncState.daemonConn remoteObjectProxy]).andReturn(self.daemonConnRop);
+  OCMStub([self.syncState.daemonConn synchronousRemoteObjectProxy]).andReturn(self.daemonConnRop);
 
   self.syncState.session = OCMClassMock([NSURLSession class]);
 


### PR DESCRIPTION
Sadly, clang-format insists on empty blocks spanning multiple lines otherwise this would look a _lot_ cleaner.