### PR TITLE
Return unique_ptr from Enrich instead of shared_ptr

### DIFF
--- a/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
@@ -46,7 +46,11 @@ class EnrichedFile {
         group_(std::move(other.group_)),
         hash_(std::move(other.hash_)) {}
 
+  // Note: Move assignment could be safely implemented but not currently needed
+  EnrichedFile &operator=(EnrichedFile &&other) = delete;
+
   EnrichedFile(const EnrichedFile &other) = delete;
+  EnrichedFile &operator=(const EnrichedFile &other) = delete;
 
   const std::optional<std::shared_ptr<std::string>> &user() const {
     return user_;
@@ -87,7 +91,11 @@ class EnrichedProcess {
         real_group_(std::move(other.real_group_)),
         executable_(std::move(other.executable_)) {}
 
+  // Note: Move assignment could be safely implemented but not currently needed
+  EnrichedProcess &operator=(EnrichedProcess &&other) = delete;
+
   EnrichedProcess(const EnrichedProcess &other) = delete;
+  EnrichedProcess &operator=(const EnrichedProcess &other) = delete;
 
   const std::optional<std::shared_ptr<std::string>> &effective_user() const {
     return effective_user_;
@@ -123,7 +131,12 @@ class EnrichedEventType {
         instigator_(std::move(other.instigator_)),
         enrichment_time_(std::move(other.enrichment_time_)) {}
 
+  // Note: Move assignment could be safely implemented but not currently needed
+  // so no sense in implementing across all child classes
+  EnrichedEventType &operator=(EnrichedEventType &&other) = delete;
+
   EnrichedEventType(const EnrichedEventType &other) = delete;
+  EnrichedEventType &operator=(const EnrichedEventType &other) = delete;
 
   virtual ~EnrichedEventType() = default;
 

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.h
@@ -34,7 +34,7 @@ class Enricher {
  public:
   Enricher();
   virtual ~Enricher() = default;
-  virtual std::shared_ptr<EnrichedMessage> Enrich(Message &&msg);
+  virtual std::unique_ptr<EnrichedMessage> Enrich(Message &&msg);
   virtual EnrichedProcess Enrich(
       const es_process_t &es_proc,
       EnrichOptions options = EnrichOptions::kDefault);

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -236,9 +236,9 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
   }
 }
 
-- (void)processEnrichedMessage:(std::shared_ptr<EnrichedMessage>)msg
-                       handler:(void (^)(std::shared_ptr<EnrichedMessage>))messageHandler {
-  __block std::shared_ptr<EnrichedMessage> msgTmp = std::move(msg);
+- (void)processEnrichedMessage:(std::unique_ptr<EnrichedMessage>)msg
+                       handler:(void (^)(std::unique_ptr<EnrichedMessage>))messageHandler {
+  __block std::unique_ptr<EnrichedMessage> msgTmp = std::move(msg);
   dispatch_async(_notifyQueue, ^{
     messageHandler(std::move(msgTmp));
   });

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -72,9 +72,9 @@
 
 - (void)
   processEnrichedMessage:
-    (std::shared_ptr<santa::santad::event_providers::endpoint_security::EnrichedMessage>)msg
+    (std::unique_ptr<santa::santad::event_providers::endpoint_security::EnrichedMessage>)msg
                  handler:
-                   (void (^)(std::shared_ptr<
+                   (void (^)(std::unique_ptr<
                              santa::santad::event_providers::endpoint_security::EnrichedMessage>))
                      messageHandler;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -406,14 +406,14 @@ using santa::santad::event_providers::endpoint_security::Message;
                                              metrics:nullptr
                                            processor:Processor::kUnknown];
   {
-    auto enrichedMsg = std::make_shared<EnrichedMessage>(
+    auto enrichedMsg = std::make_unique<EnrichedMessage>(
       EnrichedClose(Message(mockESApi, &esMsg),
                     EnrichedProcess(std::nullopt, std::nullopt, std::nullopt, std::nullopt,
                                     EnrichedFile(std::nullopt, std::nullopt, std::nullopt)),
                     EnrichedFile(std::nullopt, std::nullopt, std::nullopt)));
 
-    [client processEnrichedMessage:enrichedMsg
-                           handler:^(std::shared_ptr<EnrichedMessage> msg) {
+    [client processEnrichedMessage:std::move(enrichedMsg)
+                           handler:^(std::unique_ptr<EnrichedMessage> msg) {
                              // reset the shared_ptr to drop the held message.
                              // This is a workaround for a TSAN only false positive
                              // which happens if we switch back to the sem wait

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -110,11 +110,11 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
 
   // Enrich the message inline with the ES handler block to capture enrichment
   // data as close to the source event as possible.
-  std::shared_ptr<EnrichedMessage> sharedEnrichedMessage = _enricher->Enrich(std::move(esMsg));
+  std::unique_ptr<EnrichedMessage> enrichedMessage = _enricher->Enrich(std::move(esMsg));
 
   // Asynchronously log the message
-  [self processEnrichedMessage:std::move(sharedEnrichedMessage)
-                       handler:^(std::shared_ptr<EnrichedMessage> msg) {
+  [self processEnrichedMessage:std::move(enrichedMessage)
+                       handler:^(std::unique_ptr<EnrichedMessage> msg) {
                          self->_logger->Log(std::move(msg));
                          recordEventMetrics(EventDisposition::kProcessed);
                        }];

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -48,7 +48,7 @@ using santa::santad::logs::endpoint_security::Logger;
 
 class MockEnricher : public Enricher {
  public:
-  MOCK_METHOD(std::shared_ptr<EnrichedMessage>, Enrich, (Message &&));
+  MOCK_METHOD(std::unique_ptr<EnrichedMessage>, Enrich, (Message &&));
 };
 
 class MockAuthResultCache : public AuthResultCache {
@@ -62,7 +62,7 @@ class MockLogger : public Logger {
  public:
   using Logger::Logger;
 
-  MOCK_METHOD(void, Log, (std::shared_ptr<EnrichedMessage>));
+  MOCK_METHOD(void, Log, (std::unique_ptr<EnrichedMessage>));
 };
 
 @interface SNTEndpointSecurityRecorderTest : XCTestCase
@@ -100,10 +100,10 @@ class MockLogger : public Logger {
   mockESApi->SetExpectationsESNewClient();
   mockESApi->SetExpectationsRetainReleaseMessage();
 
-  std::shared_ptr<EnrichedMessage> enrichedMsg = std::shared_ptr<EnrichedMessage>(nullptr);
+  std::unique_ptr<EnrichedMessage> enrichedMsg = std::unique_ptr<EnrichedMessage>(nullptr);
 
   auto mockEnricher = std::make_shared<MockEnricher>();
-  EXPECT_CALL(*mockEnricher, Enrich).WillOnce(testing::Return(enrichedMsg));
+  EXPECT_CALL(*mockEnricher, Enrich).WillOnce(testing::Return(std::move(enrichedMsg)));
 
   auto mockAuthCache = std::make_shared<MockAuthResultCache>(nullptr, nil);
   EXPECT_CALL(*mockAuthCache, RemoveFromCache(&targetFile)).Times(1);

--- a/Source/santad/Logs/EndpointSecurity/Logger.h
+++ b/Source/santad/Logs/EndpointSecurity/Logger.h
@@ -50,7 +50,7 @@ class Logger {
   virtual ~Logger() = default;
 
   virtual void Log(
-    std::shared_ptr<santa::santad::event_providers::endpoint_security::EnrichedMessage> msg);
+    std::unique_ptr<santa::santad::event_providers::endpoint_security::EnrichedMessage> msg);
 
   void LogAllowlist(const santa::santad::event_providers::endpoint_security::Message &msg,
                     const std::string_view hash);

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -80,7 +80,7 @@ Logger::Logger(std::shared_ptr<serializers::Serializer> serializer,
                std::shared_ptr<writers::Writer> writer)
     : serializer_(std::move(serializer)), writer_(std::move(writer)) {}
 
-void Logger::Log(std::shared_ptr<EnrichedMessage> msg) {
+void Logger::Log(std::unique_ptr<EnrichedMessage> msg) {
   writer_->Write(serializer_->SerializeMessage(std::move(msg)));
 }
 

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -138,7 +138,7 @@ class MockWriter : public Null {
   mockESApi->SetExpectationsRetainReleaseMessage();
 
   {
-    auto enrichedMsg = std::make_shared<EnrichedMessage>(
+    auto enrichedMsg = std::make_unique<EnrichedMessage>(
       EnrichedClose(Message(mockESApi, &msg),
                     EnrichedProcess(std::nullopt, std::nullopt, std::nullopt, std::nullopt,
                                     EnrichedFile(std::nullopt, std::nullopt, std::nullopt)),
@@ -147,7 +147,7 @@ class MockWriter : public Null {
     EXPECT_CALL(*mockSerializer, SerializeMessage(testing::A<const EnrichedClose &>())).Times(1);
     EXPECT_CALL(*mockWriter, Write).Times(1);
 
-    Logger(mockSerializer, mockWriter).Log(enrichedMsg);
+    Logger(mockSerializer, mockWriter).Log(std::move(enrichedMsg));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -36,7 +36,7 @@ class Serializer {
   virtual ~Serializer() = default;
 
   std::vector<uint8_t> SerializeMessage(
-    std::shared_ptr<santa::santad::event_providers::endpoint_security::EnrichedMessage> msg) {
+    std::unique_ptr<santa::santad::event_providers::endpoint_security::EnrichedMessage> msg) {
     return std::visit([this](const auto &arg) { return this->SerializeMessageTemplate(arg); },
                       msg->GetEnrichedMessage());
   }


### PR DESCRIPTION
Design cleanup. The enricher shouldn't vend shared pointers, and enriched objects don't need to be treated as shared pointers as they move through the processing pipeline.