### PR TITLE
Add support for was_mmaped_writeable to file write monitoring when using macOS 13+

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -90,6 +90,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
     case ES_EVENT_TYPE_NOTIFY_CLOSE: {
       BOOL shouldLogClose = esMsg->event.close.modified;
 
+#if HAVE_MACOS_13
       if (@available(macOS 13.5, *)) {
         // As of macSO 13.0 we have a new field for if a file was mmaped with
         // write permissions on close events. However it did not work until
@@ -101,6 +102,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
         // account.
         shouldLogClose |= esMsg->event.close.was_mapped_writable;
       }
+#endif
 
       if (!shouldLogClose) {
         // Ignore unmodified files

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -176,7 +176,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 }
 
 - (void)testHandleMessageWithCloseMappedWriteable {
-  #if HAVE_MACOS_13
+#if HAVE_MACOS_13
   if (@available(macOS 13.0, *)) {
     // CLOSE not modified, but was_mapped_writable, should remove from cache,
     // and matches fileChangesRegex
@@ -204,11 +204,11 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 
     [self testHandleMessageWithMatchCalls:1 withMissCalls:0 withBlock:testBlock];
   }
-  #endif
+#endif
 }
 
 - (void)testHandleEventCloseNotModifiedWithWasMappedWritable {
-  #if HAVE_MACOS_13
+#if HAVE_MACOS_13
   if (@available(macOS 13.0, *)) {
     // CLOSE not modified, but was_mapped_writable, remove from cache, and does not match
     // fileChangesRegex
@@ -231,7 +231,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 
     [self testHandleMessageWithMatchCalls:0 withMissCalls:1 withBlock:testBlock];
   }
-  #endif
+#endif
 }
 
 - (void)testHandleMessage {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -176,6 +176,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 }
 
 - (void)testHandleMessageWithCloseMappedWriteable {
+  #if HAVE_MACOS_13
   if (@available(macOS 13.0, *)) {
     // CLOSE not modified, but was_mapped_writable, should remove from cache,
     // and matches fileChangesRegex
@@ -203,9 +204,11 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 
     [self testHandleMessageWithMatchCalls:1 withMissCalls:0 withBlock:testBlock];
   }
+  #endif
 }
 
 - (void)testHandleEventCloseNotModifiedWithWasMappedWritable {
+  #if HAVE_MACOS_13
   if (@available(macOS 13.0, *)) {
     // CLOSE not modified, but was_mapped_writable, remove from cache, and does not match
     // fileChangesRegex
@@ -228,6 +231,7 @@ es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 
     [self testHandleMessageWithMatchCalls:0 withMissCalls:1 withBlock:testBlock];
   }
+  #endif
 }
 
 - (void)testHandleMessage {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -113,8 +113,8 @@ es_file_t targetFileMatchesRegex = MakeESFile("/foo/matches");
 es_file_t targetFileMissesRegex = MakeESFile("/foo/misses");
 
 - (void)handleMessageWithMatchCalls:(BOOL)regexMatchCalls
-                          withMissCalls:(BOOL)regexFailsMatchCalls
-                              withBlock:(testHelperBlock)testBlock {
+                      withMissCalls:(BOOL)regexFailsMatchCalls
+                          withBlock:(testHelperBlock)testBlock {
   es_file_t file = MakeESFile("foo");
   es_process_t proc = MakeESProcess(&file);
   es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_NOTIFY_CLOSE, &proc, ActionType::Auth);


### PR DESCRIPTION
This adds support for using the new was_mapped_writable flag.

In macOS 13 close events now have a new field was_mapped_writable that lets us track if the file was mmaped writable.  Often developer tools use mmap to avoid large numbers of write syscalls (e.g. the go toolchain) and this improves transitive allow listing with those tools.

Fixes #561.