### PR TITLE
Clear ES cache when watch items change

### DIFF
--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -614,6 +614,8 @@ void WatchItems::UpdateCurrentState(
 
     last_update_time_ = [[NSDate date] timeIntervalSince1970];
 
+    LOGD(@"Changes to watch items detected, notifying registered clients.");
+
     for (const id<SNTEndpointSecurityDynamicEventHandler> &client : registerd_clients_) {
       // Note: Enable clients on an async queue in case they perform any
       // synchronous work that could trigger ES events. Otherwise they might

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -517,8 +517,10 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
 
   if (!self.isSubscribed) {
     self.isSubscribed = [super subscribe:events];
-    [super clearCache];
   }
+
+  // Always clear cache to ensure operations that were previously allowed are re-evaluated.
+  [super clearCache];
 }
 
 - (void)disable {


### PR DESCRIPTION
Fixes issue if a previously allowed and cached operation should be denied by a new config.