### PR TITLE
Revert "Project: Remove provisioning_profiles attributes from command-line to…"

### DIFF
--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -35,6 +35,10 @@ macos_command_line_application(
     ],
     infoplists = ["Info.plist"],
     minimum_os_version = "11.0",
+    provisioning_profile = select({
+        "//:adhoc_build": None,
+        "//conditions:default": "//profiles:santa_dev",
+    }),
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":santabs_lib"],

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -92,6 +92,10 @@ macos_command_line_application(
     ],
     infoplists = ["Info.plist"],
     minimum_os_version = "11.0",
+    provisioning_profile = select({
+        "//:adhoc_build": None,
+        "//conditions:default": "//profiles:santa_dev",
+    }),
     version = "//:version",
     deps = [":santactl_lib"],
 )

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -66,6 +66,10 @@ macos_command_line_application(
     ],
     infoplists = ["Info.plist"],
     minimum_os_version = "11.0",
+    provisioning_profile = select({
+        "//:adhoc_build": None,
+        "//conditions:default": "//profiles:santa_dev",
+    }),
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -168,6 +168,10 @@ macos_command_line_application(
     ],
     infoplists = ["Info.plist"],
     minimum_os_version = "11.0",
+    provisioning_profile = select({
+        "//:adhoc_build": None,
+        "//conditions:default": "//profiles:santa_dev",
+    }),
     version = "//:version",
     visibility = ["//:santa_package_group"],
     deps = [":santass_lib"],


### PR DESCRIPTION
Reverts google/santa#1247

We need to keep this in for at desk builds until the next release of `rules_apple`