### PR TITLE
Pin GitHub Actions to Specific Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     branches:
@@ -11,15 +10,13 @@ on:
       - main
     paths:
       - 'Source/**'
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
       - name: Run linters
         run: ./Testing/lint.sh
-
   build_userspace:
     strategy:
       fail-fast: false
@@ -27,10 +24,9 @@ jobs:
         os: [macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
       - name: Build Userspace
         run: bazel build --apple_generate_dsym -c opt :release --define=SANTA_BUILD_TYPE=adhoc
-
   unit_tests:
     strategy:
       fail-fast: false
@@ -38,18 +34,17 @@ jobs:
         os: [macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
       - name: Run All Tests
         run: bazel test :unit_tests --define=SANTA_BUILD_TYPE=adhoc --test_output=errors
-
   test_coverage:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
       - name: Generate test coverage
         run: sh ./generate_cov.sh
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # ratchet:coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./bazel-out/_coverage/_coverage_report.dat


### PR DESCRIPTION
This PR pins our GitHub actions in the CI workflow to specific versions to prevent tags / other versions from impacting us.

Specifically I used [ratchet](https://github.com/sethvargo/ratchet) to do this.

Steps taken in case someone needs to do this in the future 

1. Make a new branch
2. Run `ratchet pin ./ci.yml`
3. Commit and make a PR

To update actions you'll need to unpin and then redo this.
