### PR TITLE
Fix: Do not flush authcache when receiving duplicate block rules from the sync service

### DIFF
--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -464,10 +464,25 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
 
 - (BOOL)addedRulesShouldFlushDecisionCache:(NSArray *)rules {
   __block BOOL flushDecisionCache = NO;
+  uint64_t blockingRuleCount = 0;
+
+  for (SNTRule *rule in rules) {
+    if (rule.state != SNTRuleStateAllow) {
+      blockingRuleCount++;
+    }
+  }
+
+  if (blockingRuleCount > 1000) {
+    return YES;
+  }
 
   // Check newly synced rules for any blocking rules. If any are found, check
   // in the db to see if they already exist. If they're not found or were
   // previously allow rules flush the cache.
+  //
+  // If all rules in the array are allowlist rules,  look for allowlist rules
+  // where there is a previously existing allowlist compiler rule for the same
+  // identifier.  If so we find such a rule, then cache should be flushed.
   [self inTransaction:^(FMDatabase *db, BOOL *rollback) {
     for (SNTRule *rule in rules) {
       if (rule.state != SNTRuleStateAllow) {
@@ -477,27 +492,16 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
           flushDecisionCache = YES;
           break;
         }
-      }
-    }
-  }];
 
-  if (flushDecisionCache) {
-    return flushDecisionCache;
-  }
+        // Allowlist certificate rules are ignored
+        if (rule.type == SNTRuleTypeCertificate) continue;
 
-  // If still here, then all rules in the array are allowlist rules.  So now we look for allowlist
-  // rules where there is a previously existing allowlist compiler rule for the same identifier.
-  // If so we find such a rule, then cache should be flushed.
-  [self inTransaction:^(FMDatabase *db, BOOL *rollback) {
-    for (SNTRule *rule in rules) {
-      // Allowlist certificate rules are ignored
-      if (rule.type == SNTRuleTypeCertificate) continue;
-
-      if ([db longForQuery:
-                @"SELECT COUNT(*) FROM rules WHERE identifier=? AND type=? AND state=? LIMIT 1",
-                rule.identifier, @(SNTRuleTypeBinary), @(SNTRuleStateAllowCompiler)] > 0) {
-        flushDecisionCache = YES;
-        break;
+        if ([db longForQuery:
+                  @"SELECT COUNT(*) FROM rules WHERE identifier=? AND type=? AND state=? LIMIT 1",
+                  rule.identifier, @(SNTRuleTypeBinary), @(SNTRuleStateAllowCompiler)] > 0) {
+          flushDecisionCache = YES;
+          break;
+        }
       }
     }
   }];

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -308,8 +308,11 @@
 - (void)testFetchRuleOrdering {
   NSError *err;
   [self.sut addRules:@[
-    [self _exampleCertRule], [self _exampleBinaryRule], [self _exampleTeamIDRule],
-    [self _exampleSigningIDRuleIsPlatform:NO], [self _exampleCDHashRule],
+    [self _exampleCertRule],
+    [self _exampleBinaryRule],
+    [self _exampleTeamIDRule],
+    [self _exampleSigningIDRuleIsPlatform:NO],
+    [self _exampleCDHashRule],
   ]
          ruleCleanup:SNTRuleCleanupNone
                error:&err];
@@ -452,8 +455,8 @@
   XCTAssertEqual(YES, [self.sut addedRulesShouldFlushDecisionCache:@[ r ]]);
 }
 
+// Ensure that a brand new block rule flushes the decision cache.
 - (void)testAddedRulesShouldFlushDecisionCacheWithOldBlockRule {
-  // Ensure that a brand new block rule flushes the decision cache.
   NSError *error;
   SNTRule *r = [self _exampleBinaryRule];
   [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
@@ -463,8 +466,8 @@
   XCTAssertEqual(NO, [self.sut addedRulesShouldFlushDecisionCache:@[ r ]]);
 }
 
+// Ensure that a larger number of blocks flushes the decision cache.
 - (void)testAddedRulesShouldFlushDecisionCacheWithLargeNumberOfBlocks {
-  // Ensure that a brand new block rule flushes the decision cache.
   NSError *error;
   SNTRule *r = [self _exampleBinaryRule];
   [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
@@ -477,6 +480,37 @@
   }
 
   XCTAssertEqual(YES, [self.sut addedRulesShouldFlushDecisionCache:newRules]);
+}
+
+// Ensure that an allow rule that overrides a compiler rule flushes the
+// decision cache.
+- (void)testAddedRulesShouldFlushDecisionCacheWithCompilerRule {
+  NSError *error;
+  SNTRule *r = [self _exampleBinaryRule];
+  r.type = SNTRuleTypeBinary;
+  r.state = SNTRuleStateAllowCompiler;
+  [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(self.sut.ruleCount, 1);
+  XCTAssertEqual(self.sut.binaryRuleCount, 1);
+  // make the rule an allow rule
+  r.state = SNTRuleStateAllow;
+  XCTAssertEqual(YES, [self.sut addedRulesShouldFlushDecisionCache:@[ r ]]);
+}
+
+// Ensure that an Remove rule targeting an allow rule causes a flush of the cache.
+- (void)testAddedRulesShouldFlushDecisionCacheWithRemoveRule {
+  NSError *error;
+  SNTRule *r = [self _exampleBinaryRule];
+  r.type = SNTRuleTypeBinary;
+  r.state = SNTRuleStateAllow;
+  [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(self.sut.ruleCount, 1);
+  XCTAssertEqual(self.sut.binaryRuleCount, 1);
+
+  r.state = SNTRuleStateRemove;
+  XCTAssertEqual(YES, [self.sut addedRulesShouldFlushDecisionCache:@[ r ]]);
 }
 
 @end

--- a/Source/santad/DataLayer/SNTRuleTableTest.m
+++ b/Source/santad/DataLayer/SNTRuleTableTest.m
@@ -425,4 +425,46 @@
   XCTAssertEqualObjects(rules[4], [self _exampleCDHashRule]);
 }
 
+- (void)testAddedRulesShouldFlushDecisionCacheWithNewBlockRule {
+  // Ensure that a brand new block rule flushes the decision cache.
+  NSError *error;
+  SNTRule *r = [self _exampleBinaryRule];
+  [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(self.sut.ruleCount, 1);
+  XCTAssertEqual(self.sut.binaryRuleCount, 1);
+
+  // Change the identifer so that the hash of a block rule is not found in the
+  // db.
+  r.identifier = @"bfff7d3f6c389ebf7a76a666c484d42ea447834901bc29141439ae7c7b96ff09";
+  XCTAssertEqual(YES, [self.sut addedRulesShouldFlushDecisionCache:@[ r ]]);
+}
+
+- (void)testAddedRulesShouldFlushDecisionCacheWithOldBlockRule {
+  // Ensure that a brand new block rule flushes the decision cache.
+  NSError *error;
+  SNTRule *r = [self _exampleBinaryRule];
+  [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(self.sut.ruleCount, 1);
+  XCTAssertEqual(self.sut.binaryRuleCount, 1);
+  XCTAssertEqual(NO, [self.sut addedRulesShouldFlushDecisionCache:@[ r ]]);
+}
+
+- (void)testAddedRulesShouldFlushDecisionCacheWithLargeNumberOfBlocks {
+  // Ensure that a brand new block rule flushes the decision cache.
+  NSError *error;
+  SNTRule *r = [self _exampleBinaryRule];
+  [self.sut addRules:@[ r ] ruleCleanup:SNTRuleCleanupNone error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(self.sut.ruleCount, 1);
+  XCTAssertEqual(self.sut.binaryRuleCount, 1);
+  NSMutableArray<SNTRule *> *newRules = [NSMutableArray array];
+  for (int i = 0; i < 1000; i++) {
+    newRules[i] = r;
+  }
+
+  XCTAssertEqual(YES, [self.sut addedRulesShouldFlushDecisionCache:newRules]);
+}
+
 @end


### PR DESCRIPTION
This PR changes the caching behavior of santad when it receives block rules from that sync service that are already in the database. 