### PR TITLE
Config: Ignore static rules with an invalid identifier

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1120,6 +1120,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
   for (id rule in staticRules) {
     if (![rule isKindOfClass:[NSDictionary class]]) return;
     SNTRule *r = [[SNTRule alloc] initWithDictionary:rule];
+    if (!r) continue;
     rules[r.identifier] = r;
   }
   self.cachedStaticRules = [rules copy];

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -25,22 +25,22 @@
   SNTRule *sut;
 
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"identifier" : @"some-sort-of-identifier",
+    @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"BINARY",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"some-sort-of-identifier");
+  XCTAssertEqualObjects(sut.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(sut.type, SNTRuleTypeBinary);
   XCTAssertEqual(sut.state, SNTRuleStateAllow);
 
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"sha256" : @"some-sort-of-identifier",
+    @"sha256" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"BLOCKLIST",
     @"rule_type" : @"CERTIFICATE",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"some-sort-of-identifier");
+  XCTAssertEqualObjects(sut.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(sut.type, SNTRuleTypeCertificate);
   XCTAssertEqual(sut.state, SNTRuleStateBlock);
 
@@ -55,12 +55,12 @@
   XCTAssertEqual(sut.state, SNTRuleStateSilentBlock);
 
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"identifier" : @"some-sort-of-identifier",
+    @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"ALLOWLIST_COMPILER",
     @"rule_type" : @"BINARY",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"some-sort-of-identifier");
+  XCTAssertEqualObjects(sut.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(sut.type, SNTRuleTypeBinary);
   XCTAssertEqual(sut.state, SNTRuleStateAllowCompiler);
 
@@ -94,12 +94,19 @@
   XCTAssertNil(sut);
 
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"identifier" : @"an-identifier",
+    @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
   }];
   XCTAssertNil(sut);
 
   sut = [[SNTRule alloc] initWithDictionary:@{
     @"identifier" : @"an-identifier",
+    @"policy" : @"ALLOWLIST",
+    @"rule_type" : @"BINARY",
+  }];
+  XCTAssertNil(sut);
+
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
     @"policy" : @"OTHERPOLICY",
     @"rule_type" : @"BINARY",
   }];

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -30,7 +30,8 @@
     @"rule_type" : @"BINARY",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  XCTAssertEqualObjects(sut.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(sut.type, SNTRuleTypeBinary);
   XCTAssertEqual(sut.state, SNTRuleStateAllow);
 
@@ -40,7 +41,8 @@
     @"rule_type" : @"CERTIFICATE",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  XCTAssertEqualObjects(sut.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(sut.type, SNTRuleTypeCertificate);
   XCTAssertEqual(sut.state, SNTRuleStateBlock);
 
@@ -60,7 +62,8 @@
     @"rule_type" : @"BINARY",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  XCTAssertEqualObjects(sut.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(sut.type, SNTRuleTypeBinary);
   XCTAssertEqual(sut.state, SNTRuleStateAllowCompiler);
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -125,12 +125,19 @@
           cleanSlate:NO
                error:nil];
 
-  SNTRule *r = [self.sut ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670" certificateSHA256:nil teamID:nil];
+  SNTRule *r = [self.sut
+    ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
+      certificateSHA256:nil
+                 teamID:nil];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  XCTAssertEqualObjects(r.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 
-  r = [self.sut ruleForBinarySHA256:@"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2" certificateSHA256:nil teamID:nil];
+  r = [self.sut
+    ruleForBinarySHA256:@"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2"
+      certificateSHA256:nil
+                 teamID:nil];
   XCTAssertNil(r);
 }
 
@@ -139,12 +146,19 @@
           cleanSlate:NO
                error:nil];
 
-  SNTRule *r = [self.sut ruleForBinarySHA256:nil certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258" teamID:nil];
+  SNTRule *r = [self.sut
+    ruleForBinarySHA256:nil
+      certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
+                 teamID:nil];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
+  XCTAssertEqualObjects(r.identifier,
+                        @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate);
 
-  r = [self.sut ruleForBinarySHA256:nil certificateSHA256:@"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77de2b95e051e2562" teamID:nil];
+  r = [self.sut
+    ruleForBinarySHA256:nil
+      certificateSHA256:@"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77de2b95e051e2562"
+                 teamID:nil];
   XCTAssertNil(r);
 }
 
@@ -171,19 +185,31 @@
 
   // This test verifies that the implicit rule ordering we've been abusing is still working.
   // See the comment in SNTRuleTable#ruleForBinarySHA256:certificateSHA256:teamID
-  SNTRule *r = [self.sut ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670" certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258" teamID:@"teamID"];
+  SNTRule *r = [self.sut
+    ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
+      certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
+                 teamID:@"teamID"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  XCTAssertEqualObjects(r.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary, @"Implicit rule ordering failed");
 
-  r = [self.sut ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670" certificateSHA256:@"unknowncert" teamID:@"teamID"];
+  r = [self.sut
+    ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
+      certificateSHA256:@"unknowncert"
+                 teamID:@"teamID"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  XCTAssertEqualObjects(r.identifier,
+                        @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary, @"Implicit rule ordering failed");
 
-  r = [self.sut ruleForBinarySHA256:@"unknown" certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258" teamID:@"teamID"];
+  r = [self.sut
+    ruleForBinarySHA256:@"unknown"
+      certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
+                 teamID:@"teamID"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
+  XCTAssertEqualObjects(r.identifier,
+                        @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate, @"Implicit rule ordering failed");
 }
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -45,7 +45,7 @@
 
 - (SNTRule *)_exampleBinaryRule {
   SNTRule *r = [[SNTRule alloc] init];
-  r.identifier = @"a";
+  r.identifier = @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670";
   r.state = SNTRuleStateBlock;
   r.type = SNTRuleTypeBinary;
   r.customMsg = @"A rule";
@@ -54,7 +54,7 @@
 
 - (SNTRule *)_exampleCertRule {
   SNTRule *r = [[SNTRule alloc] init];
-  r.identifier = @"b";
+  r.identifier = @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258";
   r.state = SNTRuleStateAllow;
   r.type = SNTRuleTypeCertificate;
   return r;
@@ -112,7 +112,7 @@
 
 - (void)testAddInvalidRule {
   SNTRule *r = [[SNTRule alloc] init];
-  r.identifier = @"a";
+  r.identifier = @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258";
   r.type = SNTRuleTypeCertificate;
 
   NSError *error;
@@ -125,12 +125,12 @@
           cleanSlate:NO
                error:nil];
 
-  SNTRule *r = [self.sut ruleForBinarySHA256:@"a" certificateSHA256:nil teamID:nil];
+  SNTRule *r = [self.sut ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670" certificateSHA256:nil teamID:nil];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"a");
+  XCTAssertEqualObjects(r.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 
-  r = [self.sut ruleForBinarySHA256:@"b" certificateSHA256:nil teamID:nil];
+  r = [self.sut ruleForBinarySHA256:@"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2" certificateSHA256:nil teamID:nil];
   XCTAssertNil(r);
 }
 
@@ -139,12 +139,12 @@
           cleanSlate:NO
                error:nil];
 
-  SNTRule *r = [self.sut ruleForBinarySHA256:nil certificateSHA256:@"b" teamID:nil];
+  SNTRule *r = [self.sut ruleForBinarySHA256:nil certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258" teamID:nil];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"b");
+  XCTAssertEqualObjects(r.identifier, @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate);
 
-  r = [self.sut ruleForBinarySHA256:nil certificateSHA256:@"a" teamID:nil];
+  r = [self.sut ruleForBinarySHA256:nil certificateSHA256:@"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77de2b95e051e2562" teamID:nil];
   XCTAssertNil(r);
 }
 
@@ -171,19 +171,19 @@
 
   // This test verifies that the implicit rule ordering we've been abusing is still working.
   // See the comment in SNTRuleTable#ruleForBinarySHA256:certificateSHA256:teamID
-  SNTRule *r = [self.sut ruleForBinarySHA256:@"a" certificateSHA256:@"b" teamID:@"teamID"];
+  SNTRule *r = [self.sut ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670" certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258" teamID:@"teamID"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"a");
+  XCTAssertEqualObjects(r.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary, @"Implicit rule ordering failed");
 
-  r = [self.sut ruleForBinarySHA256:@"a" certificateSHA256:@"unknowncert" teamID:@"teamID"];
+  r = [self.sut ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670" certificateSHA256:@"unknowncert" teamID:@"teamID"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"a");
+  XCTAssertEqualObjects(r.identifier, @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary, @"Implicit rule ordering failed");
 
-  r = [self.sut ruleForBinarySHA256:@"unknown" certificateSHA256:@"b" teamID:@"teamID"];
+  r = [self.sut ruleForBinarySHA256:@"unknown" certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258" teamID:@"teamID"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"b");
+  XCTAssertEqualObjects(r.identifier, @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate, @"Implicit rule ordering failed");
 }
 


### PR DESCRIPTION
Unfortunately we're unable to log that the rule is ignored because SNTLogging depends on SNTConfigurator

Fixes #1047