### PR TITLE
Migrate to new SNTRuleType enum values

### DIFF
--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -38,11 +38,11 @@ typedef NS_ENUM(NSInteger, SNTAction) {
 
 // Supported Rule Types
 //
-// IMPORTANT: These enum values should be in order of decreasing precedence as
-// evaluated by Santa. That is, the lowest enum value has the highest precedence.
-// When adding new rule types, be sure to leave appropriate space between
-// surrounding values so that additional rules can more easily be added in the
-// future.
+// Note: These enum values should be in order of decreasing precedence as
+// evaluated by Santa. When adding new enum values, leave some space so that
+// additional rules can be added without violating this. The ordering isn't
+// strictly necessary but improves readability and may preemptively prevent
+// issues should SQLite behavior change.
 typedef NS_ENUM(NSInteger, SNTRuleType) {
   SNTRuleTypeUnknown = 0,
 

--- a/Source/common/SNTCommonEnums.h
+++ b/Source/common/SNTCommonEnums.h
@@ -36,13 +36,20 @@ typedef NS_ENUM(NSInteger, SNTAction) {
 #define RESPONSE_VALID(x) \
   (x == SNTActionRespondAllow || x == SNTActionRespondDeny || x == SNTActionRespondAllowCompiler)
 
+// Supported Rule Types
+//
+// IMPORTANT: These enum values should be in order of decreasing precedence as
+// evaluated by Santa. That is, the lowest enum value has the highest precedence.
+// When adding new rule types, be sure to leave appropriate space between
+// surrounding values so that additional rules can more easily be added in the
+// future.
 typedef NS_ENUM(NSInteger, SNTRuleType) {
-  SNTRuleTypeUnknown,
+  SNTRuleTypeUnknown = 0,
 
-  SNTRuleTypeBinary = 1,
-  SNTRuleTypeCertificate = 2,
-  SNTRuleTypeTeamID = 3,
-  SNTRuleTypeSigningID = 4,
+  SNTRuleTypeBinary = 1000,
+  SNTRuleTypeSigningID = 2000,
+  SNTRuleTypeCertificate = 3000,
+  SNTRuleTypeTeamID = 4000,
 };
 
 typedef NS_ENUM(NSInteger, SNTRuleState) {

--- a/Source/santad/DataLayer/SNTDatabaseTable.m
+++ b/Source/santad/DataLayer/SNTDatabaseTable.m
@@ -41,6 +41,7 @@
         }
         [self closeDeleteReopenDatabase:db];
       } else if ([db userVersion] > [self currentSupportedVersion]) {
+        LOGW(@"Database version newer than supported. Deleting.");
         [self closeDeleteReopenDatabase:db];
       }
     }];

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -25,7 +25,7 @@
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTRule.h"
 
-static const uint32_t kRuleTableCurrentVersion = 4;
+static const uint32_t kRuleTableCurrentVersion = 5;
 
 // TODO(nguyenphillip): this should be configurable.
 // How many rules must be in database before we start trying to remove transitive rules.
@@ -219,6 +219,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
 
   if (version < 5) {
     // Migrate SNTRuleType enum values
+    // Note: The reordering is intentional so that the type values are in order
+    // of precedence.
     [db executeUpdate:@"UPDATE rules SET type = 1000 WHERE type = 1"];
     [db executeUpdate:@"UPDATE rules SET type = 3000 WHERE type = 2"];
     [db executeUpdate:@"UPDATE rules SET type = 4000 WHERE type = 3"];


### PR DESCRIPTION
This change migrates the the SNTRuleType enum to have new values. They are now in order of precedence and allow room to grow for future rule types.

This requires a database version bump.