### PR TITLE
Cache flush metrics

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -384,6 +384,7 @@ objc_library(
         ":EndpointSecurityClient",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTMetricSet",
         "//Source/common:SantaCache",
         "//Source/common:SantaVnode",
         "//Source/common:SantaVnodeHash",

--- a/Source/santad/EventProviders/AuthResultCache.h
+++ b/Source/santad/EventProviders/AuthResultCache.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTMetricSet.h"
 #include "Source/common/SantaCache.h"
 #import "Source/common/SantaVnode.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
@@ -45,13 +46,17 @@ enum class FlushCacheReason {
 class AuthResultCache {
  public:
   // Santa currently only flushes caches when new DENY rules are added, not
-  // ALLOW rules. This means this value should be low enough so that if a
+  // ALLOW rules. This means cache_deny_time_ms should be low enough so that if a
   // previously denied binary is allowed, it can be re-executed by the user in a
   // timely manner. But the value should be high enough to allow the cache to be
   // effective in the event the binary is executed in rapid succession.
+  static std::unique_ptr<AuthResultCache> Create(
+    std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi,
+    SNTMetricSet *metric_set, uint64_t cache_deny_time_ms = 1500);
+
   AuthResultCache(
     std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi,
-    uint64_t cache_deny_time_ms = 1500);
+    SNTMetricCounter *flush_count, uint64_t cache_deny_time_ms = 1500);
   virtual ~AuthResultCache();
 
   AuthResultCache(AuthResultCache &&other) = delete;
@@ -75,6 +80,7 @@ class AuthResultCache {
   SantaCache<SantaVnode, uint64_t> *nonroot_cache_;
 
   std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI> esapi_;
+  SNTMetricCounter *flush_count_;
   uint64_t root_devno_;
   uint64_t cache_deny_time_ns_;
   dispatch_queue_t q_;

--- a/Source/santad/EventProviders/AuthResultCache.h
+++ b/Source/santad/EventProviders/AuthResultCache.h
@@ -33,6 +33,15 @@ enum class FlushCacheMode {
   kAllCaches,
 };
 
+enum class FlushCacheReason {
+  kClientModeChanged,
+  kPathRegexChanged,
+  kRulesChanged,
+  kStaticRulesChanged,
+  kExplicitCommand,
+  kFilesystemUnmounted,
+};
+
 class AuthResultCache {
  public:
   // Santa currently only flushes caches when new DENY rules are added, not
@@ -55,7 +64,7 @@ class AuthResultCache {
   virtual SNTAction CheckCache(const es_file_t *es_file);
   virtual SNTAction CheckCache(SantaVnode vnode_id);
 
-  virtual void FlushCache(FlushCacheMode mode);
+  virtual void FlushCache(FlushCacheMode mode, FlushCacheReason reason);
 
   virtual NSArray<NSNumber *> *CacheCounts();
 

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -25,6 +25,13 @@
 using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 
+static NSString *const kFlushCacheReasonClientModeChanged = @"ClientModeChanged";
+static NSString *const kFlushCacheReasonPathRegexChanged = @"PathRegexChanged";
+static NSString *const kFlushCacheReasonRulesChanged = @"RulesChanged";
+static NSString *const kFlushCacheReasonStaticRulesChanged = @"StaticRulesChanged";
+static NSString *const kFlushCacheReasonExplicitCommand = @"ExplicitCommand";
+static NSString *const kFlushCacheReasonFilesystemUnmounted = @"FilesystemUnmounted";
+
 namespace santa::santad::event_providers {
 
 static inline uint64_t GetCurrentUptime() {
@@ -44,9 +51,36 @@ static inline uint64_t TimestampFromCachedValue(uint64_t cachedValue) {
   return (cachedValue & ~(0xFF00000000000000));
 }
 
+NSString *const FlushCacheReasonToString(FlushCacheReason reason) {
+  switch (reason) {
+    case FlushCacheReason::kClientModeChanged: return kFlushCacheReasonClientModeChanged;
+    case FlushCacheReason::kPathRegexChanged: return kFlushCacheReasonPathRegexChanged;
+    case FlushCacheReason::kRulesChanged: return kFlushCacheReasonRulesChanged;
+    case FlushCacheReason::kStaticRulesChanged: return kFlushCacheReasonStaticRulesChanged;
+    case FlushCacheReason::kExplicitCommand: return kFlushCacheReasonExplicitCommand;
+    case FlushCacheReason::kFilesystemUnmounted: return kFlushCacheReasonFilesystemUnmounted;
+    default:
+      [NSException raise:@"Invalid reason" format:@"Unknown reason value: %d", reason];
+      return nil;
+  }
+}
+
+std::unique_ptr<AuthResultCache> AuthResultCache::Create(std::shared_ptr<EndpointSecurityAPI> esapi,
+                                                         SNTMetricSet *metric_set,
+                                                         uint64_t cache_deny_time_ms) {
+  SNTMetricCounter *flush_count =
+    [metric_set counterWithName:@"/santa/flush_count"
+                     fieldNames:@[ @"Reason" ]
+                       helpText:@"Count of times the auth result cache is flushed by reason"];
+
+  return std::make_unique<AuthResultCache>(esapi, flush_count, cache_deny_time_ms);
+}
+
 AuthResultCache::AuthResultCache(std::shared_ptr<EndpointSecurityAPI> esapi,
-                                 uint64_t cache_deny_time_ms)
-    : esapi_(esapi), cache_deny_time_ns_(cache_deny_time_ms * NSEC_PER_MSEC) {
+                                 SNTMetricCounter *flush_count, uint64_t cache_deny_time_ms)
+    : esapi_(esapi),
+      flush_count_(flush_count),
+      cache_deny_time_ns_(cache_deny_time_ms * NSEC_PER_MSEC) {
   root_cache_ = new SantaCache<SantaVnode, uint64_t>();
   nonroot_cache_ = new SantaCache<SantaVnode, uint64_t>();
 
@@ -134,6 +168,8 @@ void AuthResultCache::FlushCache(FlushCacheMode mode, FlushCacheReason reason) {
       shared_esapi->ClearCache(Client());
     });
   }
+
+  [flush_count_ incrementForFieldValues:@[ FlushCacheReasonToString(reason) ]];
 }
 
 NSArray<NSNumber *> *AuthResultCache::CacheCounts() {

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -118,7 +118,7 @@ SantaCache<SantaVnode, uint64_t> *AuthResultCache::CacheForVnodeID(SantaVnode vn
   return (vnode_id.fsid == root_devno_ || root_devno_ == 0) ? root_cache_ : nonroot_cache_;
 }
 
-void AuthResultCache::FlushCache(FlushCacheMode mode) {
+void AuthResultCache::FlushCache(FlushCacheMode mode, FlushCacheReason reason) {
   nonroot_cache_->clear();
   if (mode == FlushCacheMode::kAllCaches) {
     root_cache_->clear();

--- a/Source/santad/EventProviders/AuthResultCacheTest.mm
+++ b/Source/santad/EventProviders/AuthResultCacheTest.mm
@@ -29,6 +29,7 @@
 
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
+using santa::santad::event_providers::FlushCacheReason;
 
 // Grab the st_dev number of the root volume to match the root cache
 static uint64_t RootDevno() {
@@ -121,7 +122,7 @@ static inline void AssertCacheCounts(std::shared_ptr<AuthResultCache> cache, uin
   AssertCacheCounts(cache, 1, 1);
 
   // Flush non-root only
-  cache->FlushCache(FlushCacheMode::kNonRootOnly);
+  cache->FlushCache(FlushCacheMode::kNonRootOnly, FlushCacheReason::kClientModeChanged);
 
   AssertCacheCounts(cache, 1, 0);
 
@@ -138,7 +139,7 @@ static inline void AssertCacheCounts(std::shared_ptr<AuthResultCache> cache, uin
     dispatch_semaphore_signal(sema);
     return true;
   }));
-  cache->FlushCache(FlushCacheMode::kAllCaches);
+  cache->FlushCache(FlushCacheMode::kAllCaches, FlushCacheReason::kClientModeChanged);
 
   XCTAssertEqual(0,
                  dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)),

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -234,7 +234,7 @@ class MockAuthResultCache : public AuthResultCache {
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
+  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr, nil);
   EXPECT_CALL(*mockAuthCache, CheckCache)
     .WillOnce(testing::Return(SNTActionRequestBinary))
     .WillOnce(testing::Return(SNTActionRequestBinary))
@@ -301,7 +301,7 @@ class MockAuthResultCache : public AuthResultCache {
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
+  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr, nil);
   EXPECT_CALL(*mockAuthCache, AddToCache(&execFile, SNTActionRespondAllowCompiler))
     .WillOnce(testing::Return(true));
   EXPECT_CALL(*mockAuthCache, AddToCache(&execFile, SNTActionRespondAllow))

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -33,6 +33,7 @@
 using santa::santad::EventDisposition;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
+using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::Logger;
@@ -175,7 +176,8 @@ NS_ASSUME_NONNULL_BEGIN
   // Process the unmount event first so that caches are flushed before any
   // other potential early returns.
   if (esMsg->event_type == ES_EVENT_TYPE_NOTIFY_UNMOUNT) {
-    self->_authResultCache->FlushCache(FlushCacheMode::kNonRootOnly);
+    self->_authResultCache->FlushCache(FlushCacheMode::kNonRootOnly,
+                                       FlushCacheReason::kFilesystemUnmounted);
     recordEventMetrics(EventDisposition::kProcessed);
     return;
   }

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -39,13 +39,14 @@
 using santa::santad::EventDisposition;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
+using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::event_providers::endpoint_security::Message;
 
 class MockAuthResultCache : public AuthResultCache {
  public:
   using AuthResultCache::AuthResultCache;
 
-  MOCK_METHOD(void, FlushCache, (FlushCacheMode mode));
+  MOCK_METHOD(void, FlushCache, (FlushCacheMode mode, FlushCacheReason reason));
 };
 
 @interface SNTEndpointSecurityDeviceManager (Testing)

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -317,7 +317,7 @@ class MockAuthResultCache : public AuthResultCache {
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
+  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr, nil);
   EXPECT_CALL(*mockAuthCache, FlushCache);
 
   SNTEndpointSecurityDeviceManager *deviceManager =

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -105,7 +105,7 @@ class MockLogger : public Logger {
   auto mockEnricher = std::make_shared<MockEnricher>();
   EXPECT_CALL(*mockEnricher, Enrich).WillOnce(testing::Return(enrichedMsg));
 
-  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr);
+  auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr, nil);
   EXPECT_CALL(*mockAuthCache, RemoveFromCache(&targetFile)).Times(1);
 
   dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -39,6 +39,7 @@ using santa::santad::data_layer::WatchItems;
 using santa::santad::data_layer::WatchItemsState;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
+using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::logs::endpoint_security::Logger;
 
 // Globals used by the santad watchdog thread
@@ -84,12 +85,9 @@ double watchdogRAMPeak = 0;
   reply([counts[0] unsignedLongLongValue], [counts[1] unsignedLongLongValue]);
 }
 
-- (void)flushAllCaches {
-  self->_authResultCache->FlushCache(FlushCacheMode::kAllCaches);
-}
-
 - (void)flushCache:(void (^)(BOOL))reply {
-  [self flushAllCaches];
+  self->_authResultCache->FlushCache(FlushCacheMode::kAllCaches,
+                                     FlushCacheReason::kExplicitCommand);
   reply(YES);
 }
 
@@ -125,7 +123,7 @@ double watchdogRAMPeak = 0;
   // The actual cache flushing happens after the new rules have been added to the database.
   if (flushCache) {
     LOGI(@"Flushing caches");
-    [self flushAllCaches];
+    self->_authResultCache->FlushCache(FlushCacheMode::kAllCaches, FlushCacheReason::kRulesChanged);
   }
 
   reply(error);

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -49,6 +49,8 @@ class SantadDeps {
       std::unique_ptr<santa::santad::logs::endpoint_security::Logger> logger,
       std::shared_ptr<santa::santad::Metrics> metrics,
       std::shared_ptr<santa::santad::data_layer::WatchItems> watch_items,
+      std::shared_ptr<santa::santad::event_providers::AuthResultCache>
+          auth_result_cache,
       MOLXPCConnection *control_connection,
       SNTCompilerController *compiler_controller,
       SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,


### PR DESCRIPTION
Collect metrics when the auth result cache is flushed for various reasons.

Sample `santactl metrics` output after running `santactl flushcache` and unmounting a DMG:
```
  Metric Name               | /santa/flush_count
  Description               | Count of times the auth result cache is flushed by reason
  Type                      | SNTMetricTypeCounter
  Field                     | Reason=ExplicitCommand
  Created                   | 2023-04-20T19:56:39.661Z
  Last Updated              | 2023-04-20T19:56:39.661Z
  Data                      | 1
  Field                     | Reason=FilesystemUnmounted
  Created                   | 2023-04-20T19:57:05.904Z
  Last Updated              | 2023-04-20T19:57:05.904Z
  Data                      | 1
  ```