### PR TITLE
Restore file_bundle_hash & file_bundle_binary_count to Sync Protocol Docs

### DIFF
--- a/docs/development/sync-protocol.md
+++ b/docs/development/sync-protocol.md
@@ -365,6 +365,8 @@ downloading if the rules need to be downloaded in multiple batches.
 | custom\_msg | NO | string | A custom message to display when the rule matches | "Hello" |
 | custom\_url | NO | string | A custom URL to use for the open button when the rule matches | http://lmgtfy.app/?q=dont+download+malware |
 | creation\_time | NO | float64 | Time the rule was created | 1573543803.349378 |
+| file\_bundle\_binary\_count | NO | integer | The number of binaries in a bundle | 13 |
+| file\_bundle\_hash | NO | string | The SHA256 of all binaries in a bundle | "7466e3687f540bcb7792c6d14d5a186667dbe18a85021857b42effe9f0370805" |
 
 
 ##### Example `ruledownload` Response Payload


### PR DESCRIPTION
Restore `file_bundle_hash` and `file_bundle_binary_count` to docs that were mistakenly removed in #1159.

They're used in `SNTSyncRuleDownload's https://github.com/google/santa/blob/4fdc1e5e411d14a07aa087e26e57d0841d177644/Source/santasyncservice/SNTSyncRuleDownload.m#L139