### PR TITLE
Fix precedence for static rule evaluation, santactl fileinfo output

### DIFF
--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -403,6 +403,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
         case SNTEventStateBlockCertificate: [output appendString:@" (Certificate)"]; break;
         case SNTEventStateAllowTeamID:
         case SNTEventStateBlockTeamID: [output appendString:@" (TeamID)"]; break;
+        case SNTEventStateAllowSigningID:
+        case SNTEventStateBlockSigningID: [output appendString:@" (SigningID)"]; break;
         case SNTEventStateAllowScope:
         case SNTEventStateBlockScope: [output appendString:@" (Scope)"]; break;
         case SNTEventStateAllowCompiler: [output appendString:@" (Compiler)"]; break;

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -303,14 +303,27 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
   // Look for a static rule that matches.
   NSDictionary *staticRules = [[SNTConfigurator configurator] staticRules];
   if (staticRules.count) {
+    // IMPORTANT: The order static rules are checked here should be the same
+    // order as given by the SQL query for the rules database.
     rule = staticRules[binarySHA256];
-    if (rule.type == SNTRuleTypeBinary) return rule;
-    rule = staticRules[certificateSHA256];
-    if (rule.type == SNTRuleTypeCertificate) return rule;
-    rule = staticRules[teamID];
-    if (rule.type == SNTRuleTypeTeamID) return rule;
+    if (rule.type == SNTRuleTypeBinary) {
+      return rule;
+    }
+
     rule = staticRules[signingID];
-    if (rule.type == SNTRuleTypeSigningID) return rule;
+    if (rule.type == SNTRuleTypeSigningID) {
+      return rule;
+    }
+
+    rule = staticRules[certificateSHA256];
+    if (rule.type == SNTRuleTypeCertificate) {
+      return rule;
+    }
+
+    rule = staticRules[teamID];
+    if (rule.type == SNTRuleTypeTeamID) {
+      return rule;
+    }
   }
 
   // Now query the database.


### PR DESCRIPTION
Tested via `StaticRules` key in the config overrides file.
```
$ santactl fileinfo Source/santad/testdata/binaryrules/cert_hash_allowed_signingid_blocked
Path                   : ...Source/santad/testdata/binaryrules/cert_hash_allowed_signingid_blocked
SHA-256                : a9b62a5f8f9f77f89f8070ff109a5524e0fc67c83d7cc6655821cfd98f2e38ff
SHA-1                  : 1b1b60626f6422cb8f4aed829f0916beb7110bd9
Team ID                : EQHXZ8M8AV
Signing ID             : com.google.blocked_signing_id
Type                   : Executable (arm64, x86_64)
Code-signed            : Yes
Rule                   : Blocked (SigningID)

...
```
