### PR TITLE
Creating transitive rules for rename events should fallback to destination path

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -263,6 +263,7 @@ objc_library(
     hdrs = ["SNTFileInfo.h"],
     deps = [
         ":SNTLogging",
+        ":SantaVnode",
         "@FMDB",
         "@MOLCodesignChecker",
     ],

--- a/Source/common/SNTCachedDecision.h
+++ b/Source/common/SNTCachedDecision.h
@@ -25,7 +25,9 @@
 ///
 @interface SNTCachedDecision : NSObject
 
+- (instancetype)init;
 - (instancetype)initWithEndpointSecurityFile:(const es_file_t *)esFile;
+- (instancetype)initWithVnode:(SantaVnode)vnode NS_DESIGNATED_INITIALIZER;
 
 @property SantaVnode vnodeId;
 @property SNTEventState decision;

--- a/Source/common/SNTCachedDecision.mm
+++ b/Source/common/SNTCachedDecision.mm
@@ -17,10 +17,18 @@
 
 @implementation SNTCachedDecision
 
+- (instancetype)init {
+  return [self initWithVnode:(SantaVnode){}];
+}
+
 - (instancetype)initWithEndpointSecurityFile:(const es_file_t *)esFile {
+  return [self initWithVnode:SantaVnode::VnodeForFile(esFile)];
+}
+
+- (instancetype)initWithVnode:(SantaVnode)vnode {
   self = [super init];
   if (self) {
-    _vnodeId = SantaVnode::VnodeForFile(esFile);
+    _vnodeId = vnode;
   }
   return self;
 }

--- a/Source/common/SNTFileInfo.h
+++ b/Source/common/SNTFileInfo.h
@@ -15,6 +15,8 @@
 #import <EndpointSecurity/EndpointSecurity.h>
 #import <Foundation/Foundation.h>
 
+#import "Source/common/SantaVnode.h"
+
 @class MOLCodesignChecker;
 
 ///
@@ -219,6 +221,11 @@
 ///  @return The size of the file in bytes.
 ///
 - (NSUInteger)fileSize;
+
+///
+///  @return The devno/ino pair of the file
+///
+- (SantaVnode)vnode;
 
 ///
 ///  @return The underlying file handle.

--- a/Source/common/SNTFileInfo.m
+++ b/Source/common/SNTFileInfo.m
@@ -49,6 +49,7 @@
 @property NSString *path;
 @property NSFileHandle *fileHandle;
 @property NSUInteger fileSize;
+@property SantaVnode vnode;
 @property NSString *fileOwnerHomeDir;
 @property NSString *sha256Storage;
 
@@ -110,6 +111,7 @@ extern NSString *const NSURLQuarantinePropertiesKey WEAK_IMPORT_ATTRIBUTE;
     }
 
     _fileSize = fileStat->st_size;
+    _vnode = (SantaVnode){.fsid = fileStat->st_dev, .fileid = fileStat->st_ino};
 
     if (_fileSize == 0) return nil;
 

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -1163,6 +1163,7 @@ santa_unit_test(
         "//Source/common:SNTCachedDecision",
         "//Source/common:SNTCommonEnums",
         "//Source/common:SNTRule",
+        "//Source/common:SantaVnode",
         "//Source/common:TestUtils",
         "@OCMock",
     ],

--- a/Source/santad/SNTCompilerController.mm
+++ b/Source/santad/SNTCompilerController.mm
@@ -65,19 +65,21 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
 // Adds a fake cached decision to SNTDecisionCache for pending files. If the file
 // is executed before we can create a transitive rule for it, then we can at
 // least log the pending decision info.
-- (void)saveFakeDecision:(const es_file_t *)esFile {
-  SNTCachedDecision *cd = [[SNTCachedDecision alloc] initWithEndpointSecurityFile:esFile];
+- (void)saveFakeDecision:(SNTFileInfo *)fileInfo {
+  SNTCachedDecision *cd = [[SNTCachedDecision alloc] initWithVnode:fileInfo.vnode];
   cd.decision = SNTEventStateAllowPendingTransitive;
   cd.sha256 = @"pending";
   [[SNTDecisionCache sharedCache] cacheDecision:cd];
 }
 
-- (void)removeFakeDecision:(const es_file_t *)esFile {
-  [[SNTDecisionCache sharedCache] forgetCachedDecisionForFile:esFile->stat];
+- (void)removeFakeDecision:(SNTFileInfo *)fileInfo {
+  [[SNTDecisionCache sharedCache] forgetCachedDecisionForVnode:fileInfo.vnode];
 }
 
 - (BOOL)handleEvent:(const Message &)esMsg withLogger:(std::shared_ptr<Logger>)logger {
-  const es_file_t *targetFile = NULL;
+  SNTFileInfo *targetFile;
+  NSString *targetPath;
+  NSError *error;
 
   switch (esMsg->event_type) {
     case ES_EVENT_TYPE_NOTIFY_CLOSE:
@@ -90,7 +92,9 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
         return NO;
       }
 
-      targetFile = esMsg->event.close.target;
+      targetPath = @(esMsg->event.close.target->path.data);
+      targetFile = [[SNTFileInfo alloc] initWithEndpointSecurityFile:esMsg->event.close.target
+                                                               error:&error];
 
       break;
     case ES_EVENT_TYPE_NOTIFY_RENAME:
@@ -105,7 +109,24 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
         return NO;
       }
 
-      targetFile = esMsg->event.rename.source;
+      targetFile = [[SNTFileInfo alloc] initWithEndpointSecurityFile:esMsg->event.rename.source
+                                                               error:&error];
+      if (!targetFile) {
+        LOGD(@"Unable to locate source file for rename event while creating transitive. Falling "
+             @"back to destination. Path: %s, Error: %@",
+             esMsg->event.rename.source->path.data, error);
+        if (esMsg->event.rename.destination_type == ES_DESTINATION_TYPE_EXISTING_FILE) {
+          targetPath = @(esMsg->event.rename.destination.existing_file->path.data);
+          targetFile = [[SNTFileInfo alloc]
+            initWithEndpointSecurityFile:esMsg->event.rename.destination.existing_file
+                                   error:&error];
+        } else {
+          targetPath = [NSString
+            stringWithFormat:@"%s/%s", esMsg->event.rename.destination.new_path.dir->path.data,
+                             esMsg->event.rename.destination.new_path.filename.data];
+          targetFile = [[SNTFileInfo alloc] initWithPath:targetPath error:&error];
+        }
+      }
 
       break;
     case ES_EVENT_TYPE_NOTIFY_EXIT:
@@ -119,6 +140,9 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
     [self createTransitiveRule:esMsg target:targetFile logger:logger];
     return YES;
   } else {
+    LOGD(@"Unable to create SNTFileInfo while attempting to create transitive rule. Event: %d | "
+         @"Path: %@ | Error: %@",
+         (int)esMsg->event_type, targetPath, error);
     return NO;
   }
 }
@@ -127,30 +151,21 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
 // compiler.  It checks if the closed file is executable, and if so, transitively allowlists it.
 // The passed in message contains the pid of the writing process and path of closed file.
 - (void)createTransitiveRule:(const Message &)esMsg
-                      target:(const es_file_t *)targetFile
+                      target:(SNTFileInfo *)targetFile
                       logger:(std::shared_ptr<Logger>)logger {
-  NSError *error = nil;
-  SNTFileInfo *fi = [[SNTFileInfo alloc] initWithEndpointSecurityFile:targetFile error:&error];
-  if (error) {
-    LOGD(@"Unable to create SNTFileInfo while attempting to create transitive rule. Event: %d | "
-         @"Path: %@ | Error: %@",
-         (int)esMsg->event_type, @(targetFile->path.data), error);
-    return;
-  }
-
   [self saveFakeDecision:targetFile];
 
   // Check if this file is an executable.
-  if (fi.isExecutable) {
+  if (targetFile.isExecutable) {
     // Check if there is an existing (non-transitive) rule for this file.  We leave existing rules
     // alone, so that a allowlist or blocklist rule can't be overwritten by a transitive one.
     SNTRuleTable *ruleTable = [SNTDatabaseController ruleTable];
     SNTRule *prevRule = [ruleTable ruleForIdentifiers:(struct RuleIdentifiers){
-                                                        .binarySHA256 = fi.SHA256,
+                                                        .binarySHA256 = targetFile.SHA256,
                                                       }];
     if (!prevRule || prevRule.state == SNTRuleStateAllowTransitive) {
       // Construct a new transitive allowlist rule for the executable.
-      SNTRule *rule = [[SNTRule alloc] initWithIdentifier:fi.SHA256
+      SNTRule *rule = [[SNTRule alloc] initWithIdentifier:targetFile.SHA256
                                                     state:SNTRuleStateAllowTransitive
                                                      type:SNTRuleTypeBinary
                                                 customMsg:@""];
@@ -160,7 +175,7 @@ static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";
       if (![ruleTable addRules:@[ rule ] ruleCleanup:SNTRuleCleanupNone error:&err]) {
         LOGE(@"unable to add new transitive rule to database: %@", err.localizedDescription);
       } else {
-        logger->LogAllowlist(esMsg, [fi.SHA256 UTF8String]);
+        logger->LogAllowlist(esMsg, [targetFile.SHA256 UTF8String]);
       }
     }
   }

--- a/Source/santad/SNTDecisionCache.h
+++ b/Source/santad/SNTDecisionCache.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "Source/common/SNTCachedDecision.h"
+#import "Source/common/SantaVnode.h"
 
 @interface SNTDecisionCache : NSObject
 
@@ -24,7 +25,7 @@
 
 - (void)cacheDecision:(SNTCachedDecision *)cd;
 - (SNTCachedDecision *)cachedDecisionForFile:(const struct stat &)statInfo;
-- (void)forgetCachedDecisionForFile:(const struct stat &)statInfo;
+- (void)forgetCachedDecisionForVnode:(SantaVnode)vnode;
 - (SNTCachedDecision *)resetTimestampForCachedDecision:(const struct stat &)statInfo;
 
 @end

--- a/Source/santad/SNTDecisionCache.mm
+++ b/Source/santad/SNTDecisionCache.mm
@@ -58,8 +58,8 @@
   return self->_decisionCache.get(SantaVnode::VnodeForFile(statInfo));
 }
 
-- (void)forgetCachedDecisionForFile:(const struct stat &)statInfo {
-  self->_decisionCache.remove(SantaVnode::VnodeForFile(statInfo));
+- (void)forgetCachedDecisionForVnode:(SantaVnode)vnode {
+  self->_decisionCache.remove(vnode);
 }
 
 // Whenever a cached decision resulting from a transitive allowlist rule is used to allow the

--- a/Source/santad/SNTDecisionCacheTest.mm
+++ b/Source/santad/SNTDecisionCacheTest.mm
@@ -21,6 +21,7 @@
 
 #import "Source/common/SNTCommonEnums.h"
 #import "Source/common/SNTRule.h"
+#import "Source/common/SantaVnode.h"
 #include "Source/common/TestUtils.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #import "Source/santad/SNTDatabaseController.h"
@@ -70,7 +71,7 @@ SNTCachedDecision *MakeCachedDecision(struct stat sb, SNTEventState decision) {
   XCTAssertEqual(cachedCD.vnodeId.fileid, cd.vnodeId.fileid);
 
   // Delete the item from the cache and ensure it no longer exists
-  [dc forgetCachedDecisionForFile:sb];
+  [dc forgetCachedDecisionForVnode:SantaVnode::VnodeForFile(sb)];
   XCTAssertNil([dc cachedDecisionForFile:sb]);
 }
 


### PR DESCRIPTION
When a transitive rule is being created during a RENAME event, currently only the source path is used. However, the rename operation may have already succeeded and the path no longer exists. This change makes it so that the destination path is used in the event the source no longer exists.