### PR TITLE
Basic rate limiting for File Access Authorizer

### DIFF
--- a/Source/common/SystemResources.h
+++ b/Source/common/SystemResources.h
@@ -35,6 +35,9 @@ uint64_t MachTimeToNanos(uint64_t mach_time);
 // Convert nanoseconds to mach absolute time
 uint64_t NanosToMachTime(uint64_t nanos);
 
+// Add some number of nanoseconds to a given mach time and return the new result
+uint64_t AddNanosecondsToMachTime(uint64_t ns, uint64_t machTime);
+
 // Get the result of proc_pidinfo with the PROC_PIDTASKINFO flavor
 std::optional<SantaTaskInfo> GetTaskInfo();
 

--- a/Source/common/SystemResources.mm
+++ b/Source/common/SystemResources.mm
@@ -39,15 +39,26 @@ static mach_timebase_info_data_t GetTimebase() {
 }
 
 uint64_t MachTimeToNanos(uint64_t mach_time) {
-  mach_timebase_info_data_t timebase = GetTimebase();
+  static mach_timebase_info_data_t timebase = GetTimebase();
 
   return mach_time * timebase.numer / timebase.denom;
 }
 
 uint64_t NanosToMachTime(uint64_t nanos) {
-  mach_timebase_info_data_t timebase = GetTimebase();
+  static mach_timebase_info_data_t timebase = GetTimebase();
 
   return nanos * timebase.denom / timebase.numer;
+}
+
+uint64_t AddNanosecondsToMachTime(uint64_t ns, uint64_t machTime) {
+  // Convert machtime to nanoseconds
+  uint64_t nanoTime = MachTimeToNanos(machTime);
+
+  // Add the nanosecond offset
+  nanoTime += ns;
+
+  // Convert back to machTime
+  return NanosToMachTime(nanoTime);
 }
 
 std::optional<SantaTaskInfo> GetTaskInfo() {

--- a/Source/common/TestUtils.mm
+++ b/Source/common/TestUtils.mm
@@ -87,16 +87,6 @@ es_process_t MakeESProcess(es_file_t *file, audit_token_t tok, audit_token_t par
   };
 }
 
-static uint64_t AddMillisToMachTime(uint64_t ms, uint64_t machTime) {
-  uint64_t nanoTime = MachTimeToNanos(machTime);
-
-  // Add the ms offset
-  nanoTime += (ms * NSEC_PER_MSEC);
-
-  // Convert back to machTime
-  return NanosToMachTime(nanoTime);
-}
-
 uint32_t MaxSupportedESMessageVersionForCurrentOS() {
   // Note: ES message v3 was only in betas.
   if (@available(macOS 13.0, *)) {
@@ -115,7 +105,7 @@ uint32_t MaxSupportedESMessageVersionForCurrentOS() {
 es_message_t MakeESMessage(es_event_type_t et, es_process_t *proc, ActionType action_type,
                            uint64_t future_deadline_ms) {
   es_message_t es_msg = {
-    .deadline = AddMillisToMachTime(future_deadline_ms, mach_absolute_time()),
+    .deadline = AddNanosecondsToMachTime(future_deadline_ms * NSEC_PER_MSEC, mach_absolute_time()),
     .process = proc,
     .action_type =
       (action_type == ActionType::Notify) ? ES_ACTION_TYPE_NOTIFY : ES_ACTION_TYPE_AUTH,

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -393,6 +393,7 @@ objc_library(
     srcs = ["EventProviders/RateLimiter.mm"],
     hdrs = ["EventProviders/RateLimiter.h"],
     deps = [
+        ":Metrics",
         "//Source/common:BranchPrediction",
         "//Source/common:SystemResources",
     ],
@@ -978,6 +979,7 @@ santa_unit_test(
     name = "RateLimiterTest",
     srcs = ["EventProviders/RateLimiterTest.mm"],
     deps = [
+        ":Metrics",
         ":RateLimiter",
         "//Source/common:SystemResources",
     ],
@@ -1315,6 +1317,7 @@ test_suite(
         ":EndpointSecurityWriterFileTest",
         ":EndpointSecurityWriterSpoolTest",
         ":MetricsTest",
+        ":RateLimiterTest",
         ":SNTApplicationCoreMetricsTest",
         ":SNTCompilerControllerTest",
         ":SNTDecisionCacheTest",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -337,6 +337,7 @@ objc_library(
         ":EndpointSecurityLogger",
         ":EndpointSecurityMessage",
         ":Metrics",
+        ":RateLimiter",
         ":SNTDecisionCache",
         ":SNTEndpointSecurityClient",
         ":SNTEndpointSecurityEventHandler",
@@ -384,6 +385,16 @@ objc_library(
         "//Source/common:SantaCache",
         "//Source/common:SantaVnode",
         "//Source/common:SantaVnodeHash",
+    ],
+)
+
+objc_library(
+    name = "RateLimiter",
+    srcs = ["EventProviders/RateLimiter.mm"],
+    hdrs = ["EventProviders/RateLimiter.h"],
+    deps = [
+        "//Source/common:BranchPrediction",
+        "//Source/common:SystemResources",
     ],
 )
 
@@ -960,6 +971,15 @@ santa_unit_test(
         "//Source/common:TestUtils",
         "@OCMock",
         "@com_google_googletest//:gtest",
+    ],
+)
+
+santa_unit_test(
+    name = "RateLimiterTest",
+    srcs = ["EventProviders/RateLimiterTest.mm"],
+    deps = [
+        ":RateLimiter",
+        "//Source/common:SystemResources",
     ],
 )
 

--- a/Source/santad/EventProviders/RateLimiter.h
+++ b/Source/santad/EventProviders/RateLimiter.h
@@ -1,0 +1,67 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#ifndef SANTA__SANTAD__EVENTPROVIDERS_RATELIMITER_H
+#define SANTA__SANTAD__EVENTPROVIDERS_RATELIMITER_H
+
+#import <Foundation/Foundation.h>
+
+#include <atomic>
+#include <memory>
+
+// Forward declarations
+namespace santa::santad::event_providers {
+class RateLimiterPeer;
+}
+
+namespace santa::santad::event_providers {
+
+// Very basic rate limiting infrastructure.
+// Currently only handles X events per duration.
+//
+// TODO(mlw): Support changing QPS via config
+// TODO(mlw): Support per-rule QPS
+// TODO(mlw): Consider adding sliding window support
+class RateLimiter {
+ public:
+  // Factory
+  static std::shared_ptr<RateLimiter> Create(
+      uint16_t max_qps, NSTimeInterval reset_duration = kDefaultResetDuration);
+
+  RateLimiter(uint16_t max_qps, NSTimeInterval reset_duration);
+
+  enum class Decision {
+    kRateLimited = 0,
+    kAllowed,
+  };
+
+  Decision Decide(uint64_t cur_mach_time);
+
+  friend class santa::santad::event_providers::RateLimiterPeer;
+
+ private:
+  void TryResetLocked(uint64_t cur_mach_time);
+
+  static constexpr NSTimeInterval kDefaultResetDuration = 15.0;
+
+  size_t log_count_total_ = 0;
+  size_t max_log_count_total_;
+  uint64_t reset_mach_time_;
+  uint64_t reset_duration_ns_;
+  dispatch_queue_t q_;
+};
+
+}  // namespace santa::santad::event_providers
+
+#endif

--- a/Source/santad/EventProviders/RateLimiter.mm
+++ b/Source/santad/EventProviders/RateLimiter.mm
@@ -1,0 +1,61 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/EventProviders/RateLimiter.h"
+
+#include "Source/common/BranchPrediction.h"
+#include "Source/common/SystemResources.h"
+
+namespace santa::santad::event_providers {
+
+std::shared_ptr<RateLimiter> RateLimiter::Create(uint16_t max_qps, NSTimeInterval reset_duration) {
+  return std::make_shared<RateLimiter>(max_qps, reset_duration);
+}
+
+RateLimiter::RateLimiter(uint16_t max_qps, NSTimeInterval reset_duration)
+    : max_log_count_total_(reset_duration * max_qps),
+      reset_mach_time_(0),
+      reset_duration_ns_(reset_duration * NSEC_PER_SEC) {
+  q_ = dispatch_queue_create(
+    "com.google.santa.daemon.rate_limiter",
+    dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
+                                            QOS_CLASS_USER_INTERACTIVE, 0));
+}
+
+void RateLimiter::TryResetLocked(uint64_t cur_mach_time) {
+  if (cur_mach_time > reset_mach_time_) {
+    log_count_total_ = 0;
+    reset_mach_time_ = AddNanosecondsToMachTime(reset_duration_ns_, cur_mach_time);
+  }
+}
+
+RateLimiter::Decision RateLimiter::Decide(uint64_t cur_mach_time) {
+  __block RateLimiter::Decision decision;
+
+  dispatch_sync(q_, ^{
+    TryResetLocked(cur_mach_time);
+
+    ++log_count_total_;
+
+    if (unlikely(log_count_total_ > max_log_count_total_)) {
+      decision = Decision::kRateLimited;
+    } else {
+      decision = RateLimiter::Decision::kAllowed;
+    }
+  });
+
+  return decision;
+}
+
+}  // namespace santa::santad::event_providers

--- a/Source/santad/EventProviders/RateLimiter.mm
+++ b/Source/santad/EventProviders/RateLimiter.mm
@@ -17,14 +17,22 @@
 #include "Source/common/BranchPrediction.h"
 #include "Source/common/SystemResources.h"
 
+using santa::santad::Metrics;
+using santa::santad::Processor;
+
 namespace santa::santad::event_providers {
 
-std::shared_ptr<RateLimiter> RateLimiter::Create(uint16_t max_qps, NSTimeInterval reset_duration) {
-  return std::make_shared<RateLimiter>(max_qps, reset_duration);
+std::shared_ptr<RateLimiter> RateLimiter::Create(std::shared_ptr<Metrics> metrics,
+                                                 Processor processor, uint16_t max_qps,
+                                                 NSTimeInterval reset_duration) {
+  return std::make_shared<RateLimiter>(std::move(metrics), processor, max_qps, reset_duration);
 }
 
-RateLimiter::RateLimiter(uint16_t max_qps, NSTimeInterval reset_duration)
-    : max_log_count_total_(reset_duration * max_qps),
+RateLimiter::RateLimiter(std::shared_ptr<Metrics> metrics, Processor processor, uint16_t max_qps,
+                         NSTimeInterval reset_duration)
+    : metrics_(std::move(metrics)),
+      processor_(processor),
+      max_log_count_total_(reset_duration * max_qps),
       reset_mach_time_(0),
       reset_duration_ns_(reset_duration * NSEC_PER_SEC) {
   q_ = dispatch_queue_create(
@@ -33,8 +41,24 @@ RateLimiter::RateLimiter(uint16_t max_qps, NSTimeInterval reset_duration)
                                             QOS_CLASS_USER_INTERACTIVE, 0));
 }
 
+bool RateLimiter::ShouldRateLimitLocked() {
+  return log_count_total_ > max_log_count_total_;
+}
+
+size_t RateLimiter::EventsRateLimitedLocked() {
+  if (unlikely(ShouldRateLimitLocked())) {
+    return log_count_total_ - max_log_count_total_;
+  } else {
+    return 0;
+  }
+}
+
 void RateLimiter::TryResetLocked(uint64_t cur_mach_time) {
   if (cur_mach_time > reset_mach_time_) {
+    if (metrics_) {
+      metrics_->SetRateLimitingMetrics(processor_, EventsRateLimitedLocked());
+    }
+
     log_count_total_ = 0;
     reset_mach_time_ = AddNanosecondsToMachTime(reset_duration_ns_, cur_mach_time);
   }
@@ -48,7 +72,7 @@ RateLimiter::Decision RateLimiter::Decide(uint64_t cur_mach_time) {
 
     ++log_count_total_;
 
-    if (unlikely(log_count_total_ > max_log_count_total_)) {
+    if (unlikely(ShouldRateLimitLocked())) {
       decision = Decision::kRateLimited;
     } else {
       decision = RateLimiter::Decision::kAllowed;

--- a/Source/santad/EventProviders/RateLimiterTest.mm
+++ b/Source/santad/EventProviders/RateLimiterTest.mm
@@ -1,0 +1,117 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "Source/santad/EventProviders/RateLimiter.h"
+
+#include <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include "Source/common/SystemResources.h"
+
+using santa::santad::event_providers::RateLimiter;
+
+namespace santa::santad::event_providers {
+
+class RateLimiterPeer : public RateLimiter {
+ public:
+  using RateLimiter::RateLimiter;
+  using RateLimiter::TryResetLocked;
+
+  using RateLimiter::log_count_total_;
+  using RateLimiter::reset_mach_time_;
+};
+
+}  // namespace santa::santad::event_providers
+
+using santa::santad::event_providers::RateLimiterPeer;
+
+@interface RateLimiterTest : XCTestCase
+@end
+
+@implementation RateLimiterTest
+
+- (void)testTryResetLocked {
+  // Create an object supporting 1 QPS, and a reset duration of 2s
+  uint16_t maxQps = 1;
+  NSTimeInterval resetDuration = 2;
+  RateLimiterPeer rlp(maxQps, resetDuration);
+
+  // Check the current reset_mach_time_ is 0 so that it gets
+  // set when the first decision is made
+  XCTAssertEqual(rlp.reset_mach_time_, 0);
+
+  // Define our current mach time and create the expected new reset duration floor
+  uint64_t curMachTime = 1;
+  uint64_t expectedMachTime = AddNanosecondsToMachTime(resetDuration, curMachTime);
+
+  // Set a higher log count to ensure it is reset
+  rlp.log_count_total_ = 123;
+
+  rlp.TryResetLocked(curMachTime);
+
+  // Ensure values are reset appropriately
+  XCTAssertEqual(rlp.log_count_total_, 0);
+  XCTAssertGreaterThanOrEqual(rlp.reset_mach_time_, expectedMachTime);
+
+  // Setup values so that calling TryResetLocked shouldn't reset anything
+  size_t expectedLogCount = 123;
+  expectedMachTime = 456;
+  rlp.log_count_total_ = expectedLogCount;
+  rlp.reset_mach_time_ = expectedMachTime;
+  curMachTime = rlp.reset_mach_time_;
+
+  rlp.TryResetLocked(curMachTime);
+
+  // Ensure the values were not changed
+  XCTAssertEqual(rlp.log_count_total_, expectedLogCount);
+  XCTAssertGreaterThanOrEqual(rlp.reset_mach_time_, expectedMachTime);
+}
+
+- (void)testDecide {
+  // Create an object supporting 1 QPS, and a reset duration of 2s
+  uint16_t maxQps = 2;
+  NSTimeInterval resetDuration = 4;
+  uint64_t allowedLogsPerDuration = maxQps * resetDuration;
+  RateLimiterPeer rlp(maxQps, resetDuration);
+
+  // Check the current log count is initially 0
+  XCTAssertEqual(rlp.log_count_total_, 0);
+
+  // Make the first decision
+  RateLimiter::Decision gotDecision;
+
+  for (uint64_t i = 0; i < (allowedLogsPerDuration); i++) {
+    gotDecision = rlp.Decide(0);
+    XCTAssertEqual(gotDecision, RateLimiter::Decision::kAllowed);
+  }
+
+  // Ensure the log count is the expected amount
+  XCTAssertEqual(rlp.log_count_total_, allowedLogsPerDuration);
+
+  // Make another decision and ensure the log count still increases and
+  // the decision is rate limited
+  gotDecision = rlp.Decide(0);
+  XCTAssertEqual(gotDecision, RateLimiter::Decision::kRateLimited);
+  XCTAssertEqual(rlp.log_count_total_, allowedLogsPerDuration + 1);
+
+  // Make another decision, though now with the cur mach time greater than
+  // the reset mach time. Then ensure values were appropriately reset.
+  uint64_t oldResetMachTime = rlp.reset_mach_time_;
+  gotDecision = rlp.Decide(rlp.reset_mach_time_ + 1);
+  XCTAssertEqual(gotDecision, RateLimiter::Decision::kAllowed);
+  XCTAssertEqual(rlp.log_count_total_, 1);
+  XCTAssertGreaterThan(rlp.reset_mach_time_, oldResetMachTime);
+}
+
+@end

--- a/Source/santad/EventProviders/RateLimiterTest.mm
+++ b/Source/santad/EventProviders/RateLimiterTest.mm
@@ -86,7 +86,7 @@ using santa::santad::event_providers::RateLimiterPeer;
 }
 
 - (void)testDecide {
-  // Create an object supporting 1 QPS, and a reset duration of 2s
+  // Create an object supporting 2 QPS, and a reset duration of 4s
   uint16_t maxQps = 2;
   NSTimeInterval resetDuration = 4;
   uint64_t allowedLogsPerDuration = maxQps * resetDuration;
@@ -122,7 +122,7 @@ using santa::santad::event_providers::RateLimiterPeer;
 }
 
 - (void)testShouldRateLimitAndCounts {
-  // Create an object supporting 1 QPS, and a reset duration of 2s
+  // Create an object supporting 2 QPS, and a reset duration of 4s
   uint16_t maxQps = 2;
   NSTimeInterval resetDuration = 4;
   uint64_t allowedLogsPerDuration = maxQps * resetDuration;

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -57,6 +57,7 @@ using santa::santad::logs::endpoint_security::Logger;
 NSString *kBadCertHash = @"BAD_CERT_HASH";
 
 static constexpr uint32_t kOpenFlagsIndicatingWrite = FWRITE | O_APPEND | O_TRUNC;
+static constexpr uint16_t kDefaultRateLimitQPS = 50;
 
 // Small structure to hold a complete event path target being operated upon and
 // a bool indicating whether the path is a readable target (e.g. a file being
@@ -223,8 +224,8 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
 
     _decisionCache = decisionCache;
 
-    _rateLimiter =
-      RateLimiter::Create(metrics, santa::santad::Processor::kFileAccessAuthorizer, 50);
+    _rateLimiter = RateLimiter::Create(metrics, santa::santad::Processor::kFileAccessAuthorizer,
+                                       kDefaultRateLimitQPS);
 
     SNTMetricBooleanGauge *famEnabled = [[SNTMetricSet sharedInstance]
       booleanGaugeWithName:@"/santa/fam_enabled"

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -214,7 +214,7 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>)enricher
   decisionCache:(SNTDecisionCache *)decisionCache {
   self = [super initWithESAPI:std::move(esApi)
-                      metrics:std::move(metrics)
+                      metrics:metrics
                     processor:santa::santad::Processor::kFileAccessAuthorizer];
   if (self) {
     _watchItems = std::move(watchItems);
@@ -223,7 +223,8 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
 
     _decisionCache = decisionCache;
 
-    _rateLimiter = RateLimiter::Create(50);
+    _rateLimiter =
+      RateLimiter::Create(metrics, santa::santad::Processor::kFileAccessAuthorizer, 50);
 
     SNTMetricBooleanGauge *famEnabled = [[SNTMetricSet sharedInstance]
       booleanGaugeWithName:@"/santa/fam_enabled"

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -465,8 +465,6 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
                               self->_enricher->Enrich(*esMsg->process, EnrichOptions::kLocalOnly),
                               targetPathCopy, policyDecision);
                           }];
-    } else {
-      // TODO: Metrics
     }
   }
 

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -68,6 +68,8 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   void SetEventMetrics(Processor processor, es_event_type_t event_type,
                        EventDisposition disposition, int64_t nanos);
 
+  void SetRateLimitingMetrics(Processor processor, int64_t events_rate_limited_count);
+
   friend class santa::santad::MetricsPeer;
 
  private:
@@ -94,6 +96,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   // Small caches for storing event metrics between metrics export operations
   std::map<EventCountTuple, int64_t> event_counts_cache_;
   std::map<EventTimesTuple, int64_t> event_times_cache_;
+  std::map<Processor, int64_t> rate_limit_counts_cache_;
 };
 
 }  // namespace santa::santad

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -53,7 +53,8 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
 
   Metrics(dispatch_queue_t q, dispatch_source_t timer_source, uint64_t interval,
           SNTMetricInt64Gauge *event_processing_times, SNTMetricCounter *event_counts,
-          SNTMetricSet *metric_set, void (^run_on_first_start)(Metrics *));
+          SNTMetricCounter *rate_limit_counts, SNTMetricSet *metric_set,
+          void (^run_on_first_start)(Metrics *));
 
   ~Metrics();
 
@@ -82,6 +83,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   uint64_t interval_;
   SNTMetricInt64Gauge *event_processing_times_;
   SNTMetricCounter *event_counts_;
+  SNTMetricCounter *rate_limit_counts_;
   SNTMetricSet *metric_set_;
   // Tracks whether or not the timer_source should be running.
   // This helps manage dispatch source state to ensure the source is not

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -263,4 +263,10 @@ void Metrics::SetEventMetrics(Processor processor, es_event_type_t event_type,
   });
 }
 
+void Metrics::SetRateLimitingMetrics(Processor processor, int64_t events_rate_limited_count) {
+  dispatch_sync(events_q_, ^{
+    rate_limit_counts_cache_[processor] += events_rate_limited_count;
+  });
+}
+
 }  // namespace santa::santad


### PR DESCRIPTION
Implements some very basic rate limiting to prevent run-away configurations swamping the logs.

A future release will add support for per-rule rates, as well as being able to change QPS via config.