### PR TITLE
Make the sync client content encoding a tunable

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import <Foundation/Foundation.h>
+#include <objc/objc-api.h>
 
 ///
 ///  These enums are used in various places throughout the Santa client code.
@@ -127,6 +128,12 @@ typedef NS_ENUM(NSInteger, SNTSyncStatusType) {
   SNTSyncStatusTypeDaemonTimeout,
   SNTSyncStatusTypeSyncStarted,
   SNTSyncStatusTypeUnknown,
+};
+
+typedef NS_ENUM(NSInteger, SNTSyncCompressionEncoding) {
+  SNTSyncCompressionEncodingNone,
+  SNTSyncCompressionEncodingZlib,
+  SNTSyncCompressionEncodingGzip,
 };
 
 typedef NS_ENUM(NSInteger, SNTMetricFormatType) {

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -410,6 +410,8 @@
 ///
 @property(nonatomic) BOOL syncCleanRequired;
 
+#pragma mark - USB Settings
+
 ///
 /// USB Mount Blocking. Defaults to false.
 ///
@@ -519,6 +521,12 @@
 ///  Defaults to false.
 ///
 @property(readonly, nonatomic) BOOL enableBackwardsCompatibleContentEncoding;
+
+///
+/// If set, "santactl sync" will use the supplied "Content-Encoding", possible
+/// settings include gzip, deflate, none.
+///
+@property(readonly, nonatomic) SNTSyncCompressionEncoding syncClientContentEncoding;
 
 ///
 ///  Contains the FCM project name.

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import "Source/common/SNTConfigurator.h"
+#import "Source/common/SNTCommonEnums.h"
 
 #include <sys/stat.h>
 
@@ -110,6 +111,7 @@ static NSString *const kEnableDebugLogging = @"EnableDebugLogging";
 
 static NSString *const kEnableBackwardsCompatibleContentEncoding =
   @"EnableBackwardsCompatibleContentEncoding";
+static NSString *const kClientContentEncoding = @"SyncClientContentEncoding";
 
 static NSString *const kFCMProject = @"FCMProject";
 static NSString *const kFCMEntity = @"FCMEntity";
@@ -129,7 +131,6 @@ static NSString *const kBlockedPathRegexKeyDeprecated = @"BlacklistRegex";
 static NSString *const kEnableAllEventUploadKey = @"EnableAllEventUpload";
 static NSString *const kDisableUnknownEventUploadKey = @"DisableUnknownEventUpload";
 
-// TODO(markowsky): move these to sync server only.
 static NSString *const kMetricFormat = @"MetricFormat";
 static NSString *const kMetricURL = @"MetricURL";
 static NSString *const kMetricExportInterval = @"MetricExportInterval";
@@ -200,6 +201,7 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kClientAuthCertificatePasswordKey : string,
       kClientAuthCertificateCNKey : string,
       kClientAuthCertificateIssuerKey : string,
+      kClientContentEncoding : string,
       kServerAuthRootsDataKey : data,
       kServerAuthRootsFileKey : string,
       kMachineOwnerKey : string,
@@ -713,6 +715,20 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (NSString *)syncClientAuthCertificateIssuer {
   return self.configState[kClientAuthCertificateIssuerKey];
+}
+
+- (SNTSyncCompressionEncoding)syncClientContentEncoding {
+  NSString *contentEncoding = [self.configState[kClientContentEncoding] lowercaseString];
+  if ([contentEncoding isEqualToString:@"zlib"]) {
+    return SNTSyncCompressionEncodingZlib;
+  } else if ([contentEncoding isEqualToString:@"gzip"]) {
+    return SNTSyncCompressionEncodingGzip;
+  } else if ([contentEncoding isEqualToString:@"none"]) {
+    return SNTSyncCompressionEncodingNone;
+  } else {
+    // Ensure we have the same
+    return SNTSyncCompressionEncodingZlib;
+  }
 }
 
 - (NSData *)syncServerAuthRootsData {

--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -391,6 +391,7 @@ static void reachabilityHandler(SCNetworkReachabilityRef target, SCNetworkReacha
 
   syncState.session = [authURLSession session];
   syncState.daemonConn = self.daemonConn;
+  syncState.compressionEncoding = config.syncClientContentEncoding;
 
   syncState.compressedContentEncoding =
     config.enableBackwardsCompatibleContentEncoding ? @"zlib" : @"deflate";

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import <Foundation/Foundation.h>
+#include <objc/NSObjCRuntime.h>
 
 #import "Source/common/SNTCommonEnums.h"
 
@@ -77,5 +78,8 @@
 /// The header value for ContentEncoding when sending compressed content.
 /// Either "deflate" (default) or "zlib".
 @property(copy) NSString *compressedContentEncoding;
+
+/// The compression type to use for the sync session.
+@property SNTSyncCompressionEncoding compressionEncoding;
 
 @end


### PR DESCRIPTION
This adds a new configuration option `SyncClientContentEncoding` which allows you to tweak the content encoding used by the sync client. Currently this supports the following options:

| Value | Expected Behavior |
| --- | --- |
| "" (default) | zlib with `Content-Encoding` set to `deflate` or "zlib" depending on `EnableBackwardsCompatibleContentEncoding` *old behavior* |
| "gzip" | gzip compressed requests with `Content-Encoding` set to `gzip` |
| "zlib" |   zlib with `Content-Encoding` set to `deflate`   |
| "none" | Content is not compressed at all |

### Testing

Tested with a hacked up version of moroz.

### Headers when 

### Headers when `SyncClientContentEncoding` is set to `None`

```
POST /v1/santa/preflight/<machine_id>
Host: santa:8080
Content-Type: application/json
Connection: keep-alive
Accept: */*
User-Agent: santactl-sync/9999.1.1
Content-Length: 536
Accept-Language: en-US,en;q=0.9
Accept-Encoding: gzip, deflate
```