### PR TITLE
Only update daemon settings when sync settings explicitly set

### DIFF
--- a/Source/santasyncservice/SNTSyncPostflight.m
+++ b/Source/santasyncservice/SNTSyncPostflight.m
@@ -69,6 +69,30 @@
                      }];
   }
 
+  if (self.syncState.enableBundles) {
+    [rop setEnableBundles:[self.syncState.enableBundles boolValue]
+                    reply:^{
+                    }];
+  }
+
+  if (self.syncState.enableTransitiveRules) {
+    [rop setEnableTransitiveRules:[self.syncState.enableTransitiveRules boolValue]
+                            reply:^{
+                            }];
+  }
+
+  if (self.syncState.enableAllEventUpload) {
+    [rop setEnableAllEventUpload:[self.syncState.enableAllEventUpload boolValue]
+                           reply:^{
+                           }];
+  }
+
+  if (self.syncState.disableUnknownEventUpload) {
+    [rop setDisableUnknownEventUpload:[self.syncState.disableUnknownEventUpload boolValue]
+                                reply:^{
+                                }];
+  }
+
   // Update last sync success
   [rop setFullSyncLastSuccess:[NSDate date]
                         reply:^{

--- a/Source/santasyncservice/SNTSyncState.h
+++ b/Source/santasyncservice/SNTSyncState.h
@@ -61,6 +61,10 @@
 @property SNTClientMode clientMode;
 @property NSString *allowlistRegex;
 @property NSString *blocklistRegex;
+@property NSNumber *enableBundles;
+@property NSNumber *enableTransitiveRules;
+@property NSNumber *enableAllEventUpload;
+@property NSNumber *disableUnknownEventUpload;
 @property NSNumber *blockUSBMount;
 // Array of mount args for the forced remounting feature.
 @property NSArray *remountUSBMode;


### PR DESCRIPTION
This also moves sending to the main daemon all settings received during preflight to postflight. Currently, this is inconsistent and some settings are sent during preflight, and others during postflight.

fixes #1137 