### PR TITLE
Add ability to specify custom event URLs and button text for FAA dialog

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -408,10 +408,24 @@ santa_unit_test(
     ],
 )
 
+santa_unit_test(
+    name = "SNTBlockMessageTest",
+    srcs = ["SNTBlockMessageTest.m"],
+    deps = [
+        ":SNTBlockMessage",
+        ":SNTConfigurator",
+        ":SNTFileAccessEvent",
+        ":SNTStoredEvent",
+        ":SNTSystemInfo",
+        "@OCMock",
+    ],
+)
+
 test_suite(
     name = "unit_tests",
     tests = [
         ":PrefixTreeTest",
+        ":SNTBlockMessageTest",
         ":SNTCachedDecisionTest",
         ":SNTFileInfoTest",
         ":SNTKVOManagerTest",

--- a/Source/common/SNTBlockMessage.h
+++ b/Source/common/SNTBlockMessage.h
@@ -49,6 +49,7 @@
 ///  after replacing templates in the URL with values from the event.
 ///
 + (NSURL *)eventDetailURLForEvent:(SNTStoredEvent *)event customURL:(NSString *)url;
++ (NSURL *)eventDetailURLForFileAccessEvent:(SNTFileAccessEvent *)event customURL:(NSString *)url;
 
 ///
 ///  Strip HTML from a string, replacing <br /> with newline.

--- a/Source/common/SNTBlockMessageTest.m
+++ b/Source/common/SNTBlockMessageTest.m
@@ -1,0 +1,95 @@
+/// Copyright 2023 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "Source/common/SNTBlockMessage.h"
+#import "Source/common/SNTConfigurator.h"
+#include "Source/common/SNTFileAccessEvent.h"
+#include "Source/common/SNTStoredEvent.h"
+#import "Source/common/SNTSystemInfo.h"
+
+@interface SNTBlockMessageTest : XCTestCase
+@property id mockConfigurator;
+@property id mockSystemInfo;
+@end
+
+@implementation SNTBlockMessageTest
+
+- (void)setUp {
+  self.mockConfigurator = OCMClassMock([SNTConfigurator class]);
+  OCMStub([self.mockConfigurator configurator]).andReturn(self.mockConfigurator);
+  OCMStub([self.mockConfigurator machineID]).andReturn(@"my_mid");
+
+  self.mockSystemInfo = OCMClassMock([SNTSystemInfo class]);
+  OCMStub([self.mockSystemInfo longHostname]).andReturn(@"my_hn");
+  OCMStub([self.mockSystemInfo hardwareUUID]).andReturn(@"my_u");
+  OCMStub([self.mockSystemInfo serialNumber]).andReturn(@"my_s");
+}
+
+- (void)testEventDetailURLForEvent {
+  SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
+
+  se.fileSHA256 = @"my_fi";
+  se.executingUser = @"my_un";
+
+  NSString *url = @"http://"
+                  @"localhost?fs=%file_sha%&fi=%file_identifier%&bfi=%bundle_or_file_identifier%&"
+                  @"un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
+  NSString *wantUrl =
+    @"http://"
+    @"localhost?fs=my_fi&fi=my_fi&bfi=my_fi&bfi=my_fi&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+
+  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+
+  // Set fileBundleHash and test again for newly expected values
+  se.fileBundleHash = @"my_fbh";
+
+  wantUrl = @"http://"
+            @"localhost?fs=my_fbh&fi=my_fi&bfi=my_fbh&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+
+  gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+
+  XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
+
+  XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:nil]);
+  XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:@"null"]);
+}
+
+- (void)testEventDetailURLForFileAccessEvent {
+  SNTFileAccessEvent *fae = [[SNTFileAccessEvent alloc] init];
+
+  fae.ruleVersion = @"my_rv";
+  fae.ruleName = @"my_rn";
+  fae.fileSHA256 = @"my_fi";
+  fae.accessedPath = @"my_ap";
+  fae.executingUser = @"my_un";
+
+  NSString *url = @"http://"
+                  @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&ap=%accessed_"
+                  @"path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
+  NSString *wantUrl =
+    @"http://"
+    @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+
+  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
+
+  XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
+
+  XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:nil]);
+  XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
+}
+
+@end

--- a/Source/common/SNTXPCNotifierInterface.h
+++ b/Source/common/SNTXPCNotifierInterface.h
@@ -28,7 +28,9 @@
                  andCustomURL:(NSString *)url;
 - (void)postUSBBlockNotification:(SNTDeviceEvent *)event withCustomMessage:(NSString *)message;
 - (void)postFileAccessBlockNotification:(SNTFileAccessEvent *)event
-                      withCustomMessage:(NSString *)message API_AVAILABLE(macos(13.0));
+                          customMessage:(NSString *)message
+                              customURL:(NSString *)url
+                             customText:(NSString *)text API_AVAILABLE(macos(13.0));
 - (void)postClientModeNotification:(SNTClientMode)clientmode;
 - (void)postRuleSyncNotificationWithCustomMessage:(NSString *)message;
 - (void)updateCountsForEvent:(SNTStoredEvent *)event

--- a/Source/gui/SNTFileAccessMessageWindowController.h
+++ b/Source/gui/SNTFileAccessMessageWindowController.h
@@ -26,7 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
 API_AVAILABLE(macos(13.0))
 @interface SNTFileAccessMessageWindowController : SNTMessageWindowController <NSWindowDelegate>
 
-- (instancetype)initWithEvent:(SNTFileAccessEvent *)event customMsg:(nullable NSString *)message;
+- (instancetype)initWithEvent:(SNTFileAccessEvent *)event
+                customMessage:(nullable NSString *)message
+                    customURL:(nullable NSString *)url
+                   customText:(nullable NSString *)text;
 
 @property(readonly) SNTFileAccessEvent *event;
 

--- a/Source/gui/SNTFileAccessMessageWindowController.m
+++ b/Source/gui/SNTFileAccessMessageWindowController.m
@@ -21,16 +21,23 @@
 
 @interface SNTFileAccessMessageWindowController ()
 @property NSString *customMessage;
+@property NSString *customURL;
+@property NSString *customText;
 @property SNTFileAccessEvent *event;
 @end
 
 @implementation SNTFileAccessMessageWindowController
 
-- (instancetype)initWithEvent:(SNTFileAccessEvent *)event customMsg:(nullable NSString *)message {
+- (instancetype)initWithEvent:(SNTFileAccessEvent *)event
+                customMessage:(nullable NSString *)message
+                    customURL:(nullable NSString *)url
+                   customText:(nullable NSString *)text {
   self = [super init];
   if (self) {
-    _customMessage = message;
     _event = event;
+    _customMessage = message;
+    _customURL = url;
+    _customText = text;
   }
   return self;
 }
@@ -48,7 +55,9 @@
   self.window.contentViewController = [SNTFileAccessMessageWindowViewFactory
     createWithWindow:self.window
                event:self.event
-           customMsg:self.attributedCustomMessage
+       customMessage:self.attributedCustomMessage
+           customURL:self.customURL
+          customText:self.customText
      uiStateCallback:^(BOOL preventNotificationsForADay) {
        self.silenceFutureNotifications = preventNotificationsForADay;
      }];

--- a/Source/gui/SNTFileAccessMessageWindowController.m
+++ b/Source/gui/SNTFileAccessMessageWindowController.m
@@ -56,7 +56,8 @@
     createWithWindow:self.window
                event:self.event
        customMessage:self.attributedCustomMessage
-           customURL:self.customURL
+           customURL:[SNTBlockMessage eventDetailURLForFileAccessEvent:self.event
+                                                             customURL:self.customURL]
           customText:self.customText
      uiStateCallback:^(BOOL preventNotificationsForADay) {
        self.silenceFutureNotifications = preventNotificationsForADay;

--- a/Source/gui/SNTFileAccessMessageWindowController.m
+++ b/Source/gui/SNTFileAccessMessageWindowController.m
@@ -58,6 +58,7 @@
        customMessage:self.attributedCustomMessage
            customURL:[SNTBlockMessage eventDetailURLForFileAccessEvent:self.event
                                                              customURL:self.customURL]
+                       .absoluteString
           customText:self.customText
      uiStateCallback:^(BOOL preventNotificationsForADay) {
        self.silenceFutureNotifications = preventNotificationsForADay;

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -29,8 +29,8 @@ import santa_common_SNTFileAccessEvent
     return NSHostingController(rootView:SNTFileAccessMessageWindowView(window:window,
                                                                        event:event,
                                                                        customMessage:customMessage,
-                                                                       customURL:customURL,
-                                                                       customText:customText,
+                                                                       customURL:customURL as String?,
+                                                                       customText:customText as String?,
                                                                        uiStateCallback:uiStateCallback)
       .frame(width:800, height:600))
   }
@@ -112,8 +112,8 @@ struct SNTFileAccessMessageWindowView: View {
   let window: NSWindow?
   let event: SNTFileAccessEvent?
   let customMessage: NSAttributedString?
-  let customURL: NSString?
-  let customText: NSString?
+  let customURL: String?
+  let customText: String?
   let uiStateCallback: ((Bool) -> Void)?
 
   @Environment(\.openURL) var openURL
@@ -140,7 +140,8 @@ struct SNTFileAccessMessageWindowView: View {
       VStack(spacing:15) {
           if customURL != nil {
             Button(action: openButton, label: {
-              Text((customText as? String) ?? "Open Event...").frame(maxWidth:.infinity)
+
+              Text(customText ?? "Open Event...").frame(maxWidth:.infinity)
             })
           }
           Button(action: dismissButton, label: {
@@ -160,7 +161,7 @@ struct SNTFileAccessMessageWindowView: View {
       return
     }
 
-    guard let url = URL(string: urlString as String) else {
+    guard let url = URL(string: urlString) else {
       print("Failed to create URL")
       return
     }

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -12,6 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+import Foundation
 import SecurityInterface
 import SwiftUI
 
@@ -21,11 +22,15 @@ import santa_common_SNTFileAccessEvent
 @objc public class SNTFileAccessMessageWindowViewFactory : NSObject {
   @objc public static func createWith(window: NSWindow,
                                       event: SNTFileAccessEvent,
-                                      customMsg: NSAttributedString?,
+                                      customMessage: NSAttributedString?,
+                                      customURL: NSString?,
+                                      customText: NSString?,
                                       uiStateCallback: ((Bool) -> Void)?) -> NSViewController {
     return NSHostingController(rootView:SNTFileAccessMessageWindowView(window:window,
                                                                        event:event,
-                                                                       customMsg:customMsg,
+                                                                       customMessage:customMessage,
+                                                                       customURL:customURL,
+                                                                       customText:customText,
                                                                        uiStateCallback:uiStateCallback)
       .frame(width:800, height:600))
   }
@@ -106,9 +111,12 @@ struct Event: View {
 struct SNTFileAccessMessageWindowView: View {
   let window: NSWindow?
   let event: SNTFileAccessEvent?
-  let customMsg: NSAttributedString?
+  let customMessage: NSAttributedString?
+  let customURL: NSString?
+  let customText: NSString?
   let uiStateCallback: ((Bool) -> Void)?
 
+  @Environment(\.openURL) var openURL
   @State public var checked = false
 
   var body: some View {
@@ -116,7 +124,7 @@ struct SNTFileAccessMessageWindowView: View {
       Spacer()
       Text("Santa").font(Font.custom("HelveticaNeue-UltraLight", size: 34.0))
 
-      if let msg = customMsg {
+      if let msg = customMessage {
         Text(AttributedString(msg)).multilineTextAlignment(.center).padding(15.0)
       } else {
         Text("Access to a protected resource was denied.").multilineTextAlignment(.center).padding(15.0)
@@ -130,9 +138,11 @@ struct SNTFileAccessMessageWindowView: View {
       }
 
       VStack(spacing:15) {
-          Button(action: openButton, label: {
-            Text("Open Event Info...").frame(maxWidth:.infinity)
-          })
+          if customURL != nil {
+            Button(action: openButton, label: {
+              Text((customText as? String) ?? "Open Event...").frame(maxWidth:.infinity)
+            })
+          }
           Button(action: dismissButton, label: {
             Text("Dismiss").frame(maxWidth:.infinity)
           })
@@ -145,8 +155,17 @@ struct SNTFileAccessMessageWindowView: View {
   }
 
   func openButton() {
-    // TODO(mlw): Will hook up in a separate PR
-    print("opening event info...")
+    guard let urlString = customURL else {
+      print("No URL available")
+      return
+    }
+
+    guard let url = URL(string: urlString as String) else {
+      print("Failed to create URL")
+      return
+    }
+
+    openURL(url)
   }
 
   func dismissButton() {
@@ -154,7 +173,6 @@ struct SNTFileAccessMessageWindowView: View {
       block(self.checked)
     }
     window?.close()
-    print("close window")
   }
 }
 
@@ -182,6 +200,11 @@ func testFileAccessEvent() -> SNTFileAccessEvent {
 @available(macOS 13, *)
 struct SNTFileAccessMessageWindowView_Previews: PreviewProvider {
   static var previews: some View {
-    SNTFileAccessMessageWindowView(window: nil, event: testFileAccessEvent(), customMsg: nil, uiStateCallback: nil)
+    SNTFileAccessMessageWindowView(window: nil,
+                                    event: testFileAccessEvent(),
+                            customMessage: nil,
+                                customURL: nil,
+                               customText: nil,
+                          uiStateCallback: nil)
   }
 }

--- a/Source/gui/SNTNotificationManager.m
+++ b/Source/gui/SNTNotificationManager.m
@@ -349,14 +349,19 @@ static NSString *const silencedNotificationsKey = @"SilencedNotifications";
 }
 
 - (void)postFileAccessBlockNotification:(SNTFileAccessEvent *)event
-                      withCustomMessage:(NSString *)message API_AVAILABLE(macos(13.0)) {
+                          customMessage:(NSString *)message
+                              customURL:(NSString *)url
+                             customText:(NSString *)text API_AVAILABLE(macos(13.0)) {
   if (!event) {
     LOGI(@"Error: Missing event object in message received from daemon!");
     return;
   }
 
   SNTFileAccessMessageWindowController *pendingMsg =
-    [[SNTFileAccessMessageWindowController alloc] initWithEvent:event customMsg:message];
+    [[SNTFileAccessMessageWindowController alloc] initWithEvent:event
+                                                  customMessage:message
+                                                      customURL:url
+                                                     customText:text];
 
   [self queueMessage:pendingMsg];
 }

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -15,6 +15,7 @@
 #ifndef SANTA__SANTAD__DATALAYER_WATCHITEMPOLICY_H
 #define SANTA__SANTAD__DATALAYER_WATCHITEMPOLICY_H
 
+#import <Foundation/Foundation.h>
 #include <Kernel/kern/cs_blobs.h>
 
 #include <optional>
@@ -29,8 +30,7 @@ enum class WatchItemPathType {
   kLiteral,
 };
 
-static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType =
-    WatchItemPathType::kLiteral;
+static constexpr WatchItemPathType kWatchItemPolicyDefaultPathType = WatchItemPathType::kLiteral;
 static constexpr bool kWatchItemPolicyDefaultAllowReadAccess = false;
 static constexpr bool kWatchItemPolicyDefaultAuditOnly = true;
 static constexpr bool kWatchItemPolicyDefaultInvertProcessExceptions = false;
@@ -39,8 +39,8 @@ static constexpr bool kWatchItemPolicyDefaultEnableSilentTTYMode = false;
 
 struct WatchItemPolicy {
   struct Process {
-    Process(std::string bp, std::string sid, std::string ti,
-            std::vector<uint8_t> cdh, std::string ch, std::optional<bool> pb)
+    Process(std::string bp, std::string sid, std::string ti, std::vector<uint8_t> cdh,
+            std::string ch, std::optional<bool> pb)
         : binary_path(bp),
           signing_id(sid),
           team_id(ti),
@@ -49,13 +49,11 @@ struct WatchItemPolicy {
           platform_binary(pb) {}
 
     bool operator==(const Process &other) const {
-      return binary_path == other.binary_path &&
-             signing_id == other.signing_id && team_id == other.team_id &&
-             cdhash == other.cdhash &&
+      return binary_path == other.binary_path && signing_id == other.signing_id &&
+             team_id == other.team_id && cdhash == other.cdhash &&
              certificate_sha256 == other.certificate_sha256 &&
              platform_binary.has_value() == other.platform_binary.has_value() &&
-             platform_binary.value_or(false) ==
-                 other.platform_binary.value_or(false);
+             platform_binary.value_or(false) == other.platform_binary.value_or(false);
     }
 
     bool operator!=(const Process &other) const { return !(*this == other); }
@@ -74,8 +72,8 @@ struct WatchItemPolicy {
                   bool ao = kWatchItemPolicyDefaultAuditOnly,
                   bool ipe = kWatchItemPolicyDefaultInvertProcessExceptions,
                   bool esm = kWatchItemPolicyDefaultEnableSilentMode,
-                  bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode,
-                  std::string_view cm = "", std::vector<Process> procs = {})
+                  bool estm = kWatchItemPolicyDefaultEnableSilentTTYMode, std::string_view cm = "",
+                  NSString *edu = nil, NSString *edt = nil, std::vector<Process> procs = {})
       : name(n),
         path(p),
         path_type(pt),
@@ -84,24 +82,21 @@ struct WatchItemPolicy {
         invert_process_exceptions(ipe),
         silent(esm),
         silent_tty(estm),
-        custom_message(cm.length() == 0 ? std::nullopt
-                                        : std::make_optional<std::string>(cm)),
+        custom_message(cm.length() == 0 ? std::nullopt : std::make_optional<std::string>(cm)),
+        event_detail_url(edu.length == 0 ? std::nullopt : std::make_optional<NSString *>(edu)),
+        event_detail_text(edt.length == 0 ? std::nullopt : std::make_optional<NSString *>(edt)),
         processes(std::move(procs)) {}
 
   bool operator==(const WatchItemPolicy &other) const {
-    // Note: Custom message isn't currently considered for equality purposes
-    return name == other.name && path == other.path &&
-           path_type == other.path_type &&
-           allow_read_access == other.allow_read_access &&
-           audit_only == other.audit_only &&
-           invert_process_exceptions == other.invert_process_exceptions &&
-           silent == other.silent && silent_tty == other.silent_tty &&
-           processes == other.processes;
+    // Note: custom_message, event_detail_url, and event_detail_text are not currently considered
+    // for equality purposes
+    return name == other.name && path == other.path && path_type == other.path_type &&
+           allow_read_access == other.allow_read_access && audit_only == other.audit_only &&
+           invert_process_exceptions == other.invert_process_exceptions && silent == other.silent &&
+           silent_tty == other.silent_tty && processes == other.processes;
   }
 
-  bool operator!=(const WatchItemPolicy &other) const {
-    return !(*this == other);
-  }
+  bool operator!=(const WatchItemPolicy &other) const { return !(*this == other); }
 
   std::string name;
   std::string path;
@@ -112,6 +107,8 @@ struct WatchItemPolicy {
   bool silent;
   bool silent_tty;
   std::optional<std::string> custom_message;
+  std::optional<NSString *> event_detail_url;
+  std::optional<NSString *> event_detail_text;
   std::vector<Process> processes;
 
   // WIP - No current way to control via config

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -83,7 +83,9 @@ struct WatchItemPolicy {
         silent(esm),
         silent_tty(estm),
         custom_message(cm.length() == 0 ? std::nullopt : std::make_optional<std::string>(cm)),
-        event_detail_url(edu.length == 0 ? std::nullopt : std::make_optional<NSString *>(edu)),
+        // Note: Empty string considered valid for event_detail_url to allow rules
+        // overriding global setting in order to hide the button.
+        event_detail_url(edu == nil ? std::nullopt : std::make_optional<NSString *>(edu)),
         event_detail_text(edt.length == 0 ? std::nullopt : std::make_optional<NSString *>(edt)),
         processes(std::move(procs)) {}
 

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -96,6 +96,9 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
 
   std::optional<WatchItemsState> State();
 
+  std::pair<NSString *, NSString *> EventDetailLinkInfo(
+    const std::shared_ptr<WatchItemPolicy> &watch_item);
+
   friend class santa::santad::data_layer::WatchItemsPeer;
 
  private:
@@ -128,6 +131,8 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   std::string policy_version_ ABSL_GUARDED_BY(lock_);
   std::set<id<SNTEndpointSecurityDynamicEventHandler>> registerd_clients_ ABSL_GUARDED_BY(lock_);
   bool periodic_task_started_ = false;
+  NSString *policy_event_detail_url_ ABSL_GUARDED_BY(lock_);
+  NSString *policy_event_detail_text_ ABSL_GUARDED_BY(lock_);
 };
 
 }  // namespace santa::santad::data_layer

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -831,7 +831,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     *policies[0].get(),
     WatchItemPolicy("rule", "a", kWatchItemPolicyDefaultPathType,
                     kWatchItemPolicyDefaultAllowReadAccess, kWatchItemPolicyDefaultAuditOnly,
-                    kWatchItemPolicyDefaultInvertProcessExceptions, {}));
+                    kWatchItemPolicyDefaultInvertProcessExceptions));
 
   // Test multiple paths, options, and processes
   policies.clear();
@@ -859,10 +859,12 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
                                            policies, &err));
 
   XCTAssertEqual(policies.size(), 2);
-  XCTAssertEqual(*policies[0].get(), WatchItemPolicy("rule", "a", kWatchItemPolicyDefaultPathType,
-                                                     true, false, true, true, false, "", procs));
-  XCTAssertEqual(*policies[1].get(), WatchItemPolicy("rule", "b", WatchItemPathType::kPrefix, true,
-                                                     false, true, true, false, "", procs));
+  XCTAssertEqual(*policies[0].get(),
+                 WatchItemPolicy("rule", "a", kWatchItemPolicyDefaultPathType, true, false, true,
+                                 true, false, "", nil, nil, procs));
+  XCTAssertEqual(*policies[1].get(),
+                 WatchItemPolicy("rule", "b", WatchItemPathType::kPrefix, true, false, true, true,
+                                 false, "", nil, nil, procs));
 }
 
 - (void)testState {

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -27,7 +27,8 @@
 #import "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
-typedef void (^SNTFileAccessBlockCallback)(SNTFileAccessEvent *event, NSString *customMsg);
+typedef void (^SNTFileAccessBlockCallback)(SNTFileAccessEvent *event, NSString *customMsg,
+                                           NSString *customURL, NSString *customText);
 
 @interface SNTEndpointSecurityFileAccessAuthorizer
     : SNTEndpointSecurityClient <SNTEndpointSecurityDynamicEventHandler>

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -710,8 +710,9 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
       event.parentName = StringToNSString(msg.ParentProcessName());
       event.signingChain = cd.certChain;
 
+      std::pair<NSString *, NSString *> linkInfo = self->_watchItems->EventDetailLinkInfo(policy);
+
       if (!policy->silent && self.fileAccessBlockCallback) {
-        std::pair<NSString *, NSString *> linkInfo = self->_watchItems->EventDetailLinkInfo(policy);
         self.fileAccessBlockCallback(event, OptionalStringToNSString(policy->custom_message),
                                      linkInfo.first, linkInfo.second);
       }
@@ -734,6 +735,12 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
                                @"\033[1mParent:       \033[0m %@\n\n",
                                event.accessedPath, event.ruleVersion, event.ruleName,
                                event.filePath, event.fileSHA256, event.parentName];
+
+        NSURL *detailURL = [SNTBlockMessage eventDetailURLForFileAccessEvent:event
+                                                                   customURL:linkInfo.first];
+        if (detailURL) {
+          [blockMsg appendFormat:@"More info:\n%@\n\n", detailURL.absoluteString];
+        }
 
         self->_ttyWriter->Write(msg->process, blockMsg);
       }

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -711,7 +711,9 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
       event.signingChain = cd.certChain;
 
       if (!policy->silent && self.fileAccessBlockCallback) {
-        self.fileAccessBlockCallback(event, OptionalStringToNSString(policy->custom_message));
+        std::pair<NSString *, NSString *> linkInfo = self->_watchItems->EventDetailLinkInfo(policy);
+        self.fileAccessBlockCallback(event, OptionalStringToNSString(policy->custom_message),
+                                     linkInfo.first, linkInfo.second);
       }
 
       if (ShouldMessageTTY(policy, msg, self->_ttyMessageCache)) {

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -146,10 +146,12 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
     watch_items->RegisterClient(access_authorizer_client);
 
     access_authorizer_client.fileAccessBlockCallback =
-      ^(SNTFileAccessEvent *event, NSString *customMsg) {
+      ^(SNTFileAccessEvent *event, NSString *customMsg, NSString *customURL, NSString *customText) {
         [[notifier_queue.notifierConnection remoteObjectProxy]
           postFileAccessBlockNotification:event
-                        withCustomMessage:customMsg];
+                            customMessage:customMsg
+                                customURL:customURL
+                               customText:customText];
       };
   }
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -71,10 +71,11 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | DisableUnknownEventUpload         | Bool       | If YES, the client will *not* upload events for executions of unknown binaries allowed in monitor mode |
 | BlockUSBMount                     | Bool       | If set to 'True' blocking USB Mass storage feature is enabled. Defaults to `False`. |
 | RemountUSBMode                    | Array      | Array of strings for arguments to pass to mount -o (any of "rdonly", "noexec", "nosuid", "nobrowse", "noowners", "nodev", "async", "-j"). when forcibly remounting devices. No default. |
-| FileAccessPolicyPlist             | String      | (BETA) Path to a file access configuration plist. |
-| FileAccessPolicyUpdateIntervalSec | Integer     | (BETA) Number of seconds between re-reading the file access policy config and policies/monitored paths updated. |
-| SyncClientContentEncoding | String | Sets the Content-Encoding header for requests sent to the sync service. Acceptable values are "deflate", "gzip", "none" (Defaults to deflate.)  |
-| SyncExtraHeaders | Dictionary | Dictionary of additional headers to include in all requests made to the sync server. System managed headers such as Content-Length, Host, WWW-Authenticate etc will be ignored. |
+| FileAccessPolicyPlist             | String      | Path to a file access configuration plist. This is ignored if `FileAccessPolicy` is also set. |
+| FileAccessPolicy                  | Dictionary  | A complete file access configuration policy embedded in the main Santa config. If set, `FileAccessPolicyPlist` will be ignored. |
+| FileAccessPolicyUpdateIntervalSec | Integer     | Number of seconds between re-reading the file access policy config and policies/monitored paths updated. |
+| SyncClientContentEncoding         | String      | Sets the Content-Encoding header for requests sent to the sync service. Acceptable values are "deflate", "gzip", "none" (Defaults to deflate.)  |
+| SyncExtraHeaders                  | Dictionary  | Dictionary of additional headers to include in all requests made to the sync server. System managed headers such as Content-Length, Host, WWW-Authenticate etc will be ignored. |
 
 
 \*overridable by the sync server: run `santactl status` to check the current

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -4,9 +4,7 @@ parent: Deployment
 nav_order: 4
 ---
 
-# (BETA) File Access Authorization
-
-> **IMPORTANT:** This feature is in beta. Configuration and log formats are subject to change.
+# File Access Authorization
 
 > **IMPORTANT:** This feature is only supported on macOS 13 and above.
 

--- a/docs/deployment/file-access-auth.md
+++ b/docs/deployment/file-access-auth.md
@@ -19,6 +19,8 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 | Key                       | Parent       | Type       | Required | Santa Version | Description |
 | :------------------------ | :----------- | :--------- | :------- | :------------ | :---------- |
 | `Version`                 | `<Root>`     | String     | Yes      | v2023.1+      | Version of the configuration. Will be reported in events. |
+| `EventDetailURL`          | `<Root>`     | String     | No       | v2023.8+      | When the user gets a block notification, a button can be displayed which will take them to a web page with more information about that event. This URL will be used for all rules unless overridden by a rule-specific option. See the [EventDetailURL](#eventdetailurl) section below.  |
+| `EventDetailText`         | `<Root>`     | String     | No       | v2023.8+      | Related to `EventDetailURL`, controls the button text that will be displayed. (max length = 48 chars) |
 | `WatchItems`              | `<Root>`     | Dictionary | No       | v2023.1+      | The set of configuration items that will be monitored by Santa. |
 | `<Name>`                  | `WatchItems` | Dictionary | No       | v2023.1+      | A unique name that identifies a single watch item rule. This value will be reported in events. The name must be a legal C identifier (i.e., must conform to the regex `[A-Za-z_][A-Za-z0-9_]*`). |
 | `Paths`                   | `<Name>`     | Array      | Yes      | v2023.1+      | A list of either String or Dictionary types that contain path globs to monitor. String type entires will have default values applied for the attributes that can be manually set with the Dictionary type. |
@@ -28,6 +30,8 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 | `AllowReadAccess`         | `Options`    | Boolean    | No       | v2023.1+      | If true, indicates the rule will **not** be applied to actions that are read-only access (e.g., opening a watched path for reading, or cloning a watched path). If false, the rule will apply both to read-only access and access that could modify the watched path. (Default = `false`) |
 | `AuditOnly`               | `Options`    | Boolean    | No       | v2023.1+      | If true, operations violating the rule will only be logged. If false, operations violating the rule will be denied and logged. (Default = `true`) |
 | `InvertProcessExceptions` | `Options`    | Boolean    | No       | v2023.5+      | If true, logic is inverted for the list of processes defined by the `Processes` key such that the list becomes the set of processes that will be denied or allowed but audited. (Default = `false`) |
+| `EventDetailURL`          | `Options`    | String     | No       | v2023.8+      | Rule-specific URL that overrides the top-level `EventDetailURL`. |
+| `EventDetailText`         | `Options`    | String     | No       | v2023.8+      | Rule-specific button text that overrides the top-level `EventDetailText`. |
 | `Processes`               | `<Name>`     | Array      | No       | v2023.1+      | A list of dictionaries defining processes that are allowed to access paths matching the globs defined with the `Paths` key. For a process performing the operation to be considered a match, it must match all defined attributes of at least one entry in the list. |
 | `BinaryPath`              | `Processes`  | String     | No       | v2023.1+      | A path literal that an instigating process must be executed from. |
 | `TeamID`                  | `Processes`  | String     | No       | v2023.1+      | Team ID of the instigating process. |
@@ -35,6 +39,25 @@ To enable this feature, the `FileAccessPolicyPlist` key in the main [Santa confi
 | `CDHash`                  | `Processes`  | String     | No       | v2023.1+      | CDHash of the instigating process. |
 | `SigningID`               | `Processes`  | String     | No       | v2023.1+      | Signing ID of the instigating process. |
 | `PlatformBinary`          | `Processes`  | Boolean    | No       | v2023.2+      | Whether or not the instigating process is a platform binary. |
+
+### EventDetailURL
+When the user gets a file access block notification, a button can be displayed
+which will take them to a web page with more information about that event.
+
+This property contains a kind of format string to be turned into the URL to send
+them to. The following sequences will be replaced in the final URL:
+
+| Key                 | Description |
+| :------------------ | :---------- |
+| `%rule_version%`    | Version of the rule that was violated |
+| `%rule_name%`       | Name of the rule that was violated    |
+| `%file_identifier%` | SHA-256 of the binary being executed  |
+| `%accessed_path%`   | The path accessed by the binary       |
+| `%username%`        | The executing user                    |
+| `%machine_id%`      | ID of the machine                     |
+| `%serial%`          | System's serial number                |
+| `%uuid%`            | System's UUID                         |
+| `%hostname%`        | System's full hostname                |
 
 ### Example Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ The following pages give an overview of how Santa accomplishes authorization at 
 
 * [Getting Started](deployment/getting-started.md): A quick guide to setting up your deployment.
 * [Configuration](deployment/configuration.md): The local and sync server configuration options, along with example needed mobileconfig files.
-* (BETA) [File Access Authorization](deployment/file-access-auth.md): Guide to enabling the feature and details about its configuration and operation.
+* [File Access Authorization](deployment/file-access-auth.md): Guide to enabling the feature and details about its configuration and operation.
 * [Sync Servers](deployment/sync-servers.md): A list of open-source sync servers.
 * [Troubleshooting](deployment/troubleshooting.md): How to troubleshoot issues with your Santa deployment.
 


### PR DESCRIPTION
Adds support for FAA config keys:

* `EventDetailURL` - controls the "open" button in the UI dialog
* `EventDetailText` - controls the button text

These keys can be set at the top level to apply to all rules. Additionally, they can be set as a per-rule option that will override the top level policy if set.