### PR TITLE
Change types of repeated args and envs fields

### DIFF
--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -1,3 +1,4 @@
+
 // Important: This schema is currently in BETA
 
 syntax = "proto3";
@@ -231,10 +232,10 @@ message Execution {
   optional FileInfo working_directory = 4;
 
   // List of process arguments
-  repeated string args = 5;
+  repeated bytes args = 5;
 
   // List of environment variables
-  repeated string envs = 6;
+  repeated bytes envs = 6;
 
   // List of file descriptors
   repeated FileDescriptor fds = 7;

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -1,4 +1,3 @@
-
 // Important: This schema is currently in BETA
 
 syntax = "proto3";

--- a/Source/santad/testdata/protobuf/v1/exec.json
+++ b/Source/santad/testdata/protobuf/v1/exec.json
@@ -102,13 +102,13 @@
   }
  },
  "args": [
-  "exec_path",
-  "-l",
-  "--foo"
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
  ],
  "envs": [
-  "ENV_PATH=/path/to/bin:/and/another",
-  "DEBUG=1"
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
  ],
  "decision": "DECISION_ALLOW",
  "reason": "REASON_BINARY",

--- a/Source/santad/testdata/protobuf/v2/exec.json
+++ b/Source/santad/testdata/protobuf/v2/exec.json
@@ -130,13 +130,13 @@
   }
  },
  "args": [
-  "exec_path",
-  "-l",
-  "--foo"
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
  ],
  "envs": [
-  "ENV_PATH=/path/to/bin:/and/another",
-  "DEBUG=1"
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
  ],
  "decision": "DECISION_ALLOW",
  "reason": "REASON_BINARY",

--- a/Source/santad/testdata/protobuf/v4/exec.json
+++ b/Source/santad/testdata/protobuf/v4/exec.json
@@ -163,13 +163,13 @@
   }
  },
  "args": [
-  "exec_path",
-  "-l",
-  "--foo"
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
  ],
  "envs": [
-  "ENV_PATH=/path/to/bin:/and/another",
-  "DEBUG=1"
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
  ],
  "fds": [
   {

--- a/Source/santad/testdata/protobuf/v5/exec.json
+++ b/Source/santad/testdata/protobuf/v5/exec.json
@@ -163,13 +163,13 @@
   }
  },
  "args": [
-  "exec_path",
-  "-l",
-  "--foo"
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
  ],
  "envs": [
-  "ENV_PATH=/path/to/bin:/and/another",
-  "DEBUG=1"
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
  ],
  "fds": [
   {

--- a/Source/santad/testdata/protobuf/v6/exec.json
+++ b/Source/santad/testdata/protobuf/v6/exec.json
@@ -163,13 +163,13 @@
   }
  },
  "args": [
-  "exec_path",
-  "-l",
-  "--foo"
+  "ZXhlY19wYXRo",
+  "LWw=",
+  "LS1mb28="
  ],
  "envs": [
-  "ENV_PATH=/path/to/bin:/and/another",
-  "DEBUG=1"
+  "RU5WX1BBVEg9L3BhdGgvdG8vYmluOi9hbmQvYW5vdGhlcg==",
+  "REVCVUc9MQ=="
  ],
  "fds": [
   {


### PR DESCRIPTION
This change is necessary in order to properly encode non-UTF8 strings which aren't too uncommon in exec args/envs. Proto spec requires strings to be UTF8.

This is a compatible change - `string --> bytes` type change is safe.. Proto generated via the old schema can be successfully unmarshalled via the new schema. 