### PR TITLE
Only remount on startup if remount args are set

### DIFF
--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -267,7 +267,8 @@ REGISTER_COMMAND_NAME(@"status")
       printf("  %-25s | %s\n", "USB Remounting Mode",
              [[configurator.remountUSBMode componentsJoinedByString:@", "] UTF8String]);
     }
-    printf("  %-25s | %s\n", "On Start USB Options", StartupOptionToString(configurator.onStartUSBOptions).UTF8String);
+    printf("  %-25s | %s\n", "On Start USB Options",
+           StartupOptionToString(configurator.onStartUSBOptions).UTF8String);
     printf("  %-25s | %lld  (Peak: %.2f%%)\n", "Watchdog CPU Events", cpuEvents, cpuPeak);
     printf("  %-25s | %lld  (Peak: %.2fMB)\n", "Watchdog RAM Events", ramEvents, ramPeak);
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -55,7 +55,7 @@ class MockAuthResultCache : public AuthResultCache {
 - (void)logDiskAppeared:(NSDictionary *)props;
 - (BOOL)shouldOperateOnDisk:(DADiskRef)disk;
 - (void)performStartupTasks:(SNTDeviceManagerStartupPreferences)startupPrefs;
-- (uint32_t)updatedMountFlags:(struct statfs*)sfs;
+- (uint32_t)updatedMountFlags:(struct statfs *)sfs;
 @end
 
 @interface SNTEndpointSecurityDeviceManagerTest : XCTestCase
@@ -450,9 +450,9 @@ class MockAuthResultCache : public AuthResultCache {
     PerformStartupTest(@[ disk1, disk2 ], nil, SNTDeviceManagerStartupPreferencesRemount);
 
     XCTAssertTrue(disk1.wasUnmounted);
-    XCTAssertTrue(disk1.wasMounted);
+    XCTAssertFalse(disk1.wasMounted);
     XCTAssertTrue(disk2.wasUnmounted);
-    XCTAssertTrue(disk2.wasMounted);
+    XCTAssertFalse(disk2.wasMounted);
   }
 }
 
@@ -470,7 +470,8 @@ class MockAuthResultCache : public AuthResultCache {
 
   // For APFS, flags are still unioned, but MNT_JOUNRNALED is cleared
   strlcpy(sfs.f_fstypename, "apfs", sizeof(sfs.f_fstypename));
-  XCTAssertEqual([deviceManager updatedMountFlags:&sfs], (sfs.f_flags | MNT_RDONLY | MNT_NOEXEC) & ~MNT_JOURNALED);
+  XCTAssertEqual([deviceManager updatedMountFlags:&sfs],
+                 (sfs.f_flags | MNT_RDONLY | MNT_NOEXEC) & ~MNT_JOURNALED);
 }
 
 - (void)testEnable {


### PR DESCRIPTION
Changes behavior of #1216 (support remount on startup) to only remount if the remount args are set. The makes for consistent behavior of the runtime mount protections which will leave a device unmounted if the remount args aren't set.