### PR TITLE
santactl/sync: Drop root requirement

### DIFF
--- a/Source/santactl/Commands/SNTCommandSync.m
+++ b/Source/santactl/Commands/SNTCommandSync.m
@@ -32,7 +32,7 @@ REGISTER_COMMAND_NAME(@"sync")
 #pragma mark SNTCommand protocol methods
 
 + (BOOL)requiresRoot {
-  return YES;
+  return NO;
 }
 
 + (BOOL)requiresDaemonConn {


### PR DESCRIPTION
Previously the sync command required root in order to establish a connection to santad with enough privilege to use the XPC methods for adding rules. Now that santasyncservice exists this requirement is no longer necessary and there is no risk in allowing unprivileged users to initiate a sync.

We still ensure that privileges are dropped, just in case someone does execute as root.

Fixes #1195