### PR TITLE
Fix issue with drop count calculations

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -683,7 +683,6 @@ objc_library(
     hdrs = ["Metrics.h"],
     deps = [
         ":SNTApplicationCoreMetrics",
-        "//Source/common:BranchPrediction",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -96,7 +96,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
 
  private:
   struct SequenceStats {
-    uint64_t seq_num = 0;
+    uint64_t next_seq_num = 0;
     int64_t drops = 0;
   };
 


### PR DESCRIPTION
The previous method had an issue where state wasn't properly carried over when values were flushed after metrics collection.