### PR TITLE
chore(ci): Upgrade workflows to non-deprecated runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run linters
         run: ./Testing/lint.sh
 
@@ -27,7 +27,7 @@ jobs:
         os: [macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Userspace
         run: bazel build --apple_generate_dsym -c opt :release --define=SANTA_BUILD_TYPE=adhoc
 
@@ -38,14 +38,14 @@ jobs:
         os: [macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run All Tests
         run: bazel test :unit_tests --define=SANTA_BUILD_TYPE=adhoc --test_output=errors
 
   test_coverage:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Generate test coverage
         run: sh ./generate_cov.sh
       - name: Coveralls

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -8,6 +8,6 @@ jobs:
   preqs:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Checks for flaky tests
         run: bazel test --test_strategy=exclusive --test_output=errors --runs_per_test 50 -t- :unit_tests --define=SANTA_BUILD_TYPE=adhoc

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ jobs:
   start_vm:
     runs-on: e2e-host
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Start VM
         run: python3 Testing/integration/actions/start_vm.py macOS_12.bundle.tar.gz
 
@@ -15,7 +15,7 @@ jobs:
     env:
       VM_PASSWORD: ${{ secrets.VM_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install configuration profile
         run: bazel run //Testing/integration:install_profile -- Testing/integration/configs/default.mobileconfig
       - name: Add homebrew to PATH

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,14 +9,14 @@ jobs:
   start_vm:
     runs-on: e2e-host
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Start VM
         run: python3 Testing/integration/actions/start_vm.py macOS_13.bundle.tar.gz
 
   fuzz:
     runs-on: e2e-vm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup libfuzzer
         run: Fuzzing/install_libclang_fuzzer.sh
       - name: Fuzz

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         sanitizer: [asan, tsan, ubsan]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ${{ matrix.sanitizer }}
         run: |
           CLANG_VERSION=$(clang --version | head -n 1 | cut -d' ' -f 4)


### PR DESCRIPTION
Hi! 👋🏻

Several of the Github Actions in the repo are using the deprecated Node.js 12 runtime. Github have announced that everyone should move away from the deprecated Node.js runtime as of [this](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) blogpost. 

I've upgraded the deprecated actions to versions that uses non-deprecated runtimes.

Open to feedback if there are any other changes wanted done regarding Github Actions 😄