### PR TITLE
Add support to file monitoring config to invert process exceptions

### DIFF
--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -33,6 +33,7 @@ static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType =
     WatchItemPathType::kLiteral;
 static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
+static constexpr bool kWatchItemPolicyDefaultInvertProcessExceptions = false;
 
 struct WatchItemPolicy {
   struct Process {
@@ -69,19 +70,23 @@ struct WatchItemPolicy {
                   WatchItemPathType pt = kWatchItemPolicyDefaultPathType,
                   bool ara = kWatchItemPolicyDefaultAllowReadAccess,
                   bool ao = kWatchItemPolicyDefaultAuditOnly,
+                  bool ipe = kWatchItemPolicyDefaultInvertProcessExceptions,
                   std::vector<Process> procs = {})
       : name(n),
         path(p),
         path_type(pt),
         allow_read_access(ara),
         audit_only(ao),
+        invert_process_exceptions(ipe),
         processes(std::move(procs)) {}
 
   bool operator==(const WatchItemPolicy &other) const {
     return name == other.name && path == other.path &&
            path_type == other.path_type &&
            allow_read_access == other.allow_read_access &&
-           audit_only == other.audit_only && processes == other.processes;
+           audit_only == other.audit_only &&
+           invert_process_exceptions == other.invert_process_exceptions &&
+           processes == other.processes;
   }
 
   bool operator!=(const WatchItemPolicy &other) const {
@@ -93,6 +98,7 @@ struct WatchItemPolicy {
   WatchItemPathType path_type;
   bool allow_read_access;
   bool audit_only;
+  bool invert_process_exceptions;
   std::vector<Process> processes;
 };
 

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -39,6 +39,7 @@ extern NSString *const kWatchItemConfigKeyPathsIsPrefix;
 extern NSString *const kWatchItemConfigKeyOptions;
 extern NSString *const kWatchItemConfigKeyOptionsAllowReadAccess;
 extern NSString *const kWatchItemConfigKeyOptionsAuditOnly;
+extern NSString *const kWatchItemConfigKeyOptionsInvertProcessExceptions;
 extern NSString *const kWatchItemConfigKeyProcesses;
 extern NSString *const kWatchItemConfigKeyProcessesBinaryPath;
 extern NSString *const kWatchItemConfigKeyProcessesCertificateSha256;

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -450,6 +450,7 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
     decision = FileAccessPolicyDecision::kAllowedAuditOnly;
   }
 
+  // https://github.com/google/santa/issues/1084
   // TODO(xyz): Write to TTY like in exec controller?
   // TODO(xyz): Need new config item for custom message in UI
 

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -18,24 +18,25 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 
 ## Configuration
 
-| Key                 | Parent       | Type       | Required | Santa Version | Description |
-| :------------------ | :----------- | :--------- | :------- | :------------ | :---------- |
-| `Version`           | `<Root>`     | String     | Yes      | v2023.1+      | Version of the configuration. Will be reported in events. |
-| `WatchItems`        | `<Root>`     | Dictionary | No       | v2023.1+      | The set of configuration items that will be monitored by Santa. |
-| `<Name>`            | `WatchItems` | Dictionary | No       | v2023.1+      | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (i.e., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
-| `Paths`             | `<Name>`     | Array      | Yes      | v2023.1+      | A list of either String or Dictionary types that contain path globs to monitor. String type entires will have default values applied for the attributes that can be manually set with the Dictionary type. |
-| `Path`              | `Paths`      | String     | Yes      | v2023.1+      | The path glob to monitor. |
-| `IsPrefix`          | `Paths`      | Boolean    | No       | v2023.1+      | Whether or not the path glob represents a prefix path. (Default = `false`) |
-| `Options`           | `<Name>`     | Dictionary | No       | v2023.1+      | Customizes the actions for a given rule. |
-| `AllowReadAccess`   | `Options`    | Boolean    | No       | v2023.1+      | If true, indicates the rule will **not** be applied to actions that are read-only access (e.g., opening a watched path for reading, or cloning a watched path). If false, the rule will apply both to read-only access and access that could modify the watched path. (Default = `false`) |
-| `AuditOnly`         | `Options`    | Boolean    | No       | v2023.1+      | If true, operations violating the rule will only be logged. If false, operations violating the rule will be denied and logged. (Default = `true`) |
-| `Processes`         | `<Name>`     | Array      | No       | v2023.1+      | A list of dictionaries defining processes that are allowed to access paths matching the globs defined with the `Paths` key. For a process performing the operation to be considered a match, it must match all defined attributes of at least one entry in the list. |
-| `BinaryPath`        | `Processes`  | String     | No       | v2023.1+      | A path literal that an instigating process must be executed from. |
-| `TeamID`            | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
-| `CertificateSha256` | `Processes`  | String     | No       | v2023.1+      | SHA256 of the leaf certificate of the instigating process. |
-| `CDHash`            | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
-| `SigningID`         | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. |
-| `PlatformBinary`    | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
+| Key                       | Parent       | Type       | Required | Santa Version | Description |
+| :------------------------ | :----------- | :--------- | :------- | :------------ | :---------- |
+| `Version`                 | `<Root>`     | String     | Yes      | v2023.1+      | Version of the configuration. Will be reported in events. |
+| `WatchItems`              | `<Root>`     | Dictionary | No       | v2023.1+      | The set of configuration items that will be monitored by Santa. |
+| `<Name>`                  | `WatchItems` | Dictionary | No       | v2023.1+      | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (i.e., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
+| `Paths`                   | `<Name>`     | Array      | Yes      | v2023.1+      | A list of either String or Dictionary types that contain path globs to monitor. String type entires will have default values applied for the attributes that can be manually set with the Dictionary type. |
+| `Path`                    | `Paths`      | String     | Yes      | v2023.1+      | The path glob to monitor. |
+| `IsPrefix`                | `Paths`      | Boolean    | No       | v2023.1+      | Whether or not the path glob represents a prefix path. (Default = `false`) |
+| `Options`                 | `<Name>`     | Dictionary | No       | v2023.1+      | Customizes the actions for a given rule. |
+| `AllowReadAccess`         | `Options`    | Boolean    | No       | v2023.1+      | If true, indicates the rule will **not** be applied to actions that are read-only access (e.g., opening a watched path for reading, or cloning a watched path). If false, the rule will apply both to read-only access and access that could modify the watched path. (Default = `false`) |
+| `AuditOnly`               | `Options`    | Boolean    | No       | v2023.1+      | If true, operations violating the rule will only be logged. If false, operations violating the rule will be denied and logged. (Default = `true`) |
+| `InvertProcessExceptions` | `Options`    | Boolean    | No       | v2023.5+      | If true, logic is inverted for the list of processes defined by the `Processes` key such that the list becomes the set of processes that will be denied or allowed but audited. (Default = `false`) |
+| `Processes`               | `<Name>`     | Array      | No       | v2023.1+      | A list of dictionaries defining processes that are allowed to access paths matching the globs defined with the `Paths` key. For a process performing the operation to be considered a match, it must match all defined attributes of at least one entry in the list. |
+| `BinaryPath`              | `Processes`  | String     | No       | v2023.1+      | A path literal that an instigating process must be executed from. |
+| `TeamID`                  | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
+| `CertificateSha256`       | `Processes`  | String     | No       | v2023.1+      | SHA256 of the leaf certificate of the instigating process. |
+| `CDHash`                  | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
+| `SigningID`               | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. |
+| `PlatformBinary`          | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
 
 ### Example Configuration
 
@@ -67,6 +68,8 @@ This is an example configuration conforming to the specification outlined above:
 				<false/>
 				<key>AuditOnly</key>
 				<true/>
+				<key>InvertProcessExceptions</key>
+				<false/>
 			</dict>
 			<key>Processes</key>
 			<array>


### PR DESCRIPTION
Adds support for a new option key in the file monitoring config: `InvertProcessExceptions`. This will allow adding a rule to monitor file access from only specified processes.