### PR TITLE
Add hot cache for targets of read only policies

### DIFF
--- a/Source/common/TestUtils.h
+++ b/Source/common/TestUtils.h
@@ -70,7 +70,7 @@ audit_token_t MakeAuditToken(pid_t pid, pid_t pidver);
 struct stat MakeStat(int offset = 0);
 
 es_string_token_t MakeESStringToken(const char *s);
-es_file_t MakeESFile(const char *path, struct stat sb = {});
+es_file_t MakeESFile(const char *path, struct stat sb = MakeStat());
 es_process_t MakeESProcess(es_file_t *file, audit_token_t tok = {}, audit_token_t parent_tok = {});
 es_message_t MakeESMessage(es_event_type_t et, es_process_t *proc,
                            ActionType action_type = ActionType::Notify,

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -374,6 +374,8 @@ objc_library(
         "//Source/common:String",
         "@MOLCertificate",
         "@MOLCodesignChecker",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -84,9 +84,9 @@ struct PathTarget {
 };
 
 // This is a bespoke cache for mapping processes to a set of files the process
-// has previously been allowed to read as defined by policy. It has simialr
+// has previously been allowed to read as defined by policy. It has similar
 // semantics to SantaCache in terms of clearing the cache keys and values when
-// max sizs are reached.
+// max sizes are reached.
 // TODO: We need a proper LRU cache
 //
 // NB: SantaCache should not be used here.

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -28,8 +28,6 @@
 #include <memory>
 #include <optional>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <variant>
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -166,7 +166,7 @@ class ProcessFiles {
   void ClearLocked() { cache_.clear(); }
 
   dispatch_queue_t q_;
-  absl::flat_hash_map<std::pair<pid_t, pid_t>, FileSet, PairHash> cache_;
+  absl::flat_hash_map<std::pair<pid_t, pid_t>, FileSet> cache_;
 
   // Cache limits are merely meant to protect against unbounded growth. In practice,
   // the observed cache size is typically small for normal WatchItems rules (those

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -74,14 +74,6 @@ NSString *kBadCertHash = @"BAD_CERT_HASH";
 static constexpr uint32_t kOpenFlagsIndicatingWrite = FWRITE | O_APPEND | O_TRUNC;
 static constexpr uint16_t kDefaultRateLimitQPS = 50;
 
-// Cache limits are merely meant to protect against unbounded growth. In practice,
-// the observed cache size is typically small for normal WatchItems rules (those
-// that do not target high-volume paths). The per entry size was observed to vary
-// quite dramatically based on the type of process (e.g. large, complex applications
-// were observed to frequently have several thousands of entries).
-static constexpr size_t kMaxCacheSize = 512;
-static constexpr size_t kMaxCacheEntrySize = 8192;
-
 // Small structure to hold a complete event path target being operated upon and
 // a bool indicating whether the path is a readable target (e.g. a file being
 // opened or cloned)
@@ -180,6 +172,14 @@ class ProcessFiles {
 
   dispatch_queue_t q_;
   std::unordered_map<std::pair<pid_t, pid_t>, FileSet, PairHash> cache_;
+
+  // Cache limits are merely meant to protect against unbounded growth. In practice,
+  // the observed cache size is typically small for normal WatchItems rules (those
+  // that do not target high-volume paths). The per entry size was observed to vary
+  // quite dramatically based on the type of process (e.g. large, complex applications
+  // were observed to frequently have several thousands of entries).
+  static constexpr size_t kMaxCacheSize = 512;
+  static constexpr size_t kMaxCacheEntrySize = 8192;
 };
 
 static inline std::string Path(const es_file_t *esFile) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -64,13 +64,6 @@ using santa::santad::event_providers::endpoint_security::EnrichOptions;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::Logger;
 
-struct PairHash {
-  template <typename T1, typename T2>
-  std::size_t operator()(const std::pair<T1, T2> &pair) const {
-    return std::hash<T1>()(pair.first) << 1 ^ std::hash<T2>()(pair.second);
-  }
-};
-
 NSString *kBadCertHash = @"BAD_CERT_HASH";
 
 static constexpr uint32_t kOpenFlagsIndicatingWrite = FWRITE | O_APPEND | O_TRUNC;
@@ -97,7 +90,7 @@ struct PathTarget {
 //     unnecessarily copy the value.
 //     2.) It doesn't support size limits on value types
 class ProcessFiles {
-  using FileSet = absl::flat_hash_set<std::pair<dev_t, ino_t>, PairHash>;
+  using FileSet = absl::flat_hash_set<std::pair<dev_t, ino_t>>;
 
  public:
   ProcessFiles() {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -674,6 +674,10 @@ void PopulatePathTargets(const Message &msg, std::vector<PathTarget> &targets) {
     // begin receiving events (if not already)
     [self enable];
   }
+
+  dispatch_sync(self.hotCacheQueue, ^{
+    self->_hotCache.clear();
+  });
 }
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -48,6 +48,8 @@
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/EventProviders/RateLimiter.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 
 using santa::common::StringToNSString;
 using santa::santad::EventDisposition;
@@ -95,7 +97,7 @@ struct PathTarget {
 //     unnecessarily copy the value.
 //     2.) It doesn't support size limits on value types
 class ProcessFiles {
-  using FileSet = std::unordered_set<std::pair<dev_t, ino_t>, PairHash>;
+  using FileSet = absl::flat_hash_set<std::pair<dev_t, ino_t>, PairHash>;
 
  public:
   ProcessFiles() {
@@ -171,7 +173,7 @@ class ProcessFiles {
   void ClearLocked() { cache_.clear(); }
 
   dispatch_queue_t q_;
-  std::unordered_map<std::pair<pid_t, pid_t>, FileSet, PairHash> cache_;
+  absl::flat_hash_map<std::pair<pid_t, pid_t>, FileSet, PairHash> cache_;
 
   // Cache limits are merely meant to protect against unbounded growth. In practice,
   // the observed cache size is typically small for normal WatchItems rules (those

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sys/fcntl.h>
+#include <sys/types.h>
 #include <cstring>
 
 #include <array>
@@ -50,6 +51,7 @@ extern NSString *kBadCertHash;
 struct PathTarget {
   std::string path;
   bool isReadable;
+  std::optional<std::pair<dev_t, ino_t>> devnoIno;
 };
 
 using PathTargetsPair = std::pair<std::optional<std::string>, std::optional<std::string>>;
@@ -663,7 +665,7 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
   std::set<es_event_type_t> expectedEventSubs = {
     ES_EVENT_TYPE_AUTH_CLONE,    ES_EVENT_TYPE_AUTH_CREATE, ES_EVENT_TYPE_AUTH_EXCHANGEDATA,
     ES_EVENT_TYPE_AUTH_LINK,     ES_EVENT_TYPE_AUTH_OPEN,   ES_EVENT_TYPE_AUTH_RENAME,
-    ES_EVENT_TYPE_AUTH_TRUNCATE, ES_EVENT_TYPE_AUTH_UNLINK,
+    ES_EVENT_TYPE_AUTH_TRUNCATE, ES_EVENT_TYPE_AUTH_UNLINK, ES_EVENT_TYPE_NOTIFY_EXIT,
   };
 
 #if HAVE_MACOS_12


### PR DESCRIPTION
This adds a new cache to the FAA client that caches target paths that are allowed to be read by policy. When future OPEN events are received, if the target isn't being opened for writing, the cache is first checked  to see if the target has previously been allowed. If so, a response is sent immediately without processing the message asynchronously or having to lookup policy.