### PR TITLE
GUI: Device event window, handle empty remount args

### DIFF
--- a/Source/gui/SNTDeviceMessageWindowView.swift
+++ b/Source/gui/SNTDeviceMessageWindowView.swift
@@ -37,7 +37,7 @@ struct SNTDeviceMessageWindowView: View {
           Text("Device Name").bold()
           Text("Device BSD Path").bold()
 
-          if event!.remountArgs.count > 0 {
+          if event!.remountArgs?.count ?? 0 > 0 {
             Text("Remount Mode").bold()
           }
         }
@@ -46,7 +46,7 @@ struct SNTDeviceMessageWindowView: View {
           Text(event!.mntonname)
           Text(event!.mntfromname)
 
-          if event!.remountArgs.count > 0 {
+          if event!.remountArgs?.count ?? 0 > 0 {
             Text(event!.readableRemountArgs())
           }
         }


### PR DESCRIPTION
Fixes a crash when the remountArgs config key is empty.