### PR TITLE
Make Signing ID Rules Work With Transitive Allowlisting

### DIFF
--- a/Conf/Package/package_for_dmg.sh
+++ b/Conf/Package/package_for_dmg.sh
@@ -1,0 +1,55 @@
+!#/bin/sh
+# Script to generate a release DMG locally
+
+WORKSPACE_DIR=$(bazel info | grep 'workspace:' | awk '{print $2}')
+
+BASEPATH=$(basename $0)
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+TMP_DIR=$(mktemp -dt "$BASEPATH.$TIMESTAMP.$$")/
+
+
+# 1.Build a release tarball with bazel build --apple_generate_dsym -c opt //:release
+bazel build --apple_generate_dsym -c opt //:release
+
+# 2. Extract the resulting tarball into a directory and export the path to this
+# dir with export RELEASE_ROOT=/path/to/dir
+cp bazel-bin/santa-release.tar.gz $TMP_DIR/
+cd $TMP_DIR
+tar zxf ./santa-release.tar.gz
+export RELEASE_ROOT=$TMP_DIR
+
+# 3. Export shell variables SIGNING_IDENTITY, SIGNING_TEAMID and SIGNING_KEYCHAIN
+# specifying the identity, team ID and path to the keychain file containing
+# your Apple-provided signing ID.
+
+export SIGNING_IDENTITY=""
+export SIGNING_TEAMID=""
+export SIGNING_KEYCHAIN=""
+
+# 4. Export shell variables INSTALLER_SIGNING_IDENTITY and
+#    INSTALLER_SIGNING_KEYCHAIN, similar to the ones in step 3 but for the
+#    Developer ID Installer certificate for signing the .pkg file.
+export INSTALLER_SIGNING_IDENTITY=""
+export INSTALLER_SIGNING_KEYCHAIN=""
+
+# 5. Export the shell variable NOTARIZATION_TOOL that handles notarizing various
+#    files as part of the packaging process. This is to allow you to intercept and
+#    manage the notarization process but if you just want to use the built-in Xcode
+#    tools we provide notarization_tool.sh to handle this; it requires you to set
+#    NOTARIZATION_USERNAME and NOTARIZATION_PASSWORD environment variables
+#    containing the Apple ID login info of the user you'll be notarizing as.
+NOTARIZATION_USERNAME=""
+NOTARIZATION_PASSWORD=""
+/usr/bin/xcrun notarytool submit "${2}" --wait \
+  --apple-id "${NOTARIZATION_USERNAME}" --password "${NOTARIZATION_PASSWORD}"
+
+
+
+# 6. Export the shell variable ARTIFACTS_DIR specifying the dir to store the
+#    output files in.
+export ARTIFACTS_DIR=""
+
+# 7. Execute the package_and_sign.sh script. Once complete the folder specified
+#    in ARTIFACTS_DIR will contain the DMG file and an updated release tarball
+#    with signed and notarized versions of all the built components.
+package_and_sign.sh

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -207,7 +207,6 @@ static NSString *const kPrinterProxyPostMonterey =
 
   // TODO(markowsky): Maybe add a metric here for how many large executables we're seeing.
   // if (binInfo.fileSize > SomeUpperLimit) ...
-
   SNTCachedDecision *cd = [self.policyProcessor decisionForFileInfo:binInfo
                                                       targetProcess:targetProc];
 

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -140,6 +140,16 @@
       case SNTRuleTypeSigningID:
         switch (rule.state) {
           case SNTRuleStateAllow: cd.decision = SNTEventStateAllowSigningID; return cd;
+          case SNTRuleStateAllowCompiler:
+            // If transitive rules are enabled, then SNTRuleStateAllowListCompiler rules
+            // become SNTEventStateAllowCompiler decisions.  Otherwise we treat the rule as if
+            // it were SNTRuleStateAllowSigningID.
+            if ([self.configurator enableTransitiveRules]) {
+              cd.decision = SNTEventStateAllowCompiler;
+            } else {
+              cd.decision = SNTEventStateAllowSigningID;
+            }
+            return cd;
           case SNTRuleStateSilentBlock:
             cd.silentBlock = YES;
             // intentional fallthrough

--- a/santa.mobileconfig
+++ b/santa.mobileconfig
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.google.santa</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>ClientMode</key>
+								<integer>1</integer>
+								<key>FileChangesRegex</key>
+								<string>^/(?!(?:private/tmp|Library/(?:Caches|Managed Installs/Logs|(?:Managed )?Preferences))/)</string>
+								<key>EnablePageZeroProtection</key>
+								<true/>
+								<key>UnknownBlockMessage</key>
+								<string>This application has been blocked from executing.</string>
+								<key>BannedBlockMessage</key>
+								<string>This application has been banned</string>
+								<key>ModeNotificationMonitor</key>
+								<string>Entering Monitor mode&lt;br/&gt;Please be careful!</string>
+								<key>ModeNotificationLockdown</key>
+								<string>Entering Lockdown mode</string>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>f5177388-e5b0-11eb-b425-7831c1b9bca4</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>e395bf8e-e5b0-11eb-83e4-7a31c1b9bca4</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>com.google.santa</string>
+	<key>PayloadDisplayName</key>
+	<string>com.google.santa</string>
+	<key>PayloadIdentifier</key>
+	<string>com.google.santa</string>
+	<key>PayloadOrganization</key>
+	<string></string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>00000000-0000-0000-0000-200000000000</string>
+	<key>PayloadVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Copy and Run Santactl on VM",
+      "type": "shell",
+      "command": "./scripts/test.sh",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    }
+  ]
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Test script to automate copying and installing Santa in a VM.
+set -e
+
+# Clean up previous runs
+echo "Running \"sudo rm -f /Users/peterm/rules.json\""
+ssh -t peterm@192.168.65.2 "sudo rm -f /Users/peterm/rules.json"
+ssh peterm@192.168.65.2 "rm -f /Users/peterm/santa-release.tar.gz"
+# Delete the rule blocking /bin/ls
+#ssh peterm
+ssh -t peterm@192.168.65.2 "sudo santactl rule --remove --identifier 84de9c61777ca36b13228e2446d53e966096e78db7a72c632b5c185b2ffe68a6"
+
+# Copy and install Santa
+scp ./bazel-bin/santa-release.tar.gz peterm@192.168.65.2:
+ssh  peterm@192.168.65.2 "tar zxvf ./santa-release.tar.gz"
+ssh -t peterm@192.168.65.2 "cd ./conf && sudo ./install.sh"
+
+# Now export rules
+ssh -t peterm@192.168.65.2 "sudo santactl rules --export /Users/peterm/rules.json"
+# Cat the file
+ssh peterm@192.168.65.2 "cat /Users/peterm/rules.json"
+
+# Edit the file to have the hash for /bin/ls
+
+# Import the new rules file


### PR DESCRIPTION
This PR adds the ability to mark a binary as a compiler for transitive allowlisting via Signing ID rules.

Related to #1171.