### PR TITLE
Use 'set -xo pipefail' instead for lint.sh

### DIFF
--- a/Testing/lint.sh
+++ b/Testing/lint.sh
@@ -1,25 +1,14 @@
 #!/bin/bash
+set -xo pipefail
 
-function main() {
-    GIT_ROOT=$(git rev-parse --show-toplevel)
-    err=0
+GIT_ROOT=$(git rev-parse --show-toplevel)
 
-    find $GIT_ROOT \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \) -exec clang-format --Werror --dry-run {} \+
-    err="$(( $err | $? ))"
+find $GIT_ROOT \( -name "*.m" -o -name "*.h" -o -name "*.mm" -o -name "*.cc" \) -exec clang-format --Werror --dry-run {} \+
 
-    ! git grep -EIn $'[ \t]+$' -- ':(exclude)*.patch'
-    err="$(( $err | $? ))"
+! git grep -EIn $'[ \t]+$' -- ':(exclude)*.patch'
 
-    go install github.com/bazelbuild/buildtools/buildifier@latest
-    ~/go/bin/buildifier --lint=warn -r $GIT_ROOT
-    err="$(( $err | $? ))"
+go install github.com/bazelbuild/buildtools/buildifier@latest
+~/go/bin/buildifier --lint=warn -r $GIT_ROOT
 
-    python3 -m pip install -q pylint
-    find $GIT_ROOT \( -name "*.py" \) -exec python3 -m pylint --score n --rcfile=$GIT_ROOT/.pylintrc {} \+
-    err="$(( $err | $? ))"
-
-    return $err
-}
-
-main $@
-exit $?
+python3 -m pip install -q pylint
+find $GIT_ROOT \( -name "*.py" \) -exec python3 -m pylint --score n --rcfile=$GIT_ROOT/.pylintrc {} \+


### PR DESCRIPTION
`set -xo pipefail` implicitly does this behavior; the script will continue but without masking errors from individual commands.