### PR TITLE
Ignore TeamID and SigningID rules for dev signed code

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -202,7 +202,6 @@ objc_library(
         "//Source/common:SNTDeepCopy",
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
-        "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",
         "@FMDB",
         "@MOLCertificate",

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -118,7 +118,9 @@
   // assumption that orgs are generally more relaxed about dev signed cert
   // protections and users can more easily produce dev-signed code that
   // would otherwise be inadvertently allowed.
-  if (!isProdSignedCallback()) {
+  // Note: Only perform the check if the SigningID is still set, otherwise
+  // it is unsigned or had issues above that already cleared the values.
+  if (cd.signingID && !isProdSignedCallback()) {
     LOGD(@"Ignoring TeamID and SigningID rules for code not signed with production cert: %@",
          cd.signingID);
     cd.teamID = nil;

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -282,7 +282,7 @@
     certificateSHA256:nil
     teamID:teamID
     signingID:signingID
-    isProdSignedCallback:^BOOL() {
+    isProdSignedCallback:^BOOL {
       return ((targetProc->codesigning_flags & CS_DEV_CODE) == 0);
     }
     entitlementsFilterCallback:^NSDictionary *(NSDictionary *entitlements) {
@@ -296,11 +296,10 @@
                                  certificateSHA256:(nullable NSString *)certificateSHA256
                                             teamID:(nullable NSString *)teamID
                                          signingID:(nullable NSString *)signingID {
-  SNTFileInfo *fileInfo;
   MOLCodesignChecker *csInfo;
   NSError *error;
 
-  fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
+  SNTFileInfo *fileInfo = [[SNTFileInfo alloc] initWithPath:filePath error:&error];
   if (!fileInfo) {
     LOGW(@"Failed to read file %@: %@", filePath, error.localizedDescription);
   } else {
@@ -315,9 +314,10 @@
                  certificateSHA256:certificateSHA256
                             teamID:teamID
                          signingID:signingID
-              isProdSignedCallback:^BOOL() {
+              isProdSignedCallback:^BOOL {
                 if (csInfo) {
-                  // Development OID values taken from Security framework
+                  // Development OID values defined by Apple and used by the Security Framework
+                  // https://images.apple.com/certificateauthority/pdf/Apple_WWDR_CPS_v1.31.pdf
                   NSArray *keys = @[ @"1.2.840.113635.100.6.1.2", @"1.2.840.113635.100.6.1.12" ];
                   NSDictionary *vals = CFBridgingRelease(SecCertificateCopyValues(
                     csInfo.leafCertificate.certRef, (__bridge CFArrayRef)keys, NULL));

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -15,7 +15,6 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 #include <Foundation/Foundation.h>
 
-#include <Availability.h>
 #include <Kernel/kern/cs_blobs.h>
 #import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <Security/SecCode.h>
@@ -26,22 +25,12 @@
 #import "Source/common/SNTDeepCopy.h"
 #import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTLogging.h"
-#import "Source/common/SNTMetricSet.h"
 #import "Source/common/SNTRule.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
-
-NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validationCategoryThree,
-                                              BOOL oidsSet) {
-#define SNT_BOOL_STR(b) (b) ? @"True" : @"False"
-  return
-    @[ SNT_BOOL_STR(csDevFlagSet), SNT_BOOL_STR(validationCategoryThree), SNT_BOOL_STR(oidsSet) ];
-#undef SNT_BOOL_STR
-}
 
 @interface SNTPolicyProcessor ()
 @property SNTRuleTable *ruleTable;
 @property SNTConfigurator *configurator;
-@property SNTMetricCounter *experimentalDevMetrics;
 @end
 
 @implementation SNTPolicyProcessor
@@ -51,24 +40,19 @@ NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validation
   if (self) {
     _ruleTable = ruleTable;
     _configurator = [SNTConfigurator configurator];
-
-    _experimentalDevMetrics = [[SNTMetricSet sharedInstance]
-      counterWithName:@"/santa/tmp_signing_info_experiment"
-           fieldNames:@[ @"CSDevFlagSet", @"ValidationCategory", @"DevOIDSet" ]
-             helpText:@"Temporary experiment for dev signed code"];
   }
   return self;
 }
 
-- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
-                                        fileSHA256:(nullable NSString *)fileSHA256
-                                 certificateSHA256:(nullable NSString *)certificateSHA256
-                                            teamID:(nullable NSString *)teamID
-                                         signingID:(nullable NSString *)signingID
-                                     targetProcess:(nullable const es_process_t *)targetProc
-                        entitlementsFilterCallback:
-                          (NSDictionary *_Nullable (^_Nullable)(
-                            NSDictionary *_Nullable entitlements))entitlementsFilterCallback {
+- (nonnull SNTCachedDecision *)
+         decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
+                  fileSHA256:(nullable NSString *)fileSHA256
+           certificateSHA256:(nullable NSString *)certificateSHA256
+                      teamID:(nullable NSString *)teamID
+                   signingID:(nullable NSString *)signingID
+         isDevSignedCallback:(BOOL (^_Nonnull)(MOLCertificate *))isDevSignedCallback
+  entitlementsFilterCallback:(NSDictionary *_Nullable (^_Nullable)(
+                               NSDictionary *_Nullable entitlements))entitlementsFilterCallback {
   SNTCachedDecision *cd = [[SNTCachedDecision alloc] init];
   cd.sha256 = fileSHA256 ?: fileInfo.SHA256;
   cd.teamID = teamID;
@@ -116,6 +100,15 @@ NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validation
         }
       }
 
+      // Do not evaluate TeamID/SigningID rules for dev-signed code based on the
+      // assumption that orgs are generally more relaxed about dev signed cert
+      // protections and users can more easily produce dev-signed code that
+      // would otherwise be inadvertently allowed.
+      if (isDevSignedCallback(csInfo.leafCertificate)) {
+        cd.teamID = nil;
+        cd.signingID = nil;
+      }
+
       NSDictionary *entitlements =
         csInfo.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict];
 
@@ -126,53 +119,6 @@ NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validation
         cd.entitlements = [entitlements sntDeepCopy];
         cd.entitlementsFiltered = NO;
       }
-
-#if defined(MAC_OS_VERSION_13_3) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_13_3
-      if (@available(macOS 13.0, *)) {
-        // Temporary experiment code...
-        if (targetProc != NULL && fileInfo.path != nil) {
-          // Doing a second SecStaticCodeCreate to not need to worry about modifying the
-          // dependency...
-          SecStaticCodeRef codeRef = NULL;
-          OSStatus status = SecStaticCodeCreateWithPath(
-            (__bridge CFURLRef)[NSURL fileURLWithPath:fileInfo.path], kSecCSDefaultFlags, &codeRef);
-          if (status == errSecSuccess) {
-            CFDictionaryRef cfSigningInfo = NULL;
-            SecCodeCopySigningInformation(
-              codeRef, kSecCSSigningInformation | kSecCSRequirementInformation, &cfSigningInfo);
-            NSDictionary *signingInfo = CFBridgingRelease(cfSigningInfo);
-
-            // Taken from Security framework: LWCRHelper.mm
-            NSString *reqVaidationCategryKey = @"validation-category";
-            // Taken from Security framework:
-            NSArray *keys = @[ @"1.2.840.113635.100.6.1.2", @"1.2.840.113635.100.6.1.12" ];
-            NSDictionary *lwCodeReq = signingInfo[(
-              __bridge NSString *)kSecCodeInfoDefaultDesignatedLightweightCodeRequirement];
-
-            NSDictionary *vals = CFBridgingRelease(SecCertificateCopyValues(
-              csInfo.leafCertificate.certRef, (__bridge CFArrayRef)keys, NULL));
-
-            BOOL validationCategoryThree = [lwCodeReq[reqVaidationCategryKey] intValue] == 3;
-            BOOL csDevFlagSet = ((targetProc->codesigning_flags & CS_DEV_CODE) != 0);
-            BOOL oidsSet = vals.count > 0;
-
-            [self.experimentalDevMetrics
-              incrementForFieldValues:FieldValuesForProperties(csDevFlagSet,
-                                                               validationCategoryThree, oidsSet)];
-
-            if (!(csDevFlagSet == validationCategoryThree && csDevFlagSet == oidsSet)) {
-              NSDictionary *certVals = CFBridgingRelease(
-                SecCertificateCopyValues(csInfo.leafCertificate.certRef, NULL, NULL));
-              LOGI(@"EXPERIMENTAL Unexpected state difference: %@ | Flags(%d): 0x%08x, VC(%d): %d, "
-                   @"oids(%d): %@",
-                   fileInfo.path, csDevFlagSet, targetProc->codesigning_flags,
-                   validationCategoryThree, [lwCodeReq[reqVaidationCategryKey] intValue], oidsSet,
-                   [certVals allKeys]);
-            }
-          }
-        }
-      }
-#endif
     }
   }
   cd.quarantineURL = fileInfo.quarantineDataURL;
@@ -328,14 +274,16 @@ NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validation
   }
 
   return [self decisionForFileInfo:fileInfo
-                        fileSHA256:nil
-                 certificateSHA256:nil
-                            teamID:teamID
-                         signingID:signingID
-                     targetProcess:targetProc
-        entitlementsFilterCallback:^NSDictionary *(NSDictionary *entitlements) {
-          return entitlementsFilterCallback(entitlementsFilterTeamID, entitlements);
-        }];
+    fileSHA256:nil
+    certificateSHA256:nil
+    teamID:teamID
+    signingID:signingID
+    isDevSignedCallback:^BOOL(MOLCertificate *leafCertificate __unused) {
+      return ((targetProc->codesigning_flags & CS_DEV_CODE) != 0);
+    }
+    entitlementsFilterCallback:^NSDictionary *(NSDictionary *entitlements) {
+      return entitlementsFilterCallback(entitlementsFilterTeamID, entitlements);
+    }];
 }
 
 // Used by `$ santactl fileinfo`.
@@ -353,7 +301,12 @@ NSArray<NSString *> *FieldValuesForProperties(BOOL csDevFlagSet, BOOL validation
                  certificateSHA256:certificateSHA256
                             teamID:teamID
                          signingID:signingID
-                     targetProcess:NULL
+               isDevSignedCallback:^BOOL(MOLCertificate *leafCertificate) {
+                 NSArray *keys = @[ @"1.2.840.113635.100.6.1.2", @"1.2.840.113635.100.6.1.12" ];
+                 NSDictionary *vals = CFBridgingRelease(SecCertificateCopyValues(
+                   leafCertificate.certRef, (__bridge CFArrayRef)keys, NULL));
+                 return vals.count > 0;
+               }
         entitlementsFilterCallback:nil];
 }
 


### PR DESCRIPTION
In order for TID/SID rules to apply to execs, the binary must not be signed with a development cert.

This cleans up the experiment added in #1238 