### PR TITLE
Implement NSSecureCoding for SNTRuleIdentifiers

### DIFF
--- a/Source/common/SNTRuleIdentifiers.h
+++ b/Source/common/SNTRuleIdentifiers.h
@@ -33,7 +33,7 @@ struct RuleIdentifiers {
   NSString *teamID;
 };
 
-@interface SNTRuleIdentifiers : NSObject
+@interface SNTRuleIdentifiers : NSObject <NSSecureCoding>
 @property(readonly) NSString *cdhash;
 @property(readonly) NSString *binarySHA256;
 @property(readonly) NSString *signingID;

--- a/Source/common/SNTRuleIdentifiers.m
+++ b/Source/common/SNTRuleIdentifiers.m
@@ -36,4 +36,38 @@
                                   .teamID = self.teamID};
 }
 
+#pragma mark NSSecureCoding
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+#define ENCODE(obj, key) \
+  if (obj) [coder encodeObject:obj forKey:key]
+#define DECODE(cls, key) [decoder decodeObjectOfClass:[cls class] forKey:key]
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  self = [self init];
+  if (self) {
+    _cdhash = DECODE(NSString, @"cdhash");
+    _binarySHA256 = DECODE(NSString, @"binarySHA256");
+    _signingID = DECODE(NSString, @"signingID");
+    _certificateSHA256 = DECODE(NSString, @"certificateSHA256");
+    _teamID = DECODE(NSString, @"teamID");
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  ENCODE(self.cdhash, @"cdhash");
+  ENCODE(self.binarySHA256, @"binarySHA256");
+  ENCODE(self.signingID, @"signingID");
+  ENCODE(self.certificateSHA256, @"certificateSHA256");
+  ENCODE(self.teamID, @"teamID");
+}
+
+#pragma clang diagnostic pop
+
 @end


### PR DESCRIPTION
This fixes an issue with santactl fileinfo that stems from SNTRuleIdentifiers not implementing the NSSecureCoding protocol.

This would result in a stacktrace when a user went to use santactl fileinfo.