### PR TITLE
Add mount from name information to disk appear events

### DIFF
--- a/Source/common/TestUtils.h
+++ b/Source/common/TestUtils.h
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 #include <sys/stat.h>
 
+#include <string>
+
 #define NOBODY_UID ((unsigned int)-2)
 #define NOGROUP_GID ((unsigned int)-1)
 
@@ -37,6 +39,10 @@
 
 // Pretty print C++ string match errors
 #define XCTAssertCppStringEqual(got, want) XCTAssertCStringEqual((got).c_str(), (want).c_str())
+
+#define XCTAssertCppStringBeginsWith(got, want)                                               \
+  XCTAssertTrue((got).rfind((want), 0) == 0, "\nPrefix not found.\n\t got: %s\n\twant: %s\n", \
+                (got).c_str(), (want).c_str())
 
 // Note: Delta between local formatter and the one run on Github. Disable for now.
 // clang-format off

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -429,6 +429,9 @@ message Disk {
 
   // Time device appeared/disappeared
   optional google.protobuf.Timestamp appearance = 10;
+
+  // Path mounted from
+  optional string mount_from = 11;
 }
 
 // Information emitted when Santa captures bundle information

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -470,6 +470,7 @@ objc_library(
         "//Source/common:SantaCache",
         "//Source/common:SantaVnode",
         "//Source/common:SantaVnodeHash",
+        "//Source/common:String",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -46,6 +46,7 @@ using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::EnrichedRename;
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
+using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
 using santa::santad::logs::endpoint_security::serializers::Utilities::NonNull;
 using santa::santad::logs::endpoint_security::serializers::Utilities::Pid;
 using santa::santad::logs::endpoint_security::serializers::Utilities::Pidversion;
@@ -509,6 +510,8 @@ std::vector<uint8_t> BasicString::SerializeDiskAppeared(NSDictionary *props) {
   str.append([NonNull(dmg_path) UTF8String]);
   str.append("|appearance=");
   str.append([NonNull(appearanceDateString) UTF8String]);
+  str.append("|mountfrom=");
+  str.append([NonNull(MountFromName([props[@"DAVolumePath"] path])) UTF8String]);
 
   return FinalizeString(str);
 }

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -351,7 +351,7 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
     @"DADeviceVendor" : @"vendor",
     @"DADeviceModel" : @"model",
     @"DAAppearanceTime" : @(1252487349),  // 2009-09-09 09:09:09
-    @"DAVolumePath" : [NSURL URLWithString:@"path"],
+    @"DAVolumePath" : [NSURL URLWithString:@"/"],
     @"DAMediaBSDName" : @"bsd",
     @"DAVolumeKind" : @"apfs",
     @"DADeviceProtocol" : @"usb",
@@ -365,11 +365,11 @@ std::string BasicStringSerializeMessage(es_message_t *esMsg) {
   std::vector<uint8_t> ret = BasicString::Create(nullptr, nil, false)->SerializeDiskAppeared(props);
   std::string got(ret.begin(), ret.end());
 
-  std::string want = "action=DISKAPPEAR|mount=path|volume=|bsdname=bsd|fs=apfs"
+  std::string want = "action=DISKAPPEAR|mount=/|volume=|bsdname=bsd|fs=apfs"
                      "|model=vendor model|serial=|bus=usb|dmgpath="
-                     "|appearance=2040-09-09T09:09:09.000Z\n";
+                     "|appearance=2040-09-09T09:09:09.000Z|mountfrom=/";
 
-  XCTAssertCppStringEqual(got, want);
+  XCTAssertCppStringBeginsWith(got, want);
 }
 
 - (void)testSerializeDiskDisappeared {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -59,6 +59,7 @@ using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::serializers::Utilities::EffectiveGroup;
 using santa::santad::logs::endpoint_security::serializers::Utilities::EffectiveUser;
+using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
 using santa::santad::logs::endpoint_security::serializers::Utilities::NonNull;
 using santa::santad::logs::endpoint_security::serializers::Utilities::Pid;
 using santa::santad::logs::endpoint_security::serializers::Utilities::Pidversion;
@@ -682,6 +683,8 @@ static void EncodeDisk(::pbv1::Disk *pb_disk, ::pbv1::Disk_Action action, NSDict
   EncodeString([pb_disk] { return pb_disk->mutable_serial(); }, serial);
   EncodeString([pb_disk] { return pb_disk->mutable_bus(); }, props[@"DADeviceProtocol"]);
   EncodeString([pb_disk] { return pb_disk->mutable_dmg_path(); }, dmg_path);
+  EncodeString([pb_disk] { return pb_disk->mutable_mount_from(); },
+               MountFromName([props[@"DAVolumePath"] path]));
 
   if (props[@"DAAppearanceTime"]) {
     // Note: `DAAppearanceTime` is set via `CFAbsoluteTimeGetCurrent`, which uses the defined

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -767,7 +767,7 @@ void SerializeAndCheckNonESEvents(
     @"DADeviceVendor" : @"vendor",
     @"DADeviceModel" : @"model",
     @"DAAppearanceTime" : @(123456789),
-    @"DAVolumePath" : [NSURL URLWithString:@"path"],
+    @"DAVolumePath" : [NSURL URLWithString:@"/"],
     @"DAMediaBSDName" : @"bsd",
     @"DAVolumeKind" : @"apfs",
     @"DADeviceProtocol" : @"usb",
@@ -792,6 +792,7 @@ void SerializeAndCheckNonESEvents(
   XCTAssertEqualObjects(@(pbDisk.serial().c_str()), @"");
   XCTAssertEqualObjects(@(pbDisk.bus().c_str()), props[@"DADeviceProtocol"]);
   XCTAssertEqualObjects(@(pbDisk.dmg_path().c_str()), @"");
+  XCTAssertCppStringBeginsWith(pbDisk.mount_from(), std::string("/"));
 
   // Note: `DAAppearanceTime` is treated as a reference time since 2001 and is converted to a
   // reference time of 1970. Skip the calculation in the test here, just ensure the value is set.

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h
@@ -54,6 +54,8 @@ static inline NSString *NonNull(NSString *str) {
 NSString *OriginalPathForTranslocation(const es_process_t *es_proc);
 NSString *SerialForDevice(NSString *devPath);
 NSString *DiskImageForDevice(NSString *devPath);
+NSString *MountFromName(NSString *path);
+
 es_file_t *GetAllowListTargetFile(
   const santa::santad::event_providers::endpoint_security::Message &msg);
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
@@ -14,9 +14,13 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
+#include <sys/mount.h>
+#include <sys/param.h>
+
 #include "Source/common/SantaCache.h"
 #import "Source/common/SantaVnode.h"
 #include "Source/common/SantaVnodeHash.h"
+#include "Source/common/String.h"
 
 // These functions are exported by the Security framework, but are not included in headers
 extern "C" Boolean SecTranslocateIsTranslocatedURL(CFURLRef path, bool *isTranslocated,
@@ -112,6 +116,22 @@ NSString *SerialForDevice(NSString *devPath) {
   }
 
   return [serial stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+}
+
+NSString *MountFromName(NSString *path) {
+  if (!path.length) {
+    return nil;
+  }
+
+  struct statfs sfs;
+
+  if (statfs(path.UTF8String, &sfs) != 0) {
+    return nil;
+  }
+
+  NSString *mntFromName = santa::common::StringToNSString(sfs.f_mntfromname);
+
+  return mntFromName.length > 0 ? mntFromName : nil;
 }
 
 NSString *DiskImageForDevice(NSString *devPath) {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
@@ -24,6 +24,7 @@
 
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::serializers::Utilities::GetAllowListTargetFile;
+using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
 
 @interface UtilitiesTest : XCTestCase
 @end
@@ -60,6 +61,14 @@ using santa::santad::logs::endpoint_security::serializers::Utilities::GetAllowLi
     Message msg(mockESApi, &esMsg);
     XCTAssertThrows(GetAllowListTargetFile(msg));
   }
+}
+
+- (void)testMountFromName {
+  XCTAssertNil(MountFromName(@""));
+  XCTAssertNil(MountFromName(nil));
+  XCTAssertNil(MountFromName(@"./this/path/should/not/ever/exist/"));
+
+  XCTAssertCppStringBeginsWith(std::string(MountFromName(@"/").UTF8String), std::string("/"));
 }
 
 @end


### PR DESCRIPTION
This adds `f_mntfromname` information from `statfs(2)` for DISK APPEAR events.