### PR TITLE
sync: Add more complete XSSI prefix to be stripped.

### DIFF
--- a/Source/santasyncservice/SNTSyncStage.m
+++ b/Source/santasyncservice/SNTSyncStage.m
@@ -183,9 +183,15 @@
 }
 
 - (NSData *)stripXssi:(NSData *)data {
-  static const char xssi[3] = {']', ')', '}'};
-  if (data.length < 3 || strncmp(data.bytes, xssi, 3)) return data;
-  return [data subdataWithRange:NSMakeRange(3, data.length - 3)];
+  static const char xssiOne[5] = {')', ']', '}', '\'', '\n'};
+  static const char xssiTwo[3] = {']', ')', '}'};
+  if (data.length >= 5 && strncmp(data.bytes, xssiOne, 5) == 0) {
+    return [data subdataWithRange:NSMakeRange(5, data.length - 5)];
+  }
+  if (data.length >= 3 && strncmp(data.bytes, xssiTwo, 3) == 0) {
+    return [data subdataWithRange:NSMakeRange(3, data.length - 3)];
+  }
+  return data;
 }
 
 - (BOOL)fetchXSRFToken {

--- a/Source/santasyncservice/SNTSyncStage.m
+++ b/Source/santasyncservice/SNTSyncStage.m
@@ -185,11 +185,11 @@
 - (NSData *)stripXssi:(NSData *)data {
   static const char xssiOne[5] = {')', ']', '}', '\'', '\n'};
   static const char xssiTwo[3] = {']', ')', '}'};
-  if (data.length >= 5 && strncmp(data.bytes, xssiOne, 5) == 0) {
-    return [data subdataWithRange:NSMakeRange(5, data.length - 5)];
+  if (data.length >= sizeof(xssiOne) && strncmp(data.bytes, xssiOne, sizeof(xssiOne)) == 0) {
+    return [data subdataWithRange:NSMakeRange(sizeof(xssiOne), data.length - sizeof(xssiOne))];
   }
-  if (data.length >= 3 && strncmp(data.bytes, xssiTwo, 3) == 0) {
-    return [data subdataWithRange:NSMakeRange(3, data.length - 3)];
+  if (data.length >= sizeof(xssiTwo) && strncmp(data.bytes, xssiTwo, sizeof(xssiTwo)) == 0) {
+    return [data subdataWithRange:NSMakeRange(sizeof(xssiTwo), data.length - sizeof(xssiTwo))];
   }
   return data;
 }

--- a/Source/santasyncservice/SNTSyncTest.m
+++ b/Source/santasyncservice/SNTSyncTest.m
@@ -39,6 +39,10 @@
 }
 @end
 
+@interface SNTSyncStage (XSSI)
+- (NSData *)stripXssi:(NSData *)data;
+@end
+
 @interface SNTSyncTest : XCTestCase
 @property SNTSyncState *syncState;
 @property id<SNTDaemonControlXPC> daemonConnRop;
@@ -155,6 +159,27 @@
 }
 
 #pragma mark - SNTSyncStage Tests
+
+- (void)testStripXssi {
+  SNTSyncStage *sut = [[SNTSyncStage alloc] initWithState:self.syncState];
+
+  char wantChar[3] = {'"', 'a', '"'};
+  NSData *want = [NSData dataWithBytes:wantChar length:3];
+
+  char dOne[8] = {')', ']', '}', '\'', '\n', '"', 'a', '"'};
+  XCTAssertEqualObjects([sut stripXssi:[NSData dataWithBytes:dOne length:8]], want, @"");
+
+  char dTwo[6] = {']', ')', '}', '"', 'a', '"'};
+  XCTAssertEqualObjects([sut stripXssi:[NSData dataWithBytes:dTwo length:6]], want, @"");
+
+  char dThree[5] = {')', ']', '}', '\'', '\n'};
+  XCTAssertEqualObjects([sut stripXssi:[NSData dataWithBytes:dThree length:5]], [NSData data], @"");
+
+  char dFour[3] = {']', ')', '}'};
+  XCTAssertEqualObjects([sut stripXssi:[NSData dataWithBytes:dFour length:3]], [NSData data], @"");
+
+  XCTAssertEqualObjects([sut stripXssi:want], want, @"");
+}
 
 - (void)testBaseFetchXSRFTokenSuccess {
   // NOTE: This test only works if the other tests don't return a 403 and run before this test.


### PR DESCRIPTION
Sync will try stripping both the new longer prefix and the existing short prefix if the response data begins with either. This should have no impact on existing sync servers but will allow sync servers in the future to use the longer prefix if they wish.