### PR TITLE
Experimental metrics

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -196,6 +196,7 @@ objc_library(
     ],
     hdrs = ["SNTPolicyProcessor.h"],
     deps = [
+        "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -196,7 +196,6 @@ objc_library(
     ],
     hdrs = ["SNTPolicyProcessor.h"],
     deps = [
-        "//Source/common:Platform",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -202,6 +202,7 @@ objc_library(
         "//Source/common:SNTDeepCopy",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
+        "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",
         "@FMDB",
         "@MOLCertificate",

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -15,18 +15,17 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 #include <Foundation/Foundation.h>
 
+#include <Availability.h>
 #include <Kernel/kern/cs_blobs.h>
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <Security/SecCode.h>
-#include <Security/Security.h>
+#import <Security/Security.h>
 
-#include "Source/common/SNTLogging.h"
-
-#include "Source/common/Platform.h"
 #import "Source/common/SNTCachedDecision.h"
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTDeepCopy.h"
 #import "Source/common/SNTFileInfo.h"
+#import "Source/common/SNTLogging.h"
 #import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTRule.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
@@ -126,7 +125,7 @@ NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validation
         cd.entitlementsFiltered = NO;
       }
 
-#if HAVE_MACOS_13
+#if defined(MAC_OS_VERSION_13_3) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_13_3
       if (@available(macOS 13.0, *)) {
         // Temporary experiment code...
         if (targetProc != NULL && fileInfo.path != nil) {

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -32,8 +32,10 @@
 
 NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validationCategoryThree,
                                               BOOL oidsSet) {
-#define BOOL_STR(b) (b) ? @"True" : @"False"
-  return @[ BOOL_STR(csDevFlagSet), BOOL_STR(validationCategoryThree), BOOL_STR(oidsSet) ];
+#define SNT_BOOL_STR(b) (b) ? @"True" : @"False"
+  return
+    @[ SNT_BOOL_STR(csDevFlagSet), SNT_BOOL_STR(validationCategoryThree), SNT_BOOL_STR(oidsSet) ];
+#undef SNT_BOOL_STR
 }
 
 @interface SNTPolicyProcessor ()

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -15,8 +15,10 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 #include <Foundation/Foundation.h>
 
+#include <Kernel/kern/cs_blobs.h>
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <Security/SecCode.h>
+#include <Security/Security.h>
 
 #include "Source/common/SNTLogging.h"
 
@@ -24,12 +26,20 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTDeepCopy.h"
 #import "Source/common/SNTFileInfo.h"
+#import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTRule.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
+
+NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validationCategoryThree,
+                                              BOOL oidsSet) {
+#define BOOL_STR(b) (b) ? @"True" : @"False"
+  return @[ BOOL_STR(csDevFlagSet), BOOL_STR(validationCategoryThree), BOOL_STR(oidsSet) ];
+}
 
 @interface SNTPolicyProcessor ()
 @property SNTRuleTable *ruleTable;
 @property SNTConfigurator *configurator;
+@property SNTMetricCounter *experimentalDevMetrics;
 @end
 
 @implementation SNTPolicyProcessor
@@ -39,6 +49,11 @@
   if (self) {
     _ruleTable = ruleTable;
     _configurator = [SNTConfigurator configurator];
+
+    _experimentalDevMetrics = [[SNTMetricSet sharedInstance]
+      counterWithName:@"/santa/tmp_signing_info_experiment"
+           fieldNames:@[ @"CSDevFlagSet", @"ValidationCategory", @"DevOIDSet" ]
+             helpText:@"Temporary experiment for dev signed code"];
   }
   return self;
 }
@@ -48,6 +63,7 @@
                                  certificateSHA256:(nullable NSString *)certificateSHA256
                                             teamID:(nullable NSString *)teamID
                                          signingID:(nullable NSString *)signingID
+                                     targetProcess:(nullable const es_process_t *)targetProc
                         entitlementsFilterCallback:
                           (NSDictionary *_Nullable (^_Nullable)(
                             NSDictionary *_Nullable entitlements))entitlementsFilterCallback {
@@ -107,6 +123,48 @@
       } else {
         cd.entitlements = [entitlements sntDeepCopy];
         cd.entitlementsFiltered = NO;
+      }
+
+      // Temporary experiment code...
+      if (targetProc != NULL) {
+        // Doing a second SecStaticCodeCreate to not need to worry about modifying the dependency...
+        SecStaticCodeRef codeRef = NULL;
+        OSStatus status = SecStaticCodeCreateWithPath(
+          (__bridge CFURLRef)[NSURL fileURLWithPath:fileInfo.path], kSecCSDefaultFlags, &codeRef);
+        if (status == errSecSuccess) {
+          CFDictionaryRef cfSigningInfo = NULL;
+          SecCodeCopySigningInformation(
+            codeRef, kSecCSSigningInformation | kSecCSRequirementInformation, &cfSigningInfo);
+          NSDictionary *signingInfo = CFBridgingRelease(cfSigningInfo);
+
+          // Taken from Security framework: LWCRHelper.mm
+          NSString *reqVaidationCategryKey = @"validation-category";
+          // Taken from Security framework:
+          NSArray *keys = @[ @"1.2.840.113635.100.6.1.2", @"1.2.840.113635.100.6.1.12" ];
+          NSDictionary *lwCodeReq = signingInfo[(
+            __bridge NSString *)kSecCodeInfoDefaultDesignatedLightweightCodeRequirement];
+
+          NSDictionary *vals = CFBridgingRelease(SecCertificateCopyValues(
+            csInfo.leafCertificate.certRef, (__bridge CFArrayRef)keys, NULL));
+
+          BOOL validationCategoryThree = [lwCodeReq[reqVaidationCategryKey] intValue] == 3;
+          BOOL csDevFlagSet = ((targetProc->codesigning_flags & CS_DEV_CODE) != 0);
+          BOOL oidsSet = vals.count > 0;
+
+          [self.experimentalDevMetrics
+            incrementForFieldValues:FieldValuesForProperties(csDevFlagSet, validationCategoryThree,
+                                                             oidsSet)];
+
+          if (!(csDevFlagSet == validationCategoryThree && csDevFlagSet == oidsSet)) {
+            NSDictionary *certVals = CFBridgingRelease(
+              SecCertificateCopyValues(csInfo.leafCertificate.certRef, NULL, NULL));
+            LOGI(@"EXPERIMENTAL Unexpected state difference: %@ | Flags(%d): 0x%08x, VC(%d): %d, "
+                 @"oids(%d): %@",
+                 fileInfo.path, csDevFlagSet, targetProc->codesigning_flags,
+                 validationCategoryThree, [lwCodeReq[reqVaidationCategryKey] intValue], oidsSet,
+                 [certVals allKeys]);
+          }
+        }
       }
     }
   }
@@ -267,6 +325,7 @@
                  certificateSHA256:nil
                             teamID:teamID
                          signingID:signingID
+                     targetProcess:targetProc
         entitlementsFilterCallback:^NSDictionary *(NSDictionary *entitlements) {
           return entitlementsFilterCallback(entitlementsFilterTeamID, entitlements);
         }];
@@ -287,6 +346,7 @@
                  certificateSHA256:certificateSHA256
                             teamID:teamID
                          signingID:signingID
+                     targetProcess:NULL
         entitlementsFilterCallback:nil];
 }
 


### PR DESCRIPTION
This is experimental code only and will be stripped out before the next release.

 Sample metric output:
 ```
   Metric Name               | /santa/tmp_signing_info_experiment
  Description               | Temporary experiment for dev signed code
  Type                      | SNTMetricTypeCounter
  Field                     | CSDevFlagSet=False,ValidationCategory=False,DevOIDSet=False
  Created                   | 2023-11-20T15:46:32.345Z
  Last Updated              | 2023-11-20T15:57:55.462Z
  Data                      | 58
  Field                     | CSDevFlagSet=True,ValidationCategory=True,DevOIDSet=True
  Created                   | 2023-11-20T15:55:42.191Z
  Last Updated              | 2023-11-20T15:55:42.191Z
  Data                      | 1
  ```

Sample log line (note: test code changed to force this output, wouldn't normally display since no delta exists):
```
I com.google.santa.daemon: EXPERIMENTAL Unexpected state difference: /bin/ls | Flags(0): 0x22013b11, VC(0): 1, oids(0): (
    "2.16.840.1.113741.2.1.1.1.6",
    "2.5.29.14",
    "2.16.840.1.113741.2.1.3.2.1",
    "2.16.840.1.113741.2.1.1.1.7",
    "2.5.29.32",
    "2.16.840.1.113741.2.1.3.2.2",
    "2.16.840.1.113741.2.1.1.1.8",
    "1.2.840.113635.100.6.22",
    "2.16.840.1.113741.2.1.1.1.10",
    "2.16.840.1.113741.2.1.1.1.2",
    "2.16.840.1.113741.2.1.1.1.9",
    "2.5.29.15",
    "2.5.4.3",
    "2.5.29.19",
    "2.16.840.1.113741.2.1.1.1.3",
    "2.5.29.24",
    Fingerprints,
    "2.5.29.31",
    "2.5.29.35",
    "2.5.29.37",
    "2.16.840.1.113741.2.1.1.1.5"
)
```