### PR TITLE
Stop unmuting the default mute set unnecessarily.

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -193,13 +193,12 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
   return _esApi->UnsubscribeAll(_esClient);
 }
 
-- (bool)unmuteEverything {
-  bool result = _esApi->UnmuteAllPaths(_esClient);
-  result = _esApi->UnmuteAllTargetPaths(_esClient) && result;
-  return result;
+- (bool)unmuteAllTargetPaths {
+  return _esApi->UnmuteAllTargetPaths(_esClient);
 }
 
 - (bool)enableTargetPathWatching {
+  [self unmuteAllTargetPaths];
   return _esApi->InvertTargetPathMuting(_esClient);
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -49,7 +49,7 @@
 - (bool)subscribeAndClearCache:(const std::set<es_event_type_t> &)events;
 
 - (bool)unsubscribeAll;
-- (bool)unmuteEverything;
+- (bool)unmuteAllTargetPaths;
 - (bool)enableTargetPathWatching;
 - (bool)muteTargetPaths:
   (const std::vector<std::pair<std::string, santa::santad::data_layer::WatchItemPathType>> &)paths;

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -274,23 +274,20 @@ using santa::santad::event_providers::endpoint_security::Message;
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
 
-- (void)testUnmuteEverything {
+- (void)testUnmuteAllTargetPaths {
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
   SNTEndpointSecurityClient *client =
     [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
                                              metrics:nullptr
                                            processor:Processor::kUnknown];
 
-  // Test variations of underlying unmute impls returning both true and false
-  EXPECT_CALL(*mockESApi, UnmuteAllPaths)
-    .WillOnce(testing::Return(true))
-    .WillOnce(testing::Return(false));
+  // Test the underlying unmute impl returning both true and false
   EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths)
     .WillOnce(testing::Return(true))
-    .WillOnce(testing::Return(true));
+    .WillOnce(testing::Return(false));
 
-  XCTAssertTrue([client unmuteEverything]);
-  XCTAssertFalse([client unmuteEverything]);
+  XCTAssertTrue([client unmuteAllTargetPaths]);
+  XCTAssertFalse([client unmuteAllTargetPaths]);
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
@@ -301,6 +298,11 @@ using santa::santad::event_providers::endpoint_security::Message;
     [[SNTEndpointSecurityClient alloc] initWithESAPI:mockESApi
                                              metrics:nullptr
                                            processor:Processor::kUnknown];
+
+  // UnmuteAllTargetPaths is always attempted.
+  EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths)
+    .Times(2)
+    .WillRepeatedly(testing::Return(true));
 
   // Test the underlying invert nute impl returning both true and false
   EXPECT_CALL(*mockESApi, InvertTargetPathMuting)

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -300,9 +300,7 @@ using santa::santad::event_providers::endpoint_security::Message;
                                            processor:Processor::kUnknown];
 
   // UnmuteAllTargetPaths is always attempted.
-  EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths)
-    .Times(2)
-    .WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths).Times(2).WillRepeatedly(testing::Return(true));
 
   // Test the underlying invert nute impl returning both true and false
   EXPECT_CALL(*mockESApi, InvertTargetPathMuting)

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -241,7 +241,6 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
     [self establishClientOrDie];
 
     [super enableTargetPathWatching];
-    [super unmuteEverything];
   }
   return self;
 }
@@ -570,7 +569,7 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
     if ([super unsubscribeAll]) {
       self.isSubscribed = false;
     }
-    [super unmuteEverything];
+    [super unmuteAllTargetPaths];
   }
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -61,7 +61,6 @@ extern es_auth_result_t CombinePolicyResults(es_auth_result_t result1, es_auth_r
 void SetExpectationsForFileAccessAuthorizerInit(
   std::shared_ptr<MockEndpointSecurityAPI> mockESApi) {
   EXPECT_CALL(*mockESApi, InvertTargetPathMuting).WillOnce(testing::Return(true));
-  EXPECT_CALL(*mockESApi, UnmuteAllPaths).WillOnce(testing::Return(true));
   EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths).WillOnce(testing::Return(true));
 }
 
@@ -682,7 +681,6 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
                                                      decisionCache:nil];
 
   EXPECT_CALL(*mockESApi, UnsubscribeAll);
-  EXPECT_CALL(*mockESApi, UnmuteAllPaths).WillOnce(testing::Return(true));
   EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths).WillOnce(testing::Return(true));
 
   accessClient.isSubscribed = true;

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -111,7 +111,6 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 
 - (void)enable {
   [super enableTargetPathWatching];
-  [super unmuteEverything];
 
   // Get the set of protected paths
   std::set<std::string> protectedPaths = [SNTEndpointSecurityTamperResistance getProtectedPaths];

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -65,7 +65,6 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 
   // Setup mocks to handle inverting target path muting
   EXPECT_CALL(*mockESApi, InvertTargetPathMuting).WillOnce(testing::Return(true));
-  EXPECT_CALL(*mockESApi, UnmuteAllPaths).WillOnce(testing::Return(true));
   EXPECT_CALL(*mockESApi, UnmuteAllTargetPaths).WillOnce(testing::Return(true));
 
   // Setup mocks to handle muting the rules db and events db

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -173,3 +173,7 @@ action=FILE_ACCESS|policy_version=v0.1-experimental|policy_name=UserFoo|path=/Us
 ```
 
 When the `EventLogType` configuration key is set to `protobuf`, a log is emitted to match the `FileAccess` message in the [santa.proto](https://github.com/google/santa/blob/main/Source/common/santa.proto) schema.
+
+### Default Mute Set
+
+The EndpointSecurity framework maintains a set of paths dubbed the "default mute set" that are particularly difficult for ES clients to handle. Additionally, AUTH events from some of these paths have ES response deadline times set very low. In order to help increase stability of this feature, file accesses from binaries in the default mute set are not currently logged. A list of binaries that will not have operations logged can be found in [SNTRuleTable.m](https://github.com/google/santa/blob/2023.4/Source/santad/DataLayer/SNTRuleTable.m#L90-L105). This could be addressed in the future (see [Github Issue #1096](https://github.com/google/santa/issues/1096)).


### PR DESCRIPTION
This fixes an issue where the default mute set was being unnecessarily unmuted. Auth events from binaries within the default mute set that have very low deadlines (because deemed "critical" by ES) were getting denied, leading to unexpected behavior (such as unstable applications).

Fixes: https://github.com/google/santa/issues/1094 - Note: Tested with the config in the reported issue. Was able to repro the original issue as well as confirm this PR allows iTerm2 to launch and still log relevant FILE_ACCESS events. Note though that binaries in the default mute set will not be logged.
