### PR TITLE
Use default event detail button text when a custom URL is set

### DIFF
--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -84,7 +84,10 @@
 
   if (!url) {
     [self.openEventButton removeFromSuperview];
-  } else {
+  } else if (self.customURL.length == 0) {
+    // Set the button text only if a per-rule custom URL is not used. If a
+    // custom URL is used, it is assumed that the `EventDetailText` config value
+    // does not apply and the default text will be used.
     NSString *eventDetailText = [[SNTConfigurator configurator] eventDetailText];
     if (eventDetailText) {
       [self.openEventButton setTitle:eventDetailText];


### PR DESCRIPTION
This change makes it so that the `EventDetailText` configuration option is only used when the `EventDetailURL` value is used. If a rule has a custom URL set, it is no longer assumed that the `EventDetailText` value is valid.

A more thorough change could add the ability to set custom button text in addition to the custom URL. But this functionality is not currently necessary and the simpler approach of reverting to the default text was chosen instead.

Note: Current default button text is `Open Event...`