### PR TITLE
reorder e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,23 +23,23 @@ jobs:
         run: echo "/opt/homebrew/bin/" >> $GITHUB_PATH
       - name: Install configuration profile
         run: bazel run //Testing/integration:install_profile -- Testing/integration/configs/default.mobileconfig
+      - name: Build, install, and sync santa
+        run: |
+          bazel run :reload --define=SANTA_BUILD_TYPE=adhoc
+          bazel run //Testing/integration:allow_sysex
+      - name: Test config changes
+        run: ./Testing/integration/test_config_changes.sh
       - name: Build, install, and start moroz
         run: |
           bazel build @com_github_groob_moroz//cmd/moroz:moroz
           cp bazel-bin/external/com_github_groob_moroz/cmd/moroz/moroz_/moroz /tmp/moroz
           /tmp/moroz -configs="$GITHUB_WORKSPACE/Testing/integration/configs/moroz_default/global.toml" -use-tls=false &
-      - name: Build, install, and sync santa
-        run: |
-          bazel run :reload --define=SANTA_BUILD_TYPE=adhoc
-          bazel run //Testing/integration:allow_sysex
           sudo santactl sync --debug
       - name: Run integration test binaries
         run: |
           bazel test //Testing/integration:integration_tests
           sleep 3
           bazel run //Testing/integration:dismiss_santa_popup || true
-      - name: Test config changes
-        run: ./Testing/integration/test_config_changes.sh
       - name: Test sync server changes
         run: ./Testing/integration/test_sync_changes.sh
       - name: Test USB blocking

--- a/Testing/integration/test_config_changes.sh
+++ b/Testing/integration/test_config_changes.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -x
 
-# TODO(nickmg): These `santactl status`s should be run with sudo to mirror the others,
-# however currently (2022-10-27) non-root status is what correctly reads from provisioning profile configuration.
-
 bazel run //Testing/integration:install_profile -- Testing/integration/configs/default.mobileconfig
 if [[ "$(santactl status --json | jq .daemon.block_usb)" != "false" ]]; then
   echo "USB blocking enabled with minimal config" >&2


### PR DESCRIPTION
Reorder "provisioning profile only" tests to run before the sync server is started. With #1217 fixed, `santactl` gets the proper sync server usb block state which was causing these tests to fail.