### PR TITLE
Docs: Remove Adhoc Build Instruction

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -163,3 +163,10 @@ infrastructure.
 ```sh
 bazel build --apple_generate_dsym -c opt //:release
 ```
+
+### Remove Ad-Hoc Build
+if you would like to remove the ad-hoc build of Santa, you can run the following command:
+
+```sh
+systemextensionsctl uninstall - com.google.santa.daemon
+```


### PR DESCRIPTION
This adds instruction to the development/building docs on how to remove to adhoc build when done with development.