### PR TITLE
Cast enum to int

### DIFF
--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -60,7 +60,8 @@ NSString *const FlushCacheReasonToString(FlushCacheReason reason) {
     case FlushCacheReason::kExplicitCommand: return kFlushCacheReasonExplicitCommand;
     case FlushCacheReason::kFilesystemUnmounted: return kFlushCacheReasonFilesystemUnmounted;
     default:
-      [NSException raise:@"Invalid reason" format:@"Unknown reason value: %d", reason];
+      [NSException raise:@"Invalid reason"
+                  format:@"Unknown reason value: %d", static_cast<int>(reason)];
       return nil;
   }
 }

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -104,9 +104,9 @@ es_auth_result_t FileAccessPolicyDecisionToESAuthResult(FileAccessPolicyDecision
     case FileAccessPolicyDecision::kAllowedAuditOnly: return ES_AUTH_RESULT_ALLOW;
     default:
       // This is a programming error. Bail.
-      LOGE(@"Invalid file access decision encountered: %d", decision);
+      LOGE(@"Invalid file access decision encountered: %d", static_cast<int>(decision));
       [NSException raise:@"Invalid FileAccessPolicyDecision"
-                  format:@"Invalid FileAccessPolicyDecision: %d", decision];
+                  format:@"Invalid FileAccessPolicyDecision: %d", static_cast<int>(decision)];
   }
 }
 

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -63,7 +63,8 @@ NSString *const ProcessorToString(Processor processor) {
     case Processor::kTamperResistance: return kProcessorTamperResistance;
     case Processor::kFileAccessAuthorizer: return kProcessorFileAccessAuthorizer;
     default:
-      [NSException raise:@"Invalid processor" format:@"Unknown processor value: %d", processor];
+      [NSException raise:@"Invalid processor"
+                  format:@"Unknown processor value: %d", static_cast<int>(processor)];
       return nil;
   }
 }
@@ -103,7 +104,8 @@ NSString *const EventDispositionToString(EventDisposition d) {
     case EventDisposition::kDropped: return kEventDispositionDropped;
     case EventDisposition::kProcessed: return kEventDispositionProcessed;
     default:
-      [NSException raise:@"Invalid disposition" format:@"Unknown disposition value: %d", d];
+      [NSException raise:@"Invalid disposition"
+                  format:@"Unknown disposition value: %d", static_cast<int>(d)];
       return nil;
   }
 }


### PR DESCRIPTION
Allows the string displaying the enum to format it using %d.

Fixes the error:
error: format specifies type 'int' but the argument has type 'T' [-Werror,-Wformat]