### PR TITLE
Refactor rule and count lookups

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -313,6 +313,12 @@ santa_unit_test(
 )
 
 objc_library(
+    name = "SNTRuleIdentifiers",
+    srcs = ["SNTRuleIdentifiers.m"],
+    hdrs = ["SNTRuleIdentifiers.h"],
+)
+
+objc_library(
     name = "SNTStoredEvent",
     srcs = ["SNTStoredEvent.m"],
     hdrs = ["SNTStoredEvent.h"],
@@ -377,6 +383,7 @@ objc_library(
         ":SNTCommonEnums",
         ":SNTConfigurator",
         ":SNTRule",
+        ":SNTRuleIdentifiers",
         ":SNTStoredEvent",
         ":SNTXPCUnprivilegedControlInterface",
         "@MOLCodesignChecker",

--- a/Source/common/SNTRuleIdentifiers.h
+++ b/Source/common/SNTRuleIdentifiers.h
@@ -1,4 +1,4 @@
-/// Copyright 2022 Google LLC
+/// Copyright 2024 Google LLC
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -33,8 +33,17 @@ struct RuleIdentifiers {
 };
 
 @interface SNTRuleIdentifiers : NSObject
-@property NSString *binarySHA256;
-@property NSString *signingID;
-@property NSString *certificateSHA256;
-@property NSString *teamID;
+@property(readonly) NSString *binarySHA256;
+@property(readonly) NSString *signingID;
+@property(readonly) NSString *certificateSHA256;
+@property(readonly) NSString *teamID;
+
+/// Please use `initWithRuleIdentifiers:`
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithRuleIdentifiers:(struct RuleIdentifiers)identifiers
+  NS_DESIGNATED_INITIALIZER;
+
+- (struct RuleIdentifiers)toStruct;
+
 @end

--- a/Source/common/SNTRuleIdentifiers.h
+++ b/Source/common/SNTRuleIdentifiers.h
@@ -1,0 +1,40 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+/**
+ * This file declares two types that are mirrors of each other.
+ *
+ * The C struct serves as a way to group and pass valid rule identifiers around
+ * in order to minimize interface changes needed when new rule types are added
+ * and also alleviate the need to allocate a short lived object.
+ *
+ * The Objective C class is used for an XPC boundary to easily pass rule
+ * identifiers between Santa components.
+ */
+
+#import <Foundation/Foundation.h>
+
+struct RuleIdentifiers {
+  NSString *binarySHA256;
+  NSString *signingID;
+  NSString *certificateSHA256;
+  NSString *teamID;
+};
+
+@interface SNTRuleIdentifiers : NSObject
+@property NSString *binarySHA256;
+@property NSString *signingID;
+@property NSString *certificateSHA256;
+@property NSString *teamID;
+@end

--- a/Source/common/SNTRuleIdentifiers.m
+++ b/Source/common/SNTRuleIdentifiers.m
@@ -1,4 +1,4 @@
-/// Copyright 2022 Google LLC
+/// Copyright 2024 Google LLC
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -15,4 +15,23 @@
 #import "Source/common/SNTRuleIdentifiers.h"
 
 @implementation SNTRuleIdentifiers
+
+- (instancetype)initWithRuleIdentifiers:(struct RuleIdentifiers)identifiers {
+  self = [super init];
+  if (self) {
+    _binarySHA256 = identifiers.binarySHA256;
+    _signingID = identifiers.signingID;
+    _certificateSHA256 = identifiers.certificateSHA256;
+    _teamID = identifiers.teamID;
+  }
+  return self;
+}
+
+- (struct RuleIdentifiers)toStruct {
+  return (struct RuleIdentifiers){.binarySHA256 = self.binarySHA256,
+                                  .signingID = self.signingID,
+                                  .certificateSHA256 = self.certificateSHA256,
+                                  .teamID = self.teamID};
+}
+
 @end

--- a/Source/common/SNTRuleIdentifiers.m
+++ b/Source/common/SNTRuleIdentifiers.m
@@ -1,0 +1,18 @@
+/// Copyright 2022 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTRuleIdentifiers.h"
+
+@implementation SNTRuleIdentifiers
+@end

--- a/Source/common/SNTXPCControlInterface.h
+++ b/Source/common/SNTXPCControlInterface.h
@@ -12,6 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
+#import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCUnprivilegedControlInterface.h"
 
 ///
@@ -32,11 +33,8 @@
                        reply:(void (^)(NSError *error))reply;
 - (void)databaseEventsPending:(void (^)(NSArray *events))reply;
 - (void)databaseRemoveEventsWithIDs:(NSArray *)ids;
-- (void)databaseRuleForBinarySHA256:(NSString *)binarySHA256
-                  certificateSHA256:(NSString *)certificateSHA256
-                             teamID:(NSString *)teamID
-                          signingID:(NSString *)signingID
-                              reply:(void (^)(SNTRule *))reply;
+- (void)databaseRuleForIdentifiers:(SNTRuleIdentifiers *)identifiers
+                             reply:(void (^)(SNTRule *))reply;
 - (void)retrieveAllRules:(void (^)(NSArray<SNTRule *> *rules, NSError *error))reply;
 
 ///

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -23,12 +23,12 @@
 @class MOLXPCConnection;
 
 struct RuleCounts {
-  NSUInteger binary;
-  NSUInteger certificate;
-  NSUInteger compiler;
-  NSUInteger transitive;
-  NSUInteger teamID;
-  NSUInteger signingID;
+  int64_t binary;
+  int64_t certificate;
+  int64_t compiler;
+  int64_t transitive;
+  int64_t teamID;
+  int64_t signingID;
 };
 
 ///
@@ -46,7 +46,7 @@ struct RuleCounts {
 ///  Database ops
 ///
 - (void)databaseRuleCounts:(void (^)(struct RuleCounts ruleCounts))reply;
-- (void)databaseEventCount:(void (^)(NSUInteger count))reply;
+- (void)databaseEventCount:(void (^)(int64_t count))reply;
 - (void)staticRuleCount:(void (^)(int64_t count))reply;
 
 ///

--- a/Source/common/SNTXPCUnprivilegedControlInterface.h
+++ b/Source/common/SNTXPCUnprivilegedControlInterface.h
@@ -22,6 +22,15 @@
 @class SNTStoredEvent;
 @class MOLXPCConnection;
 
+struct RuleCounts {
+  NSUInteger binary;
+  NSUInteger certificate;
+  NSUInteger compiler;
+  NSUInteger transitive;
+  NSUInteger teamID;
+  NSUInteger signingID;
+};
+
 ///
 ///  Protocol implemented by santad and utilized by santactl (unprivileged operations)
 ///
@@ -36,9 +45,8 @@
 ///
 ///  Database ops
 ///
-- (void)databaseRuleCounts:(void (^)(int64_t binary, int64_t certificate, int64_t compiler,
-                                     int64_t transitive, int64_t teamID, int64_t signingID))reply;
-- (void)databaseEventCount:(void (^)(int64_t count))reply;
+- (void)databaseRuleCounts:(void (^)(struct RuleCounts ruleCounts))reply;
+- (void)databaseEventCount:(void (^)(NSUInteger count))reply;
 - (void)staticRuleCount:(void (^)(int64_t count))reply;
 
 ///

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -68,6 +68,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTStrengthify",
         "//Source/common:SNTSystemInfo",

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -22,6 +22,7 @@
 #import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTRule.h"
+#import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/common/SNTXPCControlInterface.h"
 #import "Source/santactl/Commands/SNTCommandRule.h"
 #import "Source/santactl/SNTCommand.h"
@@ -365,20 +366,19 @@ REGISTER_COMMAND_NAME(@"rule")
 
 - (void)printStateOfRule:(SNTRule *)rule daemonConnection:(MOLXPCConnection *)daemonConn {
   id<SNTDaemonControlXPC> rop = [daemonConn synchronousRemoteObjectProxy];
-  NSString *fileSHA256 = (rule.type == SNTRuleTypeBinary) ? rule.identifier : nil;
-  NSString *certificateSHA256 = (rule.type == SNTRuleTypeCertificate) ? rule.identifier : nil;
-  NSString *teamID = (rule.type == SNTRuleTypeTeamID) ? rule.identifier : nil;
-  NSString *signingID = (rule.type == SNTRuleTypeSigningID) ? rule.identifier : nil;
   __block NSString *output;
 
-  [rop databaseRuleForBinarySHA256:fileSHA256
-                 certificateSHA256:certificateSHA256
-                            teamID:teamID
-                         signingID:signingID
-                             reply:^(SNTRule *r) {
-                               output = [SNTCommandRule stringifyRule:r
-                                                            withColor:(isatty(STDOUT_FILENO) == 1)];
-                             }];
+  SNTRuleIdentifiers *identifiers = [[SNTRuleIdentifiers alloc] init];
+  identifiers.binarySHA256 = (rule.type == SNTRuleTypeBinary) ? rule.identifier : nil;
+  identifiers.certificateSHA256 = (rule.type == SNTRuleTypeCertificate) ? rule.identifier : nil;
+  identifiers.teamID = (rule.type == SNTRuleTypeTeamID) ? rule.identifier : nil;
+  identifiers.signingID = (rule.type == SNTRuleTypeSigningID) ? rule.identifier : nil;
+
+  [rop databaseRuleForIdentifiers:identifiers
+                            reply:^(SNTRule *r) {
+                              output = [SNTCommandRule stringifyRule:r
+                                                           withColor:(isatty(STDOUT_FILENO) == 1)];
+                            }];
 
   printf("%s\n", output.UTF8String);
   exit(0);

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -368,13 +368,14 @@ REGISTER_COMMAND_NAME(@"rule")
   id<SNTDaemonControlXPC> rop = [daemonConn synchronousRemoteObjectProxy];
   __block NSString *output;
 
-  SNTRuleIdentifiers *identifiers = [[SNTRuleIdentifiers alloc] init];
-  identifiers.binarySHA256 = (rule.type == SNTRuleTypeBinary) ? rule.identifier : nil;
-  identifiers.certificateSHA256 = (rule.type == SNTRuleTypeCertificate) ? rule.identifier : nil;
-  identifiers.teamID = (rule.type == SNTRuleTypeTeamID) ? rule.identifier : nil;
-  identifiers.signingID = (rule.type == SNTRuleTypeSigningID) ? rule.identifier : nil;
+  struct RuleIdentifiers identifiers = {
+    .binarySHA256 = (rule.type == SNTRuleTypeBinary) ? rule.identifier : nil,
+    .certificateSHA256 = (rule.type == SNTRuleTypeCertificate) ? rule.identifier : nil,
+    .teamID = (rule.type == SNTRuleTypeTeamID) ? rule.identifier : nil,
+    .signingID = (rule.type == SNTRuleTypeSigningID) ? rule.identifier : nil,
+  };
 
-  [rop databaseRuleForIdentifiers:identifiers
+  [rop databaseRuleForIdentifiers:[[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:identifiers]
                             reply:^(SNTRule *r) {
                               output = [SNTCommandRule stringifyRule:r
                                                            withColor:(isatty(STDOUT_FILENO) == 1)];

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -91,23 +91,14 @@ REGISTER_COMMAND_NAME(@"status")
   }];
 
   // Database counts
-  __block int64_t eventCount = -1;
-  __block int64_t binaryRuleCount = -1;
-  __block int64_t certRuleCount = -1;
-  __block int64_t teamIDRuleCount = -1;
-  __block int64_t signingIDRuleCount = -1;
-  __block int64_t compilerRuleCount = -1;
-  __block int64_t transitiveRuleCount = -1;
-  [rop databaseRuleCounts:^(int64_t binary, int64_t certificate, int64_t compiler,
-                            int64_t transitive, int64_t teamID, int64_t signingID) {
-    binaryRuleCount = binary;
-    certRuleCount = certificate;
-    teamIDRuleCount = teamID;
-    signingIDRuleCount = signingID;
-    compilerRuleCount = compiler;
-    transitiveRuleCount = transitive;
+  __block struct RuleCounts ruleCounts;
+  memset(&ruleCounts, NSUIntegerMax, sizeof(ruleCounts));
+  [rop databaseRuleCounts:^(struct RuleCounts counts) {
+    ruleCounts = counts;
   }];
-  [rop databaseEventCount:^(int64_t count) {
+
+  __block NSUInteger eventCount = NSUIntegerMax;
+  [rop databaseEventCount:^(NSUInteger count) {
     eventCount = count;
   }];
 
@@ -212,12 +203,12 @@ REGISTER_COMMAND_NAME(@"status")
         @"on_start_usb_options" : StartupOptionToString(configurator.onStartUSBOptions),
       },
       @"database" : @{
-        @"binary_rules" : @(binaryRuleCount),
-        @"certificate_rules" : @(certRuleCount),
-        @"teamid_rules" : @(teamIDRuleCount),
-        @"signingid_rules" : @(signingIDRuleCount),
-        @"compiler_rules" : @(compilerRuleCount),
-        @"transitive_rules" : @(transitiveRuleCount),
+        @"binary_rules" : @(ruleCounts.binary),
+        @"certificate_rules" : @(ruleCounts.certificate),
+        @"teamid_rules" : @(ruleCounts.teamID),
+        @"signingid_rules" : @(ruleCounts.signingID),
+        @"compiler_rules" : @(ruleCounts.compiler),
+        @"transitive_rules" : @(ruleCounts.transitive),
         @"events_pending_upload" : @(eventCount),
       },
       @"static_rules" : @{
@@ -284,13 +275,13 @@ REGISTER_COMMAND_NAME(@"status")
     printf("  %-25s | %lld\n", "Non-root cache count", nonRootCacheCount);
 
     printf(">>> Database Info\n");
-    printf("  %-25s | %lld\n", "Binary Rules", binaryRuleCount);
-    printf("  %-25s | %lld\n", "Certificate Rules", certRuleCount);
-    printf("  %-25s | %lld\n", "TeamID Rules", teamIDRuleCount);
-    printf("  %-25s | %lld\n", "SigningID Rules", signingIDRuleCount);
-    printf("  %-25s | %lld\n", "Compiler Rules", compilerRuleCount);
-    printf("  %-25s | %lld\n", "Transitive Rules", transitiveRuleCount);
-    printf("  %-25s | %lld\n", "Events Pending Upload", eventCount);
+    printf("  %-25s | %lu\n", "Binary Rules", ruleCounts.binary);
+    printf("  %-25s | %lu\n", "Certificate Rules", ruleCounts.certificate);
+    printf("  %-25s | %lu\n", "TeamID Rules", ruleCounts.teamID);
+    printf("  %-25s | %lu\n", "SigningID Rules", ruleCounts.signingID);
+    printf("  %-25s | %lu\n", "Compiler Rules", ruleCounts.compiler);
+    printf("  %-25s | %lu\n", "Transitive Rules", ruleCounts.transitive);
+    printf("  %-25s | %lu\n", "Events Pending Upload", eventCount);
 
     if ([SNTConfigurator configurator].staticRules.count) {
       printf(">>> Static Rules\n");

--- a/Source/santactl/Commands/SNTCommandStatus.m
+++ b/Source/santactl/Commands/SNTCommandStatus.m
@@ -91,14 +91,20 @@ REGISTER_COMMAND_NAME(@"status")
   }];
 
   // Database counts
-  __block struct RuleCounts ruleCounts;
-  memset(&ruleCounts, NSUIntegerMax, sizeof(ruleCounts));
+  __block struct RuleCounts ruleCounts = {
+    .binary = -1,
+    .certificate = -1,
+    .compiler = -1,
+    .transitive = -1,
+    .teamID = -1,
+    .signingID = -1,
+  };
   [rop databaseRuleCounts:^(struct RuleCounts counts) {
     ruleCounts = counts;
   }];
 
-  __block NSUInteger eventCount = NSUIntegerMax;
-  [rop databaseEventCount:^(NSUInteger count) {
+  __block int64_t eventCount = -1;
+  [rop databaseEventCount:^(int64_t count) {
     eventCount = count;
   }];
 
@@ -275,13 +281,13 @@ REGISTER_COMMAND_NAME(@"status")
     printf("  %-25s | %lld\n", "Non-root cache count", nonRootCacheCount);
 
     printf(">>> Database Info\n");
-    printf("  %-25s | %lu\n", "Binary Rules", ruleCounts.binary);
-    printf("  %-25s | %lu\n", "Certificate Rules", ruleCounts.certificate);
-    printf("  %-25s | %lu\n", "TeamID Rules", ruleCounts.teamID);
-    printf("  %-25s | %lu\n", "SigningID Rules", ruleCounts.signingID);
-    printf("  %-25s | %lu\n", "Compiler Rules", ruleCounts.compiler);
-    printf("  %-25s | %lu\n", "Transitive Rules", ruleCounts.transitive);
-    printf("  %-25s | %lu\n", "Events Pending Upload", eventCount);
+    printf("  %-25s | %lld\n", "Binary Rules", ruleCounts.binary);
+    printf("  %-25s | %lld\n", "Certificate Rules", ruleCounts.certificate);
+    printf("  %-25s | %lld\n", "TeamID Rules", ruleCounts.teamID);
+    printf("  %-25s | %lld\n", "SigningID Rules", ruleCounts.signingID);
+    printf("  %-25s | %lld\n", "Compiler Rules", ruleCounts.compiler);
+    printf("  %-25s | %lld\n", "Transitive Rules", ruleCounts.transitive);
+    printf("  %-25s | %lld\n", "Events Pending Upload", eventCount);
 
     if ([SNTConfigurator configurator].staticRules.count) {
       printf(">>> Static Rules\n");

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -33,6 +33,7 @@ objc_library(
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
         "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
         "@MOLCertificate",
         "@MOLCodesignChecker",
     ],
@@ -192,13 +193,10 @@ objc_library(
 
 objc_library(
     name = "SNTPolicyProcessor",
-    srcs = [
-        "DataLayer/SNTDatabaseTable.h",
-        "DataLayer/SNTRuleTable.h",
-        "SNTPolicyProcessor.m",
-    ],
+    srcs = ["SNTPolicyProcessor.m"],
     hdrs = ["SNTPolicyProcessor.h"],
     deps = [
+        ":SNTRuleTable",
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTConfigurator",
@@ -668,6 +666,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTStrengthify",
         "//Source/common:SNTXPCControlInterface",
@@ -877,6 +876,7 @@ santa_unit_test(
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTLogging",
         "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
         "@FMDB",
         "@MOLCertificate",
         "@MOLCodesignChecker",
@@ -1213,6 +1213,7 @@ santa_unit_test(
         "//Source/common:SNTFileInfo",
         "//Source/common:SNTMetricSet",
         "//Source/common:SNTRule",
+        "//Source/common:SNTRuleIdentifiers",
         "//Source/common:TestUtils",
         "@MOLCertificate",
         "@MOLCodesignChecker",

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -30,37 +30,37 @@
 ///
 ///  @return Number of rules in the database
 ///
-- (NSUInteger)ruleCount;
+- (int64_t)ruleCount;
 
 ///
 ///  @return Number of binary rules in the database
 ///
-- (NSUInteger)binaryRuleCount;
+- (int64_t)binaryRuleCount;
 
 ///
 ///  @return Number of compiler rules in the database
 ///
-- (NSUInteger)compilerRuleCount;
+- (int64_t)compilerRuleCount;
 
 ///
 ///  @return Number of transitive rules in the database
 ///
-- (NSUInteger)transitiveRuleCount;
+- (int64_t)transitiveRuleCount;
 
 ///
 ///  @return Number of certificate rules in the database
 ///
-- (NSUInteger)certificateRuleCount;
+- (int64_t)certificateRuleCount;
 
 ///
 /// @return Number of team ID rules in the database
 ///
-- (NSUInteger)teamIDRuleCount;
+- (int64_t)teamIDRuleCount;
 
 ///
 /// @return Number of signing ID rules in the database
 ///
-- (NSUInteger)signingIDRuleCount;
+- (int64_t)signingIDRuleCount;
 
 ///
 ///  @return Rule for given identifiers.

--- a/Source/santad/DataLayer/SNTRuleTable.h
+++ b/Source/santad/DataLayer/SNTRuleTable.h
@@ -15,6 +15,7 @@
 #import <Foundation/Foundation.h>
 
 #import "Source/common/SNTCommonEnums.h"
+#import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/santad/DataLayer/SNTDatabaseTable.h"
 
 @class SNTCachedDecision;
@@ -62,13 +63,11 @@
 - (NSUInteger)signingIDRuleCount;
 
 ///
-///  @return Rule for binary, signingID, certificate or teamID (in that order).
+///  @return Rule for given identifiers.
+///          Currently: binary, signingID, certificate or teamID (in that order).
 ///          The first matching rule found is returned.
 ///
-- (SNTRule *)ruleForBinarySHA256:(NSString *)binarySHA256
-                       signingID:(NSString *)signingID
-               certificateSHA256:(NSString *)certificateSHA256
-                          teamID:(NSString *)teamID;
+- (SNTRule *)ruleForIdentifiers:(struct RuleIdentifiers)identifiers;
 
 ///
 ///  Add an array of rules to the database. The rules will be added within a transaction and the

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -29,7 +29,7 @@ static const uint32_t kRuleTableCurrentVersion = 7;
 
 // TODO(nguyenphillip): this should be configurable.
 // How many rules must be in database before we start trying to remove transitive rules.
-static const NSUInteger kTransitiveRuleCullingThreshold = 500000;
+static const int64_t kTransitiveRuleCullingThreshold = 500000;
 // Consider transitive rules out of date if they haven't been used in six months.
 static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
 
@@ -263,7 +263,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
 
 #pragma mark Entry Counts
 
-- (NSUInteger)ruleCount {
+- (int64_t)ruleCount {
   __block NSUInteger count = 0;
   [self inDatabase:^(FMDatabase *db) {
     count = [db longForQuery:@"SELECT COUNT(*) FROM rules"];
@@ -271,23 +271,23 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
   return count;
 }
 
-- (NSUInteger)ruleCountForRuleType:(SNTRuleType)ruleType {
-  __block NSUInteger count = 0;
+- (int64_t)ruleCountForRuleType:(SNTRuleType)ruleType {
+  __block int64_t count = 0;
   [self inDatabase:^(FMDatabase *db) {
     count = [db longForQuery:@"SELECT COUNT(*) FROM rules WHERE type=?", @(ruleType)];
   }];
   return count;
 }
 
-- (NSUInteger)binaryRuleCount {
+- (int64_t)binaryRuleCount {
   return [self ruleCountForRuleType:SNTRuleTypeBinary];
 }
 
-- (NSUInteger)certificateRuleCount {
+- (int64_t)certificateRuleCount {
   return [self ruleCountForRuleType:SNTRuleTypeCertificate];
 }
 
-- (NSUInteger)compilerRuleCount {
+- (int64_t)compilerRuleCount {
   __block NSUInteger count = 0;
   [self inDatabase:^(FMDatabase *db) {
     count =
@@ -296,7 +296,7 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
   return count;
 }
 
-- (NSUInteger)transitiveRuleCount {
+- (int64_t)transitiveRuleCount {
   __block NSUInteger count = 0;
   [self inDatabase:^(FMDatabase *db) {
     count =
@@ -305,11 +305,11 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
   return count;
 }
 
-- (NSUInteger)teamIDRuleCount {
+- (int64_t)teamIDRuleCount {
   return [self ruleCountForRuleType:SNTRuleTypeTeamID];
 }
 
-- (NSUInteger)signingIDRuleCount {
+- (int64_t)signingIDRuleCount {
   return [self ruleCountForRuleType:SNTRuleTypeSigningID];
 }
 

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 
 #import "Source/common/SNTRule.h"
+#import "Source/common/SNTRuleIdentifiers.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 
 /// This test case actually tests SNTRuleTable and SNTRule
@@ -173,20 +174,20 @@
                error:nil];
 
   SNTRule *r = [self.sut
-    ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
-              signingID:nil
-      certificateSHA256:nil
-                 teamID:nil];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .binarySHA256 =
+                           @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+                       }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary);
 
   r = [self.sut
-    ruleForBinarySHA256:@"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2"
-              signingID:nil
-      certificateSHA256:nil
-                 teamID:nil];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .binarySHA256 =
+                           @"b6ee1c3c5a715c049d14a8457faa6b6701b8507efe908300e238e0768bd759c2",
+                       }];
   XCTAssertNil(r);
 }
 
@@ -196,20 +197,20 @@
                error:nil];
 
   SNTRule *r = [self.sut
-    ruleForBinarySHA256:nil
-              signingID:nil
-      certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
-                 teamID:nil];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .certificateSHA256 =
+                           @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+                       }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate);
 
   r = [self.sut
-    ruleForBinarySHA256:nil
-              signingID:nil
-      certificateSHA256:@"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77de2b95e051e2562"
-                 teamID:nil];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .certificateSHA256 =
+                           @"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77de2b95e051e2562",
+                       }];
   XCTAssertNil(r);
 }
 
@@ -218,19 +219,17 @@
          ruleCleanup:SNTRuleCleanupNone
                error:nil];
 
-  SNTRule *r = [self.sut ruleForBinarySHA256:nil
-                                   signingID:nil
-                           certificateSHA256:nil
-                                      teamID:@"ABCDEFGHIJ"];
+  SNTRule *r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                              .teamID = @"ABCDEFGHIJ",
+                                            }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID);
   XCTAssertEqual([self.sut teamIDRuleCount], 1);
 
-  r = [self.sut ruleForBinarySHA256:nil
-                          signingID:nil
-                  certificateSHA256:nil
-                             teamID:@"nonexistentTeamID"];
+  r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                     .teamID = @"nonexistentTeamID",
+                                   }];
   XCTAssertNil(r);
 }
 
@@ -244,24 +243,24 @@
 
   XCTAssertEqual([self.sut signingIDRuleCount], 2);
 
-  SNTRule *r = [self.sut ruleForBinarySHA256:nil
-                                   signingID:@"ABCDEFGHIJ:signingID"
-                           certificateSHA256:nil
-                                      teamID:nil];
+  SNTRule *r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                              .signingID = @"ABCDEFGHIJ:signingID",
+                                            }];
 
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ:signingID");
   XCTAssertEqual(r.type, SNTRuleTypeSigningID);
 
-  r = [self.sut ruleForBinarySHA256:nil
-                          signingID:@"platform:signingID"
-                  certificateSHA256:nil
-                             teamID:nil];
+  r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                     .signingID = @"platform:signingID",
+                                   }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"platform:signingID");
   XCTAssertEqual(r.type, SNTRuleTypeSigningID);
 
-  r = [self.sut ruleForBinarySHA256:nil signingID:@"nonexistent" certificateSHA256:nil teamID:nil];
+  r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                     .signingID = @"nonexistent",
+                                   }];
   XCTAssertNil(r);
 }
 
@@ -276,47 +275,63 @@
   // This test verifies that the implicit rule ordering we've been abusing is still working.
   // See the comment in SNTRuleTable#ruleForBinarySHA256:certificateSHA256:teamID
   SNTRule *r = [self.sut
-    ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
-              signingID:@"ABCDEFGHIJ:signingID"
-      certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
-                 teamID:@"ABCDEFGHIJ"];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .binarySHA256 =
+                           @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+                         .signingID = @"ABCDEFGHIJ:signingID",
+                         .certificateSHA256 =
+                           @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+                         .teamID = @"ABCDEFGHIJ",
+                       }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary, @"Implicit rule ordering failed");
 
   r = [self.sut
-    ruleForBinarySHA256:@"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670"
-              signingID:@"ABCDEFGHIJ:signingID"
-      certificateSHA256:@"unknowncert"
-                 teamID:@"ABCDEFGHIJ"];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .binarySHA256 =
+                           @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670",
+                         .signingID = @"ABCDEFGHIJ:signingID",
+                         .certificateSHA256 = @"unknown",
+                         .teamID = @"ABCDEFGHIJ",
+                       }];
+
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"b7c1e3fd640c5f211c89b02c2c6122f78ce322aa5c56eb0bb54bc422a8f8b670");
   XCTAssertEqual(r.type, SNTRuleTypeBinary, @"Implicit rule ordering failed");
 
   r = [self.sut
-    ruleForBinarySHA256:@"unknown"
-              signingID:@"unknown"
-      certificateSHA256:@"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258"
-                 teamID:@"ABCDEFGHIJ"];
+    ruleForIdentifiers:(struct RuleIdentifiers){
+                         .binarySHA256 = @"unknown",
+                         .signingID = @"unknown",
+                         .certificateSHA256 =
+                           @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258",
+                         .teamID = @"ABCDEFGHIJ",
+                       }];
+
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier,
                         @"7ae80b9ab38af0c63a9a81765f434d9a7cd8f720eb6037ef303de39d779bc258");
   XCTAssertEqual(r.type, SNTRuleTypeCertificate, @"Implicit rule ordering failed");
 
-  r = [self.sut ruleForBinarySHA256:@"unknown"
-                          signingID:@"ABCDEFGHIJ:signingID"
-                  certificateSHA256:@"unknown"
-                             teamID:@"ABCDEFGHIJ"];
+  r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                     .binarySHA256 = @"unknown",
+                                     .signingID = @"ABCDEFGHIJ:signingID",
+                                     .certificateSHA256 = @"unknown",
+                                     .teamID = @"ABCDEFGHIJ",
+                                   }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ:signingID");
   XCTAssertEqual(r.type, SNTRuleTypeSigningID, @"Implicit rule ordering failed (SigningID)");
 
-  r = [self.sut ruleForBinarySHA256:@"unknown"
-                          signingID:@"unknown"
-                  certificateSHA256:@"unknown"
-                             teamID:@"ABCDEFGHIJ"];
+  r = [self.sut ruleForIdentifiers:(struct RuleIdentifiers){
+                                     .binarySHA256 = @"unknown",
+                                     .signingID = @"unknown",
+                                     .certificateSHA256 = @"unknown",
+                                     .teamID = @"ABCDEFGHIJ",
+                                   }];
   XCTAssertNotNil(r);
   XCTAssertEqualObjects(r.identifier, @"ABCDEFGHIJ");
   XCTAssertEqual(r.type, SNTRuleTypeTeamID, @"Implicit rule ordering failed (TeamID)");

--- a/Source/santad/SNTCompilerController.mm
+++ b/Source/santad/SNTCompilerController.mm
@@ -145,10 +145,9 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
     // Check if there is an existing (non-transitive) rule for this file.  We leave existing rules
     // alone, so that a allowlist or blocklist rule can't be overwritten by a transitive one.
     SNTRuleTable *ruleTable = [SNTDatabaseController ruleTable];
-    SNTRule *prevRule = [ruleTable ruleForBinarySHA256:fi.SHA256
-                                             signingID:nil
-                                     certificateSHA256:nil
-                                                teamID:nil];
+    SNTRule *prevRule = [ruleTable ruleForIdentifiers:(struct RuleIdentifiers){
+                                                        .binarySHA256 = fi.SHA256,
+                                                      }];
     if (!prevRule || prevRule.state == SNTRuleStateAllowTransitive) {
       // Construct a new transitive allowlist rule for the executable.
       SNTRule *rule = [[SNTRule alloc] initWithIdentifier:fi.SHA256

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -138,7 +138,7 @@ double watchdogRAMPeak = 0;
   reply(error);
 }
 
-- (void)databaseEventCount:(void (^)(NSUInteger count))reply {
+- (void)databaseEventCount:(void (^)(int64_t count))reply {
   reply([[SNTDatabaseController eventTable] pendingEventsCount]);
 }
 
@@ -152,11 +152,7 @@ double watchdogRAMPeak = 0;
 
 - (void)databaseRuleForIdentifiers:(SNTRuleIdentifiers *)identifiers
                              reply:(void (^)(SNTRule *))reply {
-  reply([[SNTDatabaseController ruleTable]
-    ruleForIdentifiers:(struct RuleIdentifiers){.binarySHA256 = identifiers.binarySHA256,
-                                                .signingID = identifiers.signingID,
-                                                .certificateSHA256 = identifiers.certificateSHA256,
-                                                .teamID = identifiers.teamID}]);
+  reply([[SNTDatabaseController ruleTable] ruleForIdentifiers:[identifiers toStruct]]);
 }
 
 - (void)staticRuleCount:(void (^)(int64_t count))reply {

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -127,10 +127,11 @@
     cd.signingID = nil;
   }
 
-  SNTRule *rule = [self.ruleTable ruleForBinarySHA256:cd.sha256
-                                            signingID:cd.signingID
-                                    certificateSHA256:cd.certSHA256
-                                               teamID:cd.teamID];
+  SNTRule *rule =
+    [self.ruleTable ruleForIdentifiers:(struct RuleIdentifiers){.binarySHA256 = cd.sha256,
+                                                                .signingID = cd.signingID,
+                                                                .certificateSHA256 = cd.certSHA256,
+                                                                .teamID = cd.teamID}];
   if (rule) {
     switch (rule.type) {
       case SNTRuleTypeBinary:

--- a/Source/santasyncservice/SNTSyncPreflight.m
+++ b/Source/santasyncservice/SNTSyncPreflight.m
@@ -88,8 +88,6 @@ The following table expands upon the above logic to list most of the permutation
 
   id<SNTDaemonControlXPC> rop = [self.daemonConn synchronousRemoteObjectProxy];
 
-  // dispatch_group_t group = dispatch_group_create();
-  // dispatch_group_enter(group);
   [rop databaseRuleCounts:^(struct RuleCounts counts) {
     requestDict[kBinaryRuleCount] = @(counts.binary);
     requestDict[kCertificateRuleCount] = @(counts.certificate);

--- a/Source/santasyncservice/SNTSyncPreflight.m
+++ b/Source/santasyncservice/SNTSyncPreflight.m
@@ -90,14 +90,13 @@ The following table expands upon the above logic to list most of the permutation
 
   // dispatch_group_t group = dispatch_group_create();
   // dispatch_group_enter(group);
-  [rop databaseRuleCounts:^(int64_t binary, int64_t certificate, int64_t compiler,
-                            int64_t transitive, int64_t teamID, int64_t signingID) {
-    requestDict[kBinaryRuleCount] = @(binary);
-    requestDict[kCertificateRuleCount] = @(certificate);
-    requestDict[kCompilerRuleCount] = @(compiler);
-    requestDict[kTransitiveRuleCount] = @(transitive);
-    requestDict[kTeamIDRuleCount] = @(teamID);
-    requestDict[kSigningIDRuleCount] = @(signingID);
+  [rop databaseRuleCounts:^(struct RuleCounts counts) {
+    requestDict[kBinaryRuleCount] = @(counts.binary);
+    requestDict[kCertificateRuleCount] = @(counts.certificate);
+    requestDict[kCompilerRuleCount] = @(counts.compiler);
+    requestDict[kTransitiveRuleCount] = @(counts.transitive);
+    requestDict[kTeamIDRuleCount] = @(counts.teamID);
+    requestDict[kSigningIDRuleCount] = @(counts.signingID);
   }];
 
   [rop clientMode:^(SNTClientMode cm) {

--- a/Source/santasyncservice/SNTSyncTest.m
+++ b/Source/santasyncservice/SNTSyncTest.m
@@ -147,14 +147,9 @@
 }
 
 - (void)setupDefaultDaemonConnResponses {
+  struct RuleCounts ruleCounts = {0};
   OCMStub([self.daemonConnRop
-    databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(0),  // binary
-                                                    OCMOCK_VALUE(0),  // cert
-                                                    OCMOCK_VALUE(0),  // compiler
-                                                    OCMOCK_VALUE(0),  // transitive
-                                                    OCMOCK_VALUE(0),  // teamID
-                                                    OCMOCK_VALUE(0),  // signingID
-                                                    nil])]);
+    databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(ruleCounts), nil])]);
   OCMStub([self.daemonConnRop
     syncTypeRequired:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(SNTSyncTypeNormal), nil])]);
   OCMStub([self.daemonConnRop
@@ -350,29 +345,29 @@
 - (void)testPreflightDatabaseCounts {
   SNTSyncPreflight *sut = [[SNTSyncPreflight alloc] initWithState:self.syncState];
 
-  int64_t bin = 5;
-  int64_t cert = 8;
-  int64_t compiler = 2;
-  int64_t transitive = 19;
-  int64_t teamID = 3;
-  int64_t signingID = 123;
+  struct RuleCounts ruleCounts = {
+    .binary = 5,
+    .certificate = 8,
+    .compiler = 2,
+    .transitive = 19,
+    .teamID = 3,
+    .signingID = 123,
+  };
+
   OCMStub([self.daemonConnRop
-    databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(bin), OCMOCK_VALUE(cert),
-                                                    OCMOCK_VALUE(compiler),
-                                                    OCMOCK_VALUE(transitive), OCMOCK_VALUE(teamID),
-                                                    OCMOCK_VALUE(signingID), nil])]);
+    databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(ruleCounts), nil])]);
 
   [self stubRequestBody:nil
                response:nil
                   error:nil
           validateBlock:^BOOL(NSURLRequest *req) {
             NSDictionary *requestDict = [self dictFromRequest:req];
-            XCTAssertEqualObjects(requestDict[kBinaryRuleCount], @(5));
-            XCTAssertEqualObjects(requestDict[kCertificateRuleCount], @(8));
-            XCTAssertEqualObjects(requestDict[kCompilerRuleCount], @(2));
-            XCTAssertEqualObjects(requestDict[kTransitiveRuleCount], @(19));
-            XCTAssertEqualObjects(requestDict[kTeamIDRuleCount], @(3));
-            XCTAssertEqualObjects(requestDict[kSigningIDRuleCount], @(123));
+            XCTAssertEqualObjects(requestDict[kBinaryRuleCount], @(ruleCounts.binary));
+            XCTAssertEqualObjects(requestDict[kCertificateRuleCount], @(ruleCounts.certificate));
+            XCTAssertEqualObjects(requestDict[kCompilerRuleCount], @(ruleCounts.compiler));
+            XCTAssertEqualObjects(requestDict[kTransitiveRuleCount], @(ruleCounts.transitive));
+            XCTAssertEqualObjects(requestDict[kTeamIDRuleCount], @(ruleCounts.teamID));
+            XCTAssertEqualObjects(requestDict[kSigningIDRuleCount], @(ruleCounts.signingID));
             return YES;
           }];
 
@@ -387,14 +382,9 @@
                                   response:(NSDictionary *)resp {
   SNTSyncPreflight *sut = [[SNTSyncPreflight alloc] initWithState:self.syncState];
 
+  struct RuleCounts ruleCounts = {0};
   OCMStub([self.daemonConnRop
-    databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(0),  // binary
-                                                    OCMOCK_VALUE(0),  // cert
-                                                    OCMOCK_VALUE(0),  // compiler
-                                                    OCMOCK_VALUE(0),  // transitive
-                                                    OCMOCK_VALUE(0),  // teamID
-                                                    OCMOCK_VALUE(0),  // signingID
-                                                    nil])]);
+    databaseRuleCounts:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(ruleCounts), nil])]);
   OCMStub([self.daemonConnRop
     clientMode:([OCMArg invokeBlockWithArgs:OCMOCK_VALUE(SNTClientModeMonitor), nil])]);
   OCMStub([self.daemonConnRop


### PR DESCRIPTION
This change streamlines rule lookups and rule count lookups. The goal is to make it easier to add supported rule types by reducing the number of interface changes required.

This PR is not intended to introduce/change any functionality.