### PR TITLE
Enforce expected case for various rule type identifiers

### DIFF
--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -59,9 +59,10 @@ static const NSUInteger kExpectedTeamIDLength = 10;
 
     } else if (type == SNTRuleTypeSigningID) {
       // SigningID rules are a combination of `TeamID:SigningID`. The TeamID should
-      // be forced to be uppercase, but very loose rules existing for SigningIDs, the
-      // case will be kept as-is. As an exception, platform binaries are expected to
-      // have the hardcoded string "platform" as the team ID.
+      // be forced to be uppercase, but because very loose rules exist for SigningIDs,
+      // their case will be kept as-is. However, platform binaries are expected to
+      // have the hardcoded string "platform" as the team ID and the case will be left
+      // as is.
       NSArray *sidComponents = [identifier componentsSeparatedByString:@":"];
       if (!sidComponents || sidComponents.count != 2) {
         return nil;

--- a/Source/common/SNTRule.m
+++ b/Source/common/SNTRule.m
@@ -64,10 +64,11 @@ static const NSUInteger kExpectedTeamIDLength = 10;
       // have the hardcoded string "platform" as the team ID and the case will be left
       // as is.
       NSArray *sidComponents = [identifier componentsSeparatedByString:@":"];
-      if (!sidComponents || sidComponents.count != 2) {
+      if (!sidComponents || sidComponents.count < 2) {
         return nil;
       }
 
+      // The first component is the TeamID
       NSString *teamID = sidComponents[0];
 
       if (![teamID isEqualToString:@"platform"]) {
@@ -78,7 +79,10 @@ static const NSUInteger kExpectedTeamIDLength = 10;
         }
       }
 
-      NSString *signingID = sidComponents[1];
+      // The rest of the components are the Signing ID since ":" a legal character.
+      // Join all but the last element of the components to rebuild the SigningID.
+      NSString *signingID = [[sidComponents
+        subarrayWithRange:NSMakeRange(1, sidComponents.count - 1)] componentsJoinedByString:@":"];
       if (signingID.length == 0) {
         return nil;
       }

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -175,9 +175,9 @@
   // Signing ID can contain the TID:SID delimiter character (":")
   for (NSString *ident in @[
          @"ABCDEFGHIJ:com:",
-          @"ABCDEFGHIJ:com:example",
-          @"ABCDEFGHIJ::",
-          @"ABCDEFGHIJ:com:example:with:more:components:",
+         @"ABCDEFGHIJ:com:example",
+         @"ABCDEFGHIJ::",
+         @"ABCDEFGHIJ:com:example:with:more:components:",
        ]) {
     sut = [[SNTRule alloc] initWithDictionary:@{
       @"identifier" : ident,

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -143,6 +143,8 @@
          @":com.example",     // missing team ID
          @"ABCDEFGHIJ:",      // missing signing ID
          @"ABC:com.example",  // Invalid team id
+         @":",                // missing team and signing IDs
+         @"",                 // empty string
        ]) {
     sut = [[SNTRule alloc] initWithDictionary:@{
       @"identifier" : ident,

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -171,6 +171,22 @@
   }];
   XCTAssertNotNil(sut);
   XCTAssertEqualObjects(sut.identifier, @"platform:com.example");
+
+  // Signing ID can contain the TID:SID delimiter character (":")
+  for (NSString *ident in @[
+         @"ABCDEFGHIJ:com:",
+          @"ABCDEFGHIJ:com:example",
+          @"ABCDEFGHIJ::",
+          @"ABCDEFGHIJ:com:example:with:more:components:",
+       ]) {
+    sut = [[SNTRule alloc] initWithDictionary:@{
+      @"identifier" : ident,
+      @"policy" : @"ALLOWLIST",
+      @"rule_type" : @"SIGNINGID",
+    }];
+    XCTAssertNotNil(sut);
+    XCTAssertEqualObjects(sut.identifier, ident);
+  }
 }
 
 - (void)testInitWithDictionaryInvalid {

--- a/Source/common/SNTRuleTest.m
+++ b/Source/common/SNTRuleTest.m
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import <XCTest/XCTest.h>
+#include "Source/common/SNTCommonEnums.h"
 
 #import "Source/common/SNTRule.h"
 
@@ -46,13 +47,25 @@
   XCTAssertEqual(sut.type, SNTRuleTypeCertificate);
   XCTAssertEqual(sut.state, SNTRuleStateBlock);
 
+  // Ensure a Binary and Certificate rules properly convert identifiers to lowercase.
+  for (NSString *ruleType in @[ @"BINARY", @"CERTIFICATE" ]) {
+    sut = [[SNTRule alloc] initWithDictionary:@{
+      @"identifier" : @"B7C1E3FD640C5F211C89B02C2C6122F78CE322AA5C56EB0BB54BC422A8F8B670",
+      @"policy" : @"BLOCKLIST",
+      @"rule_type" : ruleType,
+    }];
+    XCTAssertNotNil(sut);
+    XCTAssertEqualObjects(sut.identifier,
+                          @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
+  }
+
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"identifier" : @"some-sort-of-identifier",
+    @"identifier" : @"ABCDEFGHIJ",
     @"policy" : @"SILENT_BLOCKLIST",
     @"rule_type" : @"TEAMID",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"some-sort-of-identifier");
+  XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(sut.type, SNTRuleTypeTeamID);
   XCTAssertEqual(sut.state, SNTRuleStateSilentBlock);
 
@@ -68,26 +81,94 @@
   XCTAssertEqual(sut.state, SNTRuleStateAllowCompiler);
 
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"identifier" : @"some-sort-of-identifier",
+    @"identifier" : @"ABCDEFGHIJ",
     @"policy" : @"REMOVE",
     @"rule_type" : @"TEAMID",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"some-sort-of-identifier");
+  XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(sut.type, SNTRuleTypeTeamID);
   XCTAssertEqual(sut.state, SNTRuleStateRemove);
 
   sut = [[SNTRule alloc] initWithDictionary:@{
-    @"identifier" : @"some-sort-of-identifier",
+    @"identifier" : @"ABCDEFGHIJ",
     @"policy" : @"ALLOWLIST",
     @"rule_type" : @"TEAMID",
     @"custom_msg" : @"A custom block message",
   }];
   XCTAssertNotNil(sut);
-  XCTAssertEqualObjects(sut.identifier, @"some-sort-of-identifier");
+  XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(sut.type, SNTRuleTypeTeamID);
   XCTAssertEqual(sut.state, SNTRuleStateAllow);
   XCTAssertEqualObjects(sut.customMsg, @"A custom block message");
+
+  // TeamIDs must be 10 chars in length
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"A",
+    @"policy" : @"ALLOWLIST",
+    @"rule_type" : @"TEAMID",
+  }];
+  XCTAssertNil(sut);
+
+  // TeamIDs must be only alphanumeric chars
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"ßßßßßßßßßß",
+    @"policy" : @"ALLOWLIST",
+    @"rule_type" : @"TEAMID",
+  }];
+  XCTAssertNil(sut);
+
+  // TeamIDs are converted to uppercase
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"abcdefghij",
+    @"policy" : @"REMOVE",
+    @"rule_type" : @"TEAMID",
+  }];
+  XCTAssertNotNil(sut);
+  XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ");
+
+  // SigningID tests
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"ABCDEFGHIJ:com.example",
+    @"policy" : @"REMOVE",
+    @"rule_type" : @"SIGNINGID",
+  }];
+  XCTAssertNotNil(sut);
+  XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ:com.example");
+  XCTAssertEqual(sut.type, SNTRuleTypeSigningID);
+  XCTAssertEqual(sut.state, SNTRuleStateRemove);
+
+  // Invalid SingingID tests:
+  for (NSString *ident in @[
+         @":com.example",     // missing team ID
+         @"ABCDEFGHIJ:",      // missing signing ID
+         @"ABC:com.example",  // Invalid team id
+       ]) {
+    sut = [[SNTRule alloc] initWithDictionary:@{
+      @"identifier" : ident,
+      @"policy" : @"REMOVE",
+      @"rule_type" : @"SIGNINGID",
+    }];
+    XCTAssertNil(sut);
+  }
+
+  // Signing ID with lower team ID has case fixed up
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"abcdefghij:com.example",
+    @"policy" : @"REMOVE",
+    @"rule_type" : @"SIGNINGID",
+  }];
+  XCTAssertNotNil(sut);
+  XCTAssertEqualObjects(sut.identifier, @"ABCDEFGHIJ:com.example");
+
+  // Signing ID with lower platform team ID is left alone
+  sut = [[SNTRule alloc] initWithDictionary:@{
+    @"identifier" : @"platform:com.example",
+    @"policy" : @"REMOVE",
+    @"rule_type" : @"SIGNINGID",
+  }];
+  XCTAssertNotNil(sut);
+  XCTAssertEqualObjects(sut.identifier, @"platform:com.example");
 }
 
 - (void)testInitWithDictionaryInvalid {

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -36,7 +36,7 @@
 
 - (SNTRule *)_exampleTeamIDRule {
   SNTRule *r = [[SNTRule alloc] init];
-  r.identifier = @"teamID";
+  r.identifier = @"ABCDEFGHIJ";
   r.state = SNTRuleStateBlock;
   r.type = SNTRuleTypeTeamID;
   r.customMsg = @"A teamID rule";
@@ -48,11 +48,11 @@
   if (isPlatformBinary) {
     r.identifier = @"platform:signingID";
   } else {
-    r.identifier = @"teamID:signingID";
+    r.identifier = @"ABCDEFGHIJ:signingID";
   }
   r.state = SNTRuleStateBlock;
   r.type = SNTRuleTypeSigningID;
-  r.customMsg = @"A teamID rule";
+  r.customMsg = @"A signingID rule";
   return r;
 }
 
@@ -187,9 +187,9 @@
   SNTRule *r = [self.sut ruleForBinarySHA256:nil
                                    signingID:nil
                            certificateSHA256:nil
-                                      teamID:@"teamID"];
+                                      teamID:@"ABCDEFGHIJ"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"teamID");
+  XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID);
   XCTAssertEqual([self.sut teamIDRuleCount], 1);
 
@@ -211,12 +211,12 @@
   XCTAssertEqual([self.sut signingIDRuleCount], 2);
 
   SNTRule *r = [self.sut ruleForBinarySHA256:nil
-                                   signingID:@"teamID:signingID"
+                                   signingID:@"ABCDEFGHIJ:signingID"
                            certificateSHA256:nil
                                       teamID:nil];
 
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"teamID:signingID");
+  XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ:signingID");
   XCTAssertEqual(r.type, SNTRuleTypeSigningID);
 
   r = [self.sut ruleForBinarySHA256:nil
@@ -243,9 +243,9 @@
   // See the comment in SNTRuleTable#ruleForBinarySHA256:certificateSHA256:teamID
   SNTRule *r = [self.sut
     ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
-              signingID:@"teamID:signingID"
+              signingID:@"ABCDEFGHIJ:signingID"
       certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
-                 teamID:@"teamID"];
+                 teamID:@"ABCDEFGHIJ"];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
@@ -253,9 +253,9 @@
 
   r = [self.sut
     ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
-              signingID:@"teamID:signingID"
+              signingID:@"ABCDEFGHIJ:signingID"
       certificateSHA256:@"unknowncert"
-                 teamID:@"teamID"];
+                 teamID:@"ABCDEFGHIJ"];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
@@ -265,26 +265,26 @@
     ruleForBinarySHA256:@"unknown"
               signingID:@"unknown"
       certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
-                 teamID:@"teamID"];
+                 teamID:@"ABCDEFGHIJ"];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate, @"Implicit rule ordering failed");
 
   r = [self.sut ruleForBinarySHA256:@"unknown"
-                          signingID:@"teamID:signingID"
+                          signingID:@"ABCDEFGHIJ:signingID"
                   certificateSHA256:@"unknown"
-                             teamID:@"teamID"];
+                             teamID:@"ABCDEFGHIJ"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"teamID:signingID");
+  XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ:signingID");
   XCTAssertEqual(r.type, SNTRuleTypeSigningID, @"Implicit rule ordering failed (SigningID)");
 
   r = [self.sut ruleForBinarySHA256:@"unknown"
                           signingID:@"unknown"
                   certificateSHA256:@"unknown"
-                             teamID:@"teamID"];
+                             teamID:@"ABCDEFGHIJ"];
   XCTAssertNotNil(r);
-  XCTAssertEqualObjects(r.identifier, @"teamID");
+  XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID, @"Implicit rule ordering failed (TeamID)");
 }
 

--- a/Source/santad/SNTDecisionCacheTest.mm
+++ b/Source/santad/SNTDecisionCacheTest.mm
@@ -85,8 +85,8 @@ SNTCachedDecision *MakeCachedDecision(struct stat sb, SNTEventState decision) {
 
   OCMExpect([self.mockRuleDatabase
     resetTimestampForRule:[OCMArg checkWithBlock:^BOOL(SNTRule *rule) {
-      return rule.identifier == cd.sha256 && rule.state == SNTRuleStateAllowTransitive &&
-             rule.type == SNTRuleTypeBinary;
+      return [rule.identifier isEqualToString:cd.sha256] &&
+             rule.state == SNTRuleStateAllowTransitive && rule.type == SNTRuleTypeBinary;
     }]]);
 
   [dc resetTimestampForCachedDecision:sb];


### PR DESCRIPTION
This PR enforces the following:
1. Binary and Certificate rule identifiers (sha 256 hex strings) will be converted to lowercase
2. TeamID rule identifiers (10 character alphanumeric strings) will be converted to uppercase
3. SigningID rule identifiers will have the TeamID portion of the rule be converted to uppercase, but the Signing ID portion will be left alone (e.g. `tid:Sid` --> `TID:Sid`)
    * However, if the hard coded TeamID "platform" is used, it will not have its case converted

fixes #1131