### PR TITLE
Revert back to C++17 for now

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,9 +7,9 @@ build --copt=-Wno-error=deprecated-declarations
 # isn't recognized on older SDKs
 build --copt=-Wno-unknown-warning-option
 build --copt=-Wno-error=deprecated-non-prototype
-build --per_file_copt=.*\.mm\$@-std=c++20
-build --cxxopt=-std=c++20
-build --host_cxxopt=-std=c++20
+build --per_file_copt=.*\.mm\$@-std=c++17
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 
 build --copt=-DSANTA_OPEN_SOURCE=1
 build --cxxopt=-DSANTA_OPEN_SOURCE=1

--- a/Source/common/SantaCacheTest.mm
+++ b/Source/common/SantaCacheTest.mm
@@ -14,7 +14,6 @@
 
 #import <XCTest/XCTest.h>
 
-#include <compare>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -246,7 +245,9 @@ struct S {
   uint64_t first_val;
   uint64_t second_val;
 
-  auto operator<=>(const S &rhs) const = default;
+  bool operator==(const S &rhs) const {
+    return first_val == rhs.first_val && second_val == rhs.second_val;
+  }
 };
 template <>
 uint64_t SantaCacheHasher<S>(S const &s) {


### PR DESCRIPTION
Due to internal reasons, we need to continue on C++17 for now.