### PR TITLE
Fix rule evaluation for TeamID and SigningID rules when encountering invalid signatures

### DIFF
--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -65,6 +65,8 @@
       csInfo = nil;
       cd.decisionExtra =
         [NSString stringWithFormat:@"Signature ignored due to error: %ld", (long)csInfoError.code];
+      cd.teamID = nil;
+      cd.signingID = nil;
     } else {
       cd.certSHA256 = csInfo.leafCertificate.SHA256;
       cd.certCommonName = csInfo.leafCertificate.commonName;


### PR DESCRIPTION
This fixes an error in rule evaluation that causes the PolicyProcessor to incorrectly use Team ID and Signing ID when code signing is broken.