### PR TITLE
Additional metrics for File Access Authorizer client

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -668,6 +668,7 @@ objc_library(
     hdrs = ["Metrics.h"],
     deps = [
         ":SNTApplicationCoreMetrics",
+        "//Source/common:SNTCommonEnums",
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTXPCMetricServiceInterface",

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -277,6 +277,7 @@ void Metrics::FlushMetrics() {
       NSString *status = FileAccessMetricStatusToString(std::get<FileAccessMetricStatus>(kv.first));
       NSString *decision =
         FileAccessPolicyDecisionToString(std::get<FileAccessPolicyDecision>(kv.first));
+
       [faa_event_counts_
            incrementBy:kv.second
         forFieldValues:@[


### PR DESCRIPTION
Example output:
```
  Metric Name               | /santa/file_access_authorizer/log/count
  Description               | Count of times a log is emitted from the File Access Authorizer client
  Type                      | SNTMetricTypeCounter
  Field                     | config_version=policy.v1,access_type=access,foo=ChromeProfile,status=OK,operation=AuthUnlink,decision=AllowedAuditOnly
  Created                   | 2023-08-22T14:30:51.343Z
  Last Updated              | 2023-08-22T14:37:21.096Z
  Data                      | 2
  Field                     | config_version=policy.v1,access_type=access,rule_id=foo,status=OK,operation=AuthOpen,decision=AllowedAuditOnly
  Created                   | 2023-08-22T14:37:21.096Z
  Last Updated              | 2023-08-22T14:37:21.096Z
  Data                      | 1
  ```