### PR TITLE
Change "exponential" backoff in SNTSyncStage.m to be exponential

### DIFF
--- a/Source/santasyncservice/SNTSyncStage.m
+++ b/Source/santasyncservice/SNTSyncStage.m
@@ -115,7 +115,7 @@
       nanosleep(&ts, NULL);
     }
 
-    SLOGD(@"Performing request, attempt %d", attempt);
+    SLOGD(@"Performing request, attempt %d (of %d maximum)...", attempt, maxAttempts);
     data = [self performRequest:request timeout:timeout response:&response error:&error];
     if (response.statusCode == 200) break;
 

--- a/Source/santasyncservice/SNTSyncStage.m
+++ b/Source/santasyncservice/SNTSyncStage.m
@@ -106,9 +106,12 @@
   NSError *error;
   NSData *data;
 
-  for (int attempt = 1; attempt < 6; ++attempt) {
-    if (attempt > 1) {
-      struct timespec ts = {.tv_sec = (attempt * 2)};
+  int maxAttempts = 5;
+  for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
+    if (attempt >= 2) {
+      // Exponentially back off with larger and larger delays.
+      int exponentialBackoffMultiplier = 2;  // E.g. 2^2 = 4, 2^3 = 8, 2^4 = 16...
+      struct timespec ts = {.tv_sec = pow(exponentialBackoffMultiplier, attempt)};
       nanosleep(&ts, NULL);
     }
 


### PR DESCRIPTION
Fixes the sync --clean "exponential" backoff to be actually exponential, instead of its current linear version (2, 4, 6, 8, 10).

Suggests an improvement to the log message to indicate that the job will ALWAYS abort after N retries. Previously, it was not clear why it would try 5 times and then give up.

This is motivated by an actual incident on July 26, 2023, where the backoff was insufficient, causing users to be unable to download updated rules.

Previously, a user would see something like this when running sudo santactl sync --clean:

```
sudo santactl sync --clean
Uploaded 1 events
Received 697 rules
Performing request, attempt 1
Received 784 rules
Performing request, attempt 1
Received 715 rules
Performing request, attempt 1
Performing request, attempt 2
Performing request, attempt 3
Performing request, attempt 4
Performing request, attempt 5  <-- is not clear to the user why this would be the last attempt
Rule download failed, aborting run
```
