### PR TITLE
Record metrics for device manager startup operations

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -398,6 +398,7 @@ objc_library(
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTDeviceEvent",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTMetricSet",
     ],
 )
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -37,6 +37,7 @@
 
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
+using santa::santad::event_providers::endpoint_security::EnrichedCSInvalidated;
 using santa::santad::event_providers::endpoint_security::EnrichedExchange;
 using santa::santad::event_providers::endpoint_security::EnrichedExec;
 using santa::santad::event_providers::endpoint_security::EnrichedExit;
@@ -45,7 +46,6 @@ using santa::santad::event_providers::endpoint_security::EnrichedLink;
 using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::EnrichedRename;
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
-using santa::santad::event_providers::endpoint_security::EnrichedCSInvalidated;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
 using santa::santad::logs::endpoint_security::serializers::Utilities::NonNull;

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -167,7 +167,7 @@ std::shared_ptr<Metrics> Metrics::Create(SNTMetricSet *metric_set, uint64_t inte
                      fieldNames:@[ @"Processor" ]
                        helpText:@"Events rate limited by each processor"];
 
-  SNTMetricCounter *faa_event_counts = [[SNTMetricSet sharedInstance]
+  SNTMetricCounter *faa_event_counts = [metric_set
     counterWithName:@"/santa/file_access_authorizer/log/count"
          fieldNames:@[
            @"config_version", @"access_type", @"rule_id", @"status", @"operation", @"decision"


### PR DESCRIPTION
Records the system's startup preference value, as well as the operation performed for each USB device found during startup.

Example:
```
  Metric Name               | /santa/device_manager/startup_preference
  Description               | The current startup preference value
  Type                      | SNTMetricTypeGaugeInt64
  Created                   | 2023-11-02T19:36:25.162Z
  Last Updated              | 2023-11-02T19:36:28.983Z
  Data                      | 3

  Metric Name               | /santa/device_manager/startup_disk_operation
  Description               | Count of the number of USB devices encountered per operation
  Type                      | SNTMetricTypeCounter
  Field                     | operation=Skipped
  Created                   | 2023-11-02T19:35:02.527Z
  Last Updated              | 2023-11-02T19:35:02.528Z
  Data                      | 11
  Field                     | operation=Success
  Created                   | 2023-11-02T19:35:04.657Z
  Last Updated              | 2023-11-02T19:35:04.657Z
  Data                      | 1
```