### PR TITLE
Bump to C++20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,9 +7,9 @@ build --copt=-Wno-error=deprecated-declarations
 # isn't recognized on older SDKs
 build --copt=-Wno-unknown-warning-option
 build --copt=-Wno-error=deprecated-non-prototype
-build --per_file_copt=.*\.mm\$@-std=c++17
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+build --per_file_copt=.*\.mm\$@-std=c++20
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
 
 build --copt=-DSANTA_OPEN_SOURCE=1
 build --cxxopt=-DSANTA_OPEN_SOURCE=1


### PR DESCRIPTION
Move to C++20 for at-desk builds. The released binaries are already built with C++20.