### PR TITLE
Add back support for EnableForkAndExitLogging config key

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -134,6 +134,13 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
 
   [self.compilerController handleEvent:esMsg withLogger:self->_logger];
 
+  if ((esMsg->event_type == ES_EVENT_TYPE_NOTIFY_FORK ||
+       esMsg->event_type == ES_EVENT_TYPE_NOTIFY_EXIT) &&
+      self.configurator.enableForkAndExitLogging == NO) {
+    recordEventMetrics(EventDisposition::kDropped);
+    return;
+  }
+
   // Filter file op events matching the prefix tree.
   es_file_t *targetFile = GetTargetFileForPrefixTree(&(*esMsg));
   if (targetFile != NULL && self->_prefixTree->HasPrefix(targetFile->path.data)) {


### PR DESCRIPTION
This PR adds back support for this configuration key that was inadvertently removed in v2022.9.

The default value is meant to be `false`. However since v2022.9, this value has effectively been hardcoded to `true`. This change fixes the logic back to the original intention.

**IMPORTANT: This means that if you want `FORK`/`EXIT` events to continue to be logged, you must set the `EnableForkAndExitLogging` config key to `true`**

Fixes #1269 