### PR TITLE
Entitlements logging config options

### DIFF
--- a/Source/common/PrefixTree.h
+++ b/Source/common/PrefixTree.h
@@ -74,6 +74,11 @@ class PrefixTree {
     node_count_ = 0;
   }
 
+  uint32_t NodeCount() {
+    absl::ReaderMutexLock lock(&lock_);
+    return node_count_;
+  }
+
 #if SANTA_PREFIX_TREE_DEBUG
   void Print() {
     char buf[max_depth_ + 1];
@@ -81,11 +86,6 @@ class PrefixTree {
 
     absl::ReaderMutexLock lock(&lock_);
     PrintLocked(root_, buf, 0);
-  }
-
-  uint32_t NodeCount() {
-    absl::ReaderMutexLock lock(&lock_);
-    return node_count_;
   }
 #endif
 

--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -39,6 +39,7 @@
 @property NSString *teamID;
 @property NSString *signingID;
 @property NSDictionary *entitlements;
+@property BOOL entitlementsFiltered;
 
 @property NSString *quarantineURL;
 

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -643,6 +643,18 @@
 @property(readonly, nonatomic) NSUInteger metricExportTimeout;
 
 ///
+/// List of TeamIDs for which entitlements should not be logged. Use the string
+/// "platform" to refer to platform binaries.
+///
+@property(readonly, nonatomic) NSArray<NSString *> *entitlementsPrefixFilter;
+
+///
+/// List of prefix strings for which individual entitlement keys with a matching
+/// prefix should not be logged.
+///
+@property(readonly, nonatomic) NSArray<NSString *> *entitlementsTeamIDFilter;
+
+///
 ///  Retrieve an initialized singleton configurator object using the default file path.
 ///
 + (instancetype)configurator;

--- a/Source/common/SNTConfigurator.h
+++ b/Source/common/SNTConfigurator.h
@@ -643,14 +643,14 @@
 @property(readonly, nonatomic) NSUInteger metricExportTimeout;
 
 ///
-/// List of TeamIDs for which entitlements should not be logged. Use the string
-/// "platform" to refer to platform binaries.
+/// List of prefix strings for which individual entitlement keys with a matching
+/// prefix should not be logged.
 ///
 @property(readonly, nonatomic) NSArray<NSString *> *entitlementsPrefixFilter;
 
 ///
-/// List of prefix strings for which individual entitlement keys with a matching
-/// prefix should not be logged.
+/// List of TeamIDs for which entitlements should not be logged. Use the string
+/// "platform" to refer to platform binaries.
 ///
 @property(readonly, nonatomic) NSArray<NSString *> *entitlementsTeamIDFilter;
 

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -20,6 +20,21 @@
 #import "Source/common/SNTStrengthify.h"
 #import "Source/common/SNTSystemInfo.h"
 
+// Ensures the given object is an NSArray and only contains NSString value types
+static NSArray<NSString *> *EnsureArrayOfStrings(id obj) {
+  if (![obj isKindOfClass:[NSArray class]]) {
+    return nil;
+  }
+
+  for (id item in obj) {
+    if (![item isKindOfClass:[NSString class]]) {
+      return nil;
+    }
+  }
+
+  return obj;
+}
+
 @interface SNTConfigurator ()
 /// A NSUserDefaults object set to use the com.google.santa suite.
 @property(readonly, nonatomic) NSUserDefaults *defaults;
@@ -115,6 +130,9 @@ static NSString *const kClientContentEncoding = @"SyncClientContentEncoding";
 static NSString *const kFCMProject = @"FCMProject";
 static NSString *const kFCMEntity = @"FCMEntity";
 static NSString *const kFCMAPIKey = @"FCMAPIKey";
+
+static NSString *const kEntitlementsPrefixFilterKey = @"EntitlementsPrefixFilter";
+static NSString *const kEntitlementsTeamIDFilterKey = @"EntitlementsTeamIDFilter";
 
 // The keys managed by a sync server or mobileconfig.
 static NSString *const kClientModeKey = @"ClientMode";
@@ -240,6 +258,8 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
       kEnableAllEventUploadKey : number,
       kDisableUnknownEventUploadKey : number,
       kOverrideFileAccessActionKey : string,
+      kEntitlementsPrefixFilterKey : array,
+      kEntitlementsTeamIDFilterKey : array,
     };
     _defaults = [NSUserDefaults standardUserDefaults];
     [_defaults addSuiteNamed:@"com.google.santa"];
@@ -525,6 +545,14 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 + (NSSet *)keyPathsForValuesAffectingOverrideFileAccessActionKey {
   return [self syncAndConfigStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingEntitlementsPrefixFilter {
+  return [self configStateSet];
+}
+
++ (NSSet *)keyPathsForValuesAffectingEntitlementsTeamIDFilter {
+  return [self configStateSet];
 }
 
 #pragma mark Public Interface
@@ -1109,6 +1137,14 @@ static NSString *const kSyncCleanRequired = @"SyncCleanRequired";
 
 - (void)clearSyncState {
   self.syncState = [NSMutableDictionary dictionary];
+}
+
+- (NSArray *)entitlementsPrefixFilter {
+  return EnsureArrayOfStrings(self.configState[kEntitlementsPrefixFilterKey]);
+}
+
+- (NSArray *)entitlementsTeamIDFilter {
+  return EnsureArrayOfStrings(self.configState[kEntitlementsTeamIDFilterKey]);
 }
 
 #pragma mark Private Defaults Methods

--- a/Source/common/santa.proto
+++ b/Source/common/santa.proto
@@ -222,6 +222,18 @@ message Entitlement {
   optional string value = 2;
 }
 
+// Information about entitlements
+message EntitlementInfo {
+  // Whether or not the set of reported entilements is complete or has been
+  // filtered (e.g. by configuration or clipped because too many to log).
+  optional bool entitlements_filtered = 1;
+
+  // The set of entitlements associated with the target executable
+  // Only top level keys are represented
+  // Values (including nested keys) are JSON serialized
+  repeated Entitlement entitlements = 2;
+}
+
 // Information about a process execution event
 message Execution {
   // The process that executed the new image (e.g. the process that called
@@ -296,10 +308,8 @@ message Execution {
   // Applies when executables are translocated
   optional string original_path = 15;
 
-  // The set of entitlements associated with the target executable
-  // Only top level keys are represented
-  // Values (including nested keys) are JSON serialized
-  repeated Entitlement entitlements = 16;
+  // Entitlement information about the target executbale
+  optional EntitlementInfo entitlement_info = 16;
 }
 
 // Information about a fork event

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -237,10 +237,12 @@ objc_library(
         ":SNTSyncdQueue",
         ":TTYWriter",
         "//Source/common:BranchPrediction",
+        "//Source/common:PrefixTree",
         "//Source/common:SNTBlockMessage",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
+        "//Source/common:SNTDeepCopy",
         "//Source/common:SNTDropRootPrivs",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
@@ -249,7 +251,9 @@ objc_library(
         "//Source/common:SNTStoredEvent",
         "//Source/common:SantaVnode",
         "//Source/common:String",
+        "//Source/common:Unit",
         "@MOLCodesignChecker",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 

--- a/Source/santad/EventProviders/AuthResultCache.h
+++ b/Source/santad/EventProviders/AuthResultCache.h
@@ -41,6 +41,8 @@ enum class FlushCacheReason {
   kStaticRulesChanged,
   kExplicitCommand,
   kFilesystemUnmounted,
+  kEntitlementsPrefixFilterChanged,
+  kEntitlementsTeamIDFilterChanged,
 };
 
 class AuthResultCache {

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -31,6 +31,10 @@ static NSString *const kFlushCacheReasonRulesChanged = @"RulesChanged";
 static NSString *const kFlushCacheReasonStaticRulesChanged = @"StaticRulesChanged";
 static NSString *const kFlushCacheReasonExplicitCommand = @"ExplicitCommand";
 static NSString *const kFlushCacheReasonFilesystemUnmounted = @"FilesystemUnmounted";
+static NSString *const kFlushCacheReasonEntitlementsPrefixFilterChanged =
+  @"EntitlementsPrefixFilterChanged";
+static NSString *const kFlushCacheReasonEntitlementsTeamIDFilterChanged =
+  @"EntitlementsTeamIDFilterChanged";
 
 namespace santa::santad::event_providers {
 
@@ -59,6 +63,10 @@ NSString *const FlushCacheReasonToString(FlushCacheReason reason) {
     case FlushCacheReason::kStaticRulesChanged: return kFlushCacheReasonStaticRulesChanged;
     case FlushCacheReason::kExplicitCommand: return kFlushCacheReasonExplicitCommand;
     case FlushCacheReason::kFilesystemUnmounted: return kFlushCacheReasonFilesystemUnmounted;
+    case FlushCacheReason::kEntitlementsPrefixFilterChanged:
+      return kFlushCacheReasonEntitlementsPrefixFilterChanged;
+    case FlushCacheReason::kEntitlementsTeamIDFilterChanged:
+      return kFlushCacheReasonEntitlementsTeamIDFilterChanged;
     default:
       [NSException raise:@"Invalid reason"
                   format:@"Unknown reason value: %d", static_cast<int>(reason)];

--- a/Source/santad/EventProviders/AuthResultCacheTest.mm
+++ b/Source/santad/EventProviders/AuthResultCacheTest.mm
@@ -230,13 +230,16 @@ static inline void AssertCacheCounts(std::shared_ptr<AuthResultCache> cache, uin
     {FlushCacheReason::kStaticRulesChanged, @"StaticRulesChanged"},
     {FlushCacheReason::kExplicitCommand, @"ExplicitCommand"},
     {FlushCacheReason::kFilesystemUnmounted, @"FilesystemUnmounted"},
+    {FlushCacheReason::kEntitlementsPrefixFilterChanged, @"EntitlementsPrefixFilterChanged"},
+    {FlushCacheReason::kEntitlementsTeamIDFilterChanged, @"EntitlementsTeamIDFilterChanged"},
   };
 
   for (const auto &kv : reasonToString) {
     XCTAssertEqualObjects(FlushCacheReasonToString(kv.first), kv.second);
   }
 
-  XCTAssertThrows(FlushCacheReasonToString((FlushCacheReason)12345));
+  XCTAssertThrows(FlushCacheReasonToString(
+    (FlushCacheReason)(static_cast<int>(FlushCacheReason::kEntitlementsTeamIDFilterChanged) + 1)));
 }
 
 @end

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -57,7 +57,9 @@ const static NSString *kBlockLongPath = @"BlockLongPath";
                        eventTable:(SNTEventTable *)eventTable
                     notifierQueue:(SNTNotificationQueue *)notifierQueue
                        syncdQueue:(SNTSyncdQueue *)syncdQueue
-                        ttyWriter:(std::shared_ptr<santa::santad::TTYWriter>)ttyWriter;
+                        ttyWriter:(std::shared_ptr<santa::santad::TTYWriter>)ttyWriter
+         entitlementsPrefixFilter:(NSArray<NSString *> *)prefixFilter
+         entitlementsTeamIDFilter:(NSArray<NSString *> *)teamIDFilter;
 
 ///
 ///  Handles the logic of deciding whether to allow the binary to run or not, sends the response to
@@ -82,4 +84,6 @@ const static NSString *kBlockLongPath = @"BlockLongPath";
 - (bool)synchronousShouldProcessExecEvent:
   (const santa::santad::event_providers::endpoint_security::Message &)esMsg;
 
+- (void)updateEntitlementsPrefixFilter:(NSArray<NSString *> *)filter;
+- (void)updateEntitlementsTeamIDFilter:(NSArray<NSString *> *)filter;
 @end

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -143,13 +143,11 @@ static NSString *const kPrinterProxyPostMonterey =
 - (void)updateEntitlementsPrefixFilter:(NSArray<NSString *> *)filter {
   absl::MutexLock lock(&self->_filterMutex);
   UpdatePrefixFilterLocked(self->_entitlementsPrefixFilter, filter);
-  LOGD(@"Updated EntitlementPrefixFilter: %@", filter);
 }
 
 - (void)updateEntitlementsTeamIDFilter:(NSArray<NSString *> *)filter {
   absl::MutexLock lock(&self->_filterMutex);
   UpdateTeamIDFilterLocked(self->_entitlementsTeamIDFilter, filter);
-  LOGD(@"Updated EntitlementTeamIDFilter: %@", filter);
 }
 
 - (void)incrementEventCounters:(SNTEventState)eventType {

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -89,7 +89,7 @@ void UpdatePrefixFilterLocked(std::unique_ptr<PrefixTree<Unit>> &tree,
 
 @implementation SNTExecutionController {
   std::shared_ptr<TTYWriter> _ttyWriter;
-  absl::Mutex _filterMutex;
+  absl::Mutex _entitlementFilterMutex;
   std::set<std::string> _entitlementsTeamIDFilter;
   std::unique_ptr<PrefixTree<Unit>> _entitlementsPrefixFilter;
 }
@@ -141,12 +141,12 @@ static NSString *const kPrinterProxyPostMonterey =
 }
 
 - (void)updateEntitlementsPrefixFilter:(NSArray<NSString *> *)filter {
-  absl::MutexLock lock(&self->_filterMutex);
+  absl::MutexLock lock(&self->_entitlementFilterMutex);
   UpdatePrefixFilterLocked(self->_entitlementsPrefixFilter, filter);
 }
 
 - (void)updateEntitlementsTeamIDFilter:(NSArray<NSString *> *)filter {
-  absl::MutexLock lock(&self->_filterMutex);
+  absl::MutexLock lock(&self->_entitlementFilterMutex);
   UpdateTeamIDFilterLocked(self->_entitlementsTeamIDFilter, filter);
 }
 
@@ -262,7 +262,7 @@ static NSString *const kPrinterProxyPostMonterey =
         return nil;
       }
 
-      absl::ReaderMutexLock lock(&self->_filterMutex);
+      absl::ReaderMutexLock lock(&self->_entitlementFilterMutex);
 
       if (teamID && self->_entitlementsTeamIDFilter.count(std::string(teamID)) > 0) {
         LOGD(@"Dropping entitlement logging for configured TeamID: %s", teamID);

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -96,7 +96,9 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
                                                     eventTable:self.mockEventDatabase
                                                  notifierQueue:nil
                                                     syncdQueue:nil
-                                                     ttyWriter:nullptr];
+                                                     ttyWriter:nullptr
+                                      entitlementsPrefixFilter:nil
+                                      entitlementsTeamIDFilter:nil];
 }
 
 - (void)tearDown {

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -36,22 +36,19 @@
 - (nullable instancetype)initWithRuleTable:(nonnull SNTRuleTable *)ruleTable;
 
 ///
-///  @param fileInfo A SNTFileInfo object.
-///  @param fileSHA256 The pre-calculated SHA256 hash for the file, can be nil. If nil the hash will
-///                    be calculated by this method from the filePath.
-///  @param certificateSHA256 The pre-calculated SHA256 hash of the leaf certificate. If nil, the
-///                    signature will be validated on the binary represented by fileInfo.
-///
-- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
-                                        fileSHA256:(nullable NSString *)fileSHA256
-                                 certificateSHA256:(nullable NSString *)certificateSHA256
-                                            teamID:(nullable NSString *)teamID
-                                         signingID:(nullable NSString *)signingID;
-
 ///  Convenience initializer. Will obtain the teamID and construct the signingID
 ///  identifier if able.
+///
+/// IMPORTANT: The lifetimes of arguments to `entitlementsFilterCallback` are
+/// only guaranteed for the duration of the call to the block. Do not perform
+/// any async processing without extending their lifetimes.
+///
 - (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
-                                     targetProcess:(nonnull const es_process_t *)targetProc;
+                                     targetProcess:(nonnull const es_process_t *)targetProc
+                        entitlementsFilterCallback:
+                          (NSDictionary *_Nullable (^_Nonnull)(
+                            const char *_Nullable teamID,
+                            NSDictionary *_Nullable entitlements))entitlementsFilterCallback;
 
 ///
 ///  A wrapper for decisionForFileInfo:fileSHA256:certificateSHA256:. This method is slower as it

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -39,9 +39,9 @@
 ///  Convenience initializer. Will obtain the teamID and construct the signingID
 ///  identifier if able.
 ///
-/// IMPORTANT: The lifetimes of arguments to `entitlementsFilterCallback` are
-/// only guaranteed for the duration of the call to the block. Do not perform
-/// any async processing without extending their lifetimes.
+///  IMPORTANT: The lifetimes of arguments to `entitlementsFilterCallback` are
+///  only guaranteed for the duration of the call to the block. Do not perform
+///  any async processing without extending their lifetimes.
 ///
 - (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
                                      targetProcess:(nonnull const es_process_t *)targetProc

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -13,6 +13,7 @@
 ///    limitations under the License.
 
 #import "Source/santad/SNTPolicyProcessor.h"
+#include <Foundation/Foundation.h>
 
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <Security/SecCode.h>
@@ -97,13 +98,16 @@
         }
       }
 
+      NSDictionary *entitlements =
+        csInfo.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict];
+
       if (entitlementsFilterCallback) {
-        cd.entitlements = entitlementsFilterCallback(
-          csInfo.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict]);
+        NSDictionary *filtered = entitlementsFilterCallback(entitlements);
+        cd.entitlements = filtered;
+        cd.entitlementsFiltered = filtered.count == entitlements.count;
       } else {
-        cd.entitlements =
-          [csInfo.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict]
-            sntDeepCopy];
+        cd.entitlements = [entitlements sntDeepCopy];
+        cd.entitlementsFiltered = NO;
       }
     }
   }

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -102,9 +102,8 @@
         csInfo.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict];
 
       if (entitlementsFilterCallback) {
-        NSDictionary *filtered = entitlementsFilterCallback(entitlements);
-        cd.entitlements = filtered;
-        cd.entitlementsFiltered = filtered.count == entitlements.count;
+        cd.entitlements = entitlementsFilterCallback(entitlements);
+        cd.entitlementsFiltered = (cd.entitlements.count == entitlements.count);
       } else {
         cd.entitlements = [entitlements sntDeepCopy];
         cd.entitlementsFiltered = NO;

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -378,7 +378,7 @@ void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logg
               // future execs get SNTCachedDecision entitlement values filtered
               // with the new settings.
               auth_result_cache->FlushCache(FlushCacheMode::kAllCaches,
-                                            FlushCacheReason::kEntitlementsPrefixFilterChanged);
+                                            FlushCacheReason::kEntitlementsTeamIDFilterChanged);
               [authorizer_client clearCache];
             }],
     [[SNTKVOManager alloc]

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -94,7 +94,9 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
                                            eventTable:event_table
                                         notifierQueue:notifier_queue
                                            syncdQueue:syncd_queue
-                                            ttyWriter:tty_writer];
+                                            ttyWriter:tty_writer
+                             entitlementsPrefixFilter:[configurator entitlementsPrefixFilter]
+                             entitlementsTeamIDFilter:[configurator entitlementsTeamIDFilter]];
   if (!exec_controller) {
     LOGE(@"Failed to initialize exec controller.");
     exit(EXIT_FAILURE);

--- a/Source/santad/testdata/protobuf/v1/exec.json
+++ b/Source/santad/testdata/protobuf/v1/exec.json
@@ -121,42 +121,45 @@
  },
  "explain": "extra!",
  "quarantine_url": "google.com",
- "entitlements": [
-  {
-   "key": "key_with_arr_val_multitype",
-   "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
-  },
-  {
-   "key": "key_with_data_val",
-   "value": "\"SGVsbG8gV29ybGQ=\""
-  },
-  {
-   "key": "key_with_str_val",
-   "value": "\"bar\""
-  },
-  {
-   "key": "key_with_arr_val_nested",
-   "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
-  },
-  {
-   "key": "key_with_dict_val",
-   "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_date_val",
-   "value": "\"2023-11-07T17:00:02.000Z\""
-  },
-  {
-   "key": "key_with_dict_val_nested",
-   "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_num_val",
-   "value": "1234"
-  },
-  {
-   "key": "key_with_arr_val",
-   "value": "[\"v1\",\"v2\",\"v3\"]"
-  }
- ]
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
 }

--- a/Source/santad/testdata/protobuf/v2/exec.json
+++ b/Source/santad/testdata/protobuf/v2/exec.json
@@ -149,42 +149,45 @@
  },
  "explain": "extra!",
  "quarantine_url": "google.com",
- "entitlements": [
-  {
-   "key": "key_with_arr_val_multitype",
-   "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
-  },
-  {
-   "key": "key_with_data_val",
-   "value": "\"SGVsbG8gV29ybGQ=\""
-  },
-  {
-   "key": "key_with_str_val",
-   "value": "\"bar\""
-  },
-  {
-   "key": "key_with_arr_val_nested",
-   "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
-  },
-  {
-   "key": "key_with_dict_val",
-   "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_date_val",
-   "value": "\"2023-11-07T17:00:02.000Z\""
-  },
-  {
-   "key": "key_with_dict_val_nested",
-   "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_num_val",
-   "value": "1234"
-  },
-  {
-   "key": "key_with_arr_val",
-   "value": "[\"v1\",\"v2\",\"v3\"]"
-  }
- ]
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
 }

--- a/Source/santad/testdata/protobuf/v4/exec.json
+++ b/Source/santad/testdata/protobuf/v4/exec.json
@@ -198,42 +198,45 @@
  },
  "explain": "extra!",
  "quarantine_url": "google.com",
- "entitlements": [
-  {
-   "key": "key_with_arr_val_multitype",
-   "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
-  },
-  {
-   "key": "key_with_data_val",
-   "value": "\"SGVsbG8gV29ybGQ=\""
-  },
-  {
-   "key": "key_with_str_val",
-   "value": "\"bar\""
-  },
-  {
-   "key": "key_with_arr_val_nested",
-   "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
-  },
-  {
-   "key": "key_with_dict_val",
-   "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_date_val",
-   "value": "\"2023-11-07T17:00:02.000Z\""
-  },
-  {
-   "key": "key_with_dict_val_nested",
-   "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_num_val",
-   "value": "1234"
-  },
-  {
-   "key": "key_with_arr_val",
-   "value": "[\"v1\",\"v2\",\"v3\"]"
-  }
- ]
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
 }

--- a/Source/santad/testdata/protobuf/v5/exec.json
+++ b/Source/santad/testdata/protobuf/v5/exec.json
@@ -198,42 +198,45 @@
  },
  "explain": "extra!",
  "quarantine_url": "google.com",
- "entitlements": [
-  {
-   "key": "key_with_arr_val_multitype",
-   "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
-  },
-  {
-   "key": "key_with_data_val",
-   "value": "\"SGVsbG8gV29ybGQ=\""
-  },
-  {
-   "key": "key_with_str_val",
-   "value": "\"bar\""
-  },
-  {
-   "key": "key_with_arr_val_nested",
-   "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
-  },
-  {
-   "key": "key_with_dict_val",
-   "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_date_val",
-   "value": "\"2023-11-07T17:00:02.000Z\""
-  },
-  {
-   "key": "key_with_dict_val_nested",
-   "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_num_val",
-   "value": "1234"
-  },
-  {
-   "key": "key_with_arr_val",
-   "value": "[\"v1\",\"v2\",\"v3\"]"
-  }
- ]
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
 }

--- a/Source/santad/testdata/protobuf/v6/exec.json
+++ b/Source/santad/testdata/protobuf/v6/exec.json
@@ -198,42 +198,45 @@
  },
  "explain": "extra!",
  "quarantine_url": "google.com",
- "entitlements": [
-  {
-   "key": "key_with_arr_val_multitype",
-   "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
-  },
-  {
-   "key": "key_with_data_val",
-   "value": "\"SGVsbG8gV29ybGQ=\""
-  },
-  {
-   "key": "key_with_str_val",
-   "value": "\"bar\""
-  },
-  {
-   "key": "key_with_arr_val_nested",
-   "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
-  },
-  {
-   "key": "key_with_dict_val",
-   "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_date_val",
-   "value": "\"2023-11-07T17:00:02.000Z\""
-  },
-  {
-   "key": "key_with_dict_val_nested",
-   "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
-  },
-  {
-   "key": "key_with_num_val",
-   "value": "1234"
-  },
-  {
-   "key": "key_with_arr_val",
-   "value": "[\"v1\",\"v2\",\"v3\"]"
-  }
- ]
+ "entitlement_info": {
+  "entitlements_filtered": false,
+  "entitlements": [
+   {
+    "key": "key_with_arr_val_multitype",
+    "value": "[\"v1\",\"v2\",\"v3\",123,\"2023-11-07T17:00:02.000Z\"]"
+   },
+   {
+    "key": "key_with_data_val",
+    "value": "\"SGVsbG8gV29ybGQ=\""
+   },
+   {
+    "key": "key_with_str_val",
+    "value": "\"bar\""
+   },
+   {
+    "key": "key_with_arr_val_nested",
+    "value": "[\"v1\",\"v2\",\"v3\",[\"nv1\",\"nv2\"]]"
+   },
+   {
+    "key": "key_with_dict_val",
+    "value": "{\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_date_val",
+    "value": "\"2023-11-07T17:00:02.000Z\""
+   },
+   {
+    "key": "key_with_dict_val_nested",
+    "value": "{\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"2023-11-07T17:00:02.000Z\"},\"k2\":\"v2\",\"k1\":\"v1\"}"
+   },
+   {
+    "key": "key_with_num_val",
+    "value": "1234"
+   },
+   {
+    "key": "key_with_arr_val",
+    "value": "[\"v1\",\"v2\",\"v3\"]"
+   }
+  ]
+ }
 }

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -77,7 +77,9 @@ also known as mobileconfig files, which are in an Apple-specific XML format.
 | FileAccessPolicyUpdateIntervalSec | Integer     | Number of seconds between re-reading the file access policy config and policies/monitored paths updated. |
 | SyncClientContentEncoding         | String      | Sets the Content-Encoding header for requests sent to the sync service. Acceptable values are "deflate", "gzip", "none" (Defaults to deflate.)  |
 | SyncExtraHeaders                  | Dictionary  | Dictionary of additional headers to include in all requests made to the sync server. System managed headers such as Content-Length, Host, WWW-Authenticate etc will be ignored. |
-| EnableDebugLogging                | Bool  | If YES, the client will log additional debug messages to the Apple Unified Log.  For example, transitive rule creation logs can be viewed with `log stream --predicate 'sender=="com.google.santa.daemon"'`.  Defaults to NO. |
+| EnableDebugLogging                | Bool        | If YES, the client will log additional debug messages to the Apple Unified Log.  For example, transitive rule creation logs can be viewed with `log stream --predicate 'sender=="com.google.santa.daemon"'`.  Defaults to NO. |
+| EntitlementsPrefixFilter          | Array       | Array of strings of entitlement prefixes that should not be logged (for example: `com.apple.private`). No default. |
+| EntitlementsTeamIDFilter          | Array       | Array of TeamID strings. Entitlements from processes with a matching TeamID in the code signature will not be logged. Use the value `platform` to filter entitlements from platform binaries. No default. |
 
 
 \*overridable by the sync server: run `santactl status` to check the current


### PR DESCRIPTION
Adds two configuration options supporting entitlement logging:
* `EntitlementsTeamIDFilter` - Filter out entitlements from binaries from configured organizations
* `EntitlementsPrefixFilter` - Filter out specific entitlement prefixes