### PR TITLE
Replace SNTDecisionCache dictionary with SantaCache

### DIFF
--- a/Source/common/SantaVnode.h
+++ b/Source/common/SantaVnode.h
@@ -28,11 +28,15 @@ typedef struct SantaVnode {
     return fsid == rhs.fsid && fileid == rhs.fileid;
   }
 
-  static inline SantaVnode VnodeForFile(const es_file_t *es_file) {
+  static inline SantaVnode VnodeForFile(const struct stat &sb) {
     return SantaVnode{
-        .fsid = es_file->stat.st_dev,
-        .fileid = es_file->stat.st_ino,
+        .fsid = sb.st_dev,
+        .fileid = sb.st_ino,
     };
+  }
+
+  static inline SantaVnode VnodeForFile(const es_file_t *es_file) {
+    return VnodeForFile(es_file->stat);
   }
 #endif
 } SantaVnode;

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -137,6 +137,9 @@ objc_library(
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTRule",
+        "//Source/common:SantaCache",
+        "//Source/common:SantaVnode",
+        "//Source/common:SantaVnodeHash",
     ],
 )
 
@@ -409,6 +412,7 @@ objc_library(
         ":EndpointSecurityEnrichedTypes",
         ":EndpointSecurityMessage",
         ":SNTDecisionCache",
+        "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
     ],
@@ -437,6 +441,7 @@ objc_library(
     hdrs = ["Logs/EndpointSecurity/Serializers/Empty.h"],
     deps = [
         ":EndpointSecuritySerializer",
+        "//Source/common:SNTCachedDecision",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <vector>
 
+#import "Source/common/SNTCachedDecision.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
@@ -41,7 +42,8 @@ class BasicString : public Serializer {
   std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExchange &) override;
   std::vector<uint8_t> SerializeMessage(
-    const santa::santad::event_providers::endpoint_security::EnrichedExec &) override;
+    const santa::santad::event_providers::endpoint_security::EnrichedExec &,
+    SNTCachedDecision *) override;
   std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExit &) override;
   std::vector<uint8_t> SerializeMessage(

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -241,15 +241,12 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExchange &msg) 
   return FinalizeString(str);
 }
 
-std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExec &msg) {
+std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExec &msg, SNTCachedDecision *cd) {
   const es_message_t &esm = msg.es_msg();
   std::string str = CreateDefaultString(1024);  // EXECs tend to be bigger, reserve more space.
 
   // Only need to grab the shared instance once
   static SNTConfigurator *configurator = [SNTConfigurator configurator];
-
-  SNTCachedDecision *cd =
-    [[SNTDecisionCache sharedCache] cachedDecisionForFile:esm.event.exec.target->executable->stat];
 
   str.append("action=EXEC|decision=");
   str.append(GetDecisionString(cd.decision));

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -97,7 +97,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
 
   self.mockDecisionCache = OCMClassMock([SNTDecisionCache class]);
   OCMStub([self.mockDecisionCache sharedCache]).andReturn(self.mockDecisionCache);
-  OCMStub([self.mockDecisionCache cachedDecisionForFile:{}])
+  OCMStub([self.mockDecisionCache resetTimestampForCachedDecision:{}])
     .ignoringNonObjectArgs()
     .andReturn(self.testCachedDecision);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <vector>
 
+#include "Source/common/SNTCachedDecision.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
 namespace santa::santad::logs::endpoint_security::serializers {
@@ -33,7 +34,8 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExchange &) override;
   std::vector<uint8_t> SerializeMessage(
-    const santa::santad::event_providers::endpoint_security::EnrichedExec &) override;
+    const santa::santad::event_providers::endpoint_security::EnrichedExec &,
+    SNTCachedDecision *) override;
   std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExit &) override;
   std::vector<uint8_t> SerializeMessage(

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -39,7 +39,7 @@ std::vector<uint8_t> Empty::SerializeMessage(const EnrichedExchange &msg) {
   return {};
 }
 
-std::vector<uint8_t> Empty::SerializeMessage(const EnrichedExec &msg) {
+std::vector<uint8_t> Empty::SerializeMessage(const EnrichedExec &msg, SNTCachedDecision *cd) {
   return {};
 }
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/EmptyTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/EmptyTest.mm
@@ -37,7 +37,7 @@ namespace es = santa::santad::event_providers::endpoint_security;
   int fake;
   XCTAssertEqual(e->SerializeMessage(*(es::EnrichedClose *)&fake).size(), 0);
   XCTAssertEqual(e->SerializeMessage(*(es::EnrichedExchange *)&fake).size(), 0);
-  XCTAssertEqual(e->SerializeMessage(*(es::EnrichedExec *)&fake).size(), 0);
+  XCTAssertEqual(e->SerializeMessage(*(es::EnrichedExec *)&fake, nil).size(), 0);
   XCTAssertEqual(e->SerializeMessage(*(es::EnrichedExit *)&fake).size(), 0);
   XCTAssertEqual(e->SerializeMessage(*(es::EnrichedFork *)&fake).size(), 0);
   XCTAssertEqual(e->SerializeMessage(*(es::EnrichedLink *)&fake).size(), 0);

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#import "Source/common/SNTCachedDecision.h"
 #include "Source/common/santa_proto_include_wrapper.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
@@ -40,7 +41,8 @@ class Protobuf : public Serializer {
   std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExchange &) override;
   std::vector<uint8_t> SerializeMessage(
-    const santa::santad::event_providers::endpoint_security::EnrichedExec &) override;
+    const santa::santad::event_providers::endpoint_security::EnrichedExec &,
+    SNTCachedDecision *) override;
   std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExit &) override;
   std::vector<uint8_t> SerializeMessage(

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -418,15 +418,12 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExchange &msg) {
   return FinalizeProto(santa_msg);
 }
 
-std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg) {
+std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg, SNTCachedDecision *cd) {
   Arena arena;
   ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena, msg);
 
   // Only need to grab the shared instance once
   static SNTConfigurator *configurator = [SNTConfigurator configurator];
-
-  SNTCachedDecision *cd = [[SNTDecisionCache sharedCache]
-    cachedDecisionForFile:msg.es_msg().event.exec.target->executable->stat];
 
   GetDecisionEnum(cd.decision);
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -283,7 +283,7 @@ void SerializeAndCheckNonESEvents(
 
   self.mockDecisionCache = OCMClassMock([SNTDecisionCache class]);
   OCMStub([self.mockDecisionCache sharedCache]).andReturn(self.mockDecisionCache);
-  OCMStub([self.mockDecisionCache cachedDecisionForFile:{}])
+  OCMStub([self.mockDecisionCache resetTimestampForCachedDecision:{}])
     .ignoringNonObjectArgs()
     .andReturn(self.testCachedDecision);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -15,11 +15,12 @@
 #ifndef SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_SERIALIZER_H
 #define SANTA__SANTAD__LOGS_ENDPOINTSECURITY_SERIALIZERS_SERIALIZER_H
 
+#import <Foundation/Foundation.h>
+
 #include <memory>
 #include <vector>
 
-#import <Foundation/Foundation.h>
-
+#import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTCommonEnums.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 
@@ -46,7 +47,8 @@ class Serializer {
   virtual std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExchange &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(
-    const santa::santad::event_providers::endpoint_security::EnrichedExec &) = 0;
+    const santa::santad::event_providers::endpoint_security::EnrichedExec &,
+    SNTCachedDecision *cd) = 0;
   virtual std::vector<uint8_t> SerializeMessage(
     const santa::santad::event_providers::endpoint_security::EnrichedExit &) = 0;
   virtual std::vector<uint8_t> SerializeMessage(

--- a/Source/santad/SNTDecisionCache.h
+++ b/Source/santad/SNTDecisionCache.h
@@ -25,6 +25,6 @@
 - (void)cacheDecision:(SNTCachedDecision *)cd;
 - (SNTCachedDecision *)cachedDecisionForFile:(const struct stat &)statInfo;
 - (void)forgetCachedDecisionForFile:(const struct stat &)statInfo;
-- (void)resetTimestampForCachedDecision:(const struct stat &)statInfo;
+- (SNTCachedDecision *)resetTimestampForCachedDecision:(const struct stat &)statInfo;
 
 @end

--- a/Source/santad/SNTDecisionCache.mm
+++ b/Source/santad/SNTDecisionCache.mm
@@ -24,7 +24,6 @@
 #import "Source/santad/SNTDatabaseController.h"
 
 @interface SNTDecisionCache ()
-@property dispatch_queue_t detailStoreQueue;
 // Cache for sha256 -> date of last timestamp reset.
 @property NSCache<NSString *, NSDate *> *timestampResetMap;
 @end
@@ -45,15 +44,6 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    // TODO(mlw): We should protect this structure with a read/write lock
-    // instead of a serial dispatch queue since it's expected that most most
-    // accesses will be lookups, not caching new items.
-    // _detailStore = [NSMutableDictionary dictionaryWithCapacity:1000];
-    _detailStoreQueue = dispatch_queue_create(
-      "com.google.santa.daemon.detail_store",
-      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
-                                              QOS_CLASS_USER_INTERACTIVE, 0));
-
     _timestampResetMap = [[NSCache alloc] init];
     _timestampResetMap.countLimit = 100;
   }

--- a/Source/santad/SNTDecisionCache.mm
+++ b/Source/santad/SNTDecisionCache.mm
@@ -17,17 +17,21 @@
 #include <dispatch/dispatch.h>
 
 #import "Source/common/SNTRule.h"
+#include "Source/common/SantaCache.h"
+#include "Source/common/SantaVnode.h"
+#include "Source/common/SantaVnodeHash.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTDatabaseController.h"
 
 @interface SNTDecisionCache ()
-@property NSMutableDictionary<NSNumber *, SNTCachedDecision *> *detailStore;
 @property dispatch_queue_t detailStoreQueue;
 // Cache for sha256 -> date of last timestamp reset.
 @property NSCache<NSString *, NSDate *> *timestampResetMap;
 @end
 
-@implementation SNTDecisionCache
+@implementation SNTDecisionCache {
+  SantaCache<SantaVnode, SNTCachedDecision *> _decisionCache;
+}
 
 + (instancetype)sharedCache {
   static SNTDecisionCache *cache;
@@ -44,7 +48,7 @@
     // TODO(mlw): We should protect this structure with a read/write lock
     // instead of a serial dispatch queue since it's expected that most most
     // accesses will be lookups, not caching new items.
-    _detailStore = [NSMutableDictionary dictionaryWithCapacity:1000];
+    // _detailStore = [NSMutableDictionary dictionaryWithCapacity:1000];
     _detailStoreQueue = dispatch_queue_create(
       "com.google.santa.daemon.detail_store",
       dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
@@ -57,32 +61,24 @@
 }
 
 - (void)cacheDecision:(SNTCachedDecision *)cd {
-  dispatch_sync(self.detailStoreQueue, ^{
-    self.detailStore[@(cd.vnodeId.fileid)] = cd;
-  });
+  self->_decisionCache.set(cd.vnodeId, cd);
 }
 
 - (SNTCachedDecision *)cachedDecisionForFile:(const struct stat &)statInfo {
-  __block SNTCachedDecision *cd;
-  dispatch_sync(self.detailStoreQueue, ^{
-    cd = self.detailStore[@(statInfo.st_ino)];
-  });
-  return cd;
+  return self->_decisionCache.get(SantaVnode::VnodeForFile(statInfo));
 }
 
 - (void)forgetCachedDecisionForFile:(const struct stat &)statInfo {
-  dispatch_sync(self.detailStoreQueue, ^{
-    [self.detailStore removeObjectForKey:@(statInfo.st_ino)];
-  });
+  self->_decisionCache.remove(SantaVnode::VnodeForFile(statInfo));
 }
 
 // Whenever a cached decision resulting from a transitive allowlist rule is used to allow the
 // execution of a binary, we update the timestamp on the transitive rule in the rules database.
 // To prevent writing to the database too often, we space out consecutive writes by 3600 seconds.
-- (void)resetTimestampForCachedDecision:(const struct stat &)statInfo {
+- (SNTCachedDecision *)resetTimestampForCachedDecision:(const struct stat &)statInfo {
   SNTCachedDecision *cd = [self cachedDecisionForFile:statInfo];
   if (!cd || cd.decision != SNTEventStateAllowTransitive || !cd.sha256) {
-    return;
+    return cd;
   }
 
   NSDate *lastUpdate = [self.timestampResetMap objectForKey:cd.sha256];
@@ -94,6 +90,8 @@
     [[SNTDatabaseController ruleTable] resetTimestampForRule:rule];
     [self.timestampResetMap setObject:[NSDate date] forKey:cd.sha256];
   }
+
+  return cd;
 }
 
 @end

--- a/Source/santad/SNTDecisionCacheTest.mm
+++ b/Source/santad/SNTDecisionCacheTest.mm
@@ -32,7 +32,7 @@ SNTCachedDecision *MakeCachedDecision(struct stat sb, SNTEventState decision) {
   cd.decision = decision;
   cd.sha256 = @"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
   cd.vnodeId = {
-    .fsid = 0,
+    .fsid = sb.st_dev,
     .fileid = sb.st_ino,
   };
 


### PR DESCRIPTION
CPU traces were showing a lot of contention in the dispatch blocks synchronizing access to the dictionary. This helps relieve the contention. Also removes a second lookup for a cached decision that was previously necessary on the EXEC logging path.