### PR TITLE
[BUGFIX] Fix SD Card Block not operating on Internal SD Card Readers

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -259,7 +259,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // We are okay with operations for devices that are non-removable as long as
   // they are NOT a USB device, or an SD Card.
-  if !isRemovable && !isEjectable && !isUSB && !isSecureDigital {
+  if (!isRemovable && !isEjectable && !isUSB && !isSecureDigital) {
     return ES_AUTH_RESULT_ALLOW;
   }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -248,13 +248,12 @@ NS_ASSUME_NONNULL_BEGIN
        @"isEjectable: %d",
        protocol, kind, isInternal, isRemovable, isEjectable);
 
-  
-  // if the device is internal, or virtual *AND* is not an SD Card, 
+  // if the device is internal, or virtual *AND* is not an SD Card,
   // then allow the mount. This is to ensure we block SD cards inserted into
   // the internal reader of some Macs, whilst also ensuring we don't block
   // the internal storage device.
   if ((isInternal || isVirtual) && !isSecureDigital) {
-    return ES_AUTH_RESULT_ALLOW; 
+    return ES_AUTH_RESULT_ALLOW;
   }
 
   // We are okay with operations for devices that are non-removable as long as

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -248,10 +248,18 @@ NS_ASSUME_NONNULL_BEGIN
        @"isEjectable: %d",
        protocol, kind, isInternal, isRemovable, isEjectable);
 
-  // If the device is internal or virtual we are okay with the operation. We
-  // also are okay with operations for devices that are non-removal as long as
+  
+  // if the device is internal, or virtual *AND* is not an SD Card, 
+  // then allow the mount. This is to ensure we block SD cards inserted into
+  // the internal reader of some Macs, whilst also ensuring we don't block
+  // the internal storage device.
+  if ((isInternal || isVirtual) && !isSecureDigital) {
+    return ES_AUTH_RESULT_ALLOW; 
+  }
+
+  // We are okay with operations for devices that are non-removable as long as
   // they are NOT a USB device, or an SD Card.
-  if (isInternal || isVirtual || (!isRemovable && !isEjectable && !isUSB && !isSecureDigital)) {
+  if !isRemovable && !isEjectable && !isUSB && !isSecureDigital {
     return ES_AUTH_RESULT_ALLOW;
   }
 


### PR DESCRIPTION
The SD Card block added in #938 did not operate when an SD Card was inserted into the built in SD Card reader on some Mac models. This is because the SD Card was classed as an internal disk - as show below in this screenshot from Disk Arbitrator:  

<img width="721" alt="Screenshot 2023-03-22 at 10 56 46" src="https://user-images.githubusercontent.com/876495/226892436-1c575db8-4387-4d0a-aafe-299d533f26db.png">

This PR splits up the existing if statement to ensure that internally mounted SD Cards are included in the SD Card block. 