### PR TITLE
Check if spool dir has changed before estimating size

### DIFF
--- a/Source/common/TestUtils.h
+++ b/Source/common/TestUtils.h
@@ -49,14 +49,17 @@
 // function returns early due to interrupts.
 void SleepMS(long ms);
 
-enum class ActionType {
-  Auth,
-  Notify,
-};
+// Helper to construct strings of a given length
+NSString *RepeatedString(NSString *str, NSUInteger len);
 
 //
 // Helpers to construct various ES structs
 //
+
+enum class ActionType {
+  Auth,
+  Notify,
+};
 
 audit_token_t MakeAuditToken(pid_t pid, pid_t pidver);
 

--- a/Source/common/TestUtils.mm
+++ b/Source/common/TestUtils.mm
@@ -21,6 +21,10 @@
 #include <uuid/uuid.h>
 #include "Source/common/SystemResources.h"
 
+NSString *RepeatedString(NSString *str, NSUInteger len) {
+  return [@"" stringByPaddingToLength:len withString:str startingAtIndex:0];
+}
+
 audit_token_t MakeAuditToken(pid_t pid, pid_t pidver) {
   return audit_token_t{
     .val =

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -93,10 +93,6 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   return [@{@"Version" : @(kVersion.data()), @"WatchItems" : [config mutableCopy]} mutableCopy];
 }
 
-static NSString *RepeatedString(NSString *str, NSUInteger len) {
-  return [@"" stringByPaddingToLength:len withString:str startingAtIndex:0];
-}
-
 @interface WatchItemsTest : XCTestCase
 @property NSFileManager *fileMgr;
 @property NSString *testDir;

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/BUILD
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/BUILD
@@ -69,6 +69,7 @@ santa_unit_test(
     deps = [
         ":fsspool",
         ":fsspool_log_batch_writer",
+        "//Source/common:TestUtils",
         "@OCMock",
     ],
 )

--- a/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_log_batch_writer.cc
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_log_batch_writer.cc
@@ -33,7 +33,6 @@ FsSpoolLogBatchWriter::~FsSpoolLogBatchWriter() {
   if (!s.ok()) {
     os_log(OS_LOG_DEFAULT, "Flush() failed with %s",
            s.ToString(absl::StatusToStringMode::kWithEverything).c_str());
-    // LOG(WARNING) << "Flush() failed with " << s;
   }
 }
 


### PR DESCRIPTION
Santa imposes size limits on the spool directory when using the protobuf logger to help ensure too much disk space isn't used. However when the limit is reached, Santa will attempt to re-estimate the size of the spool directory on every event in the hopes that some space cleared and more logs can be written. However if there are many files in the spool, this will lead to `stat(2)` being called excessively (on every spool file for every logged event).

This change stores the last modification time of the spool directory when a size estimate is requested. If the modification time hasn't changed since the previous call, the old estimate is used instead of computing a new one. Once files are removed, the modification time will change and a new estimate will be gathered.

b/288318170