### PR TITLE
Overrides disabled when running tests unless explicitly enabled

### DIFF
--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1234,6 +1234,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
     }
   }
 #ifdef DEBUG
+  BOOL overridesApplied = NO;
   NSDictionary *overrides = [NSDictionary dictionaryWithContentsOfFile:kConfigOverrideFilePath];
   for (NSString *key in overrides) {
     id obj = overrides[key];
@@ -1242,11 +1243,18 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
          ![obj isKindOfClass:[NSString class]])) {
       continue;
     }
+
     forcedConfig[key] = obj;
+    overridesApplied = YES;
+
     if (self.forcedConfigKeyTypes[key] == [NSRegularExpression class]) {
       NSString *pattern = [obj isKindOfClass:[NSString class]] ? obj : nil;
       forcedConfig[key] = [self expressionForPattern:pattern];
     }
+  }
+
+  if (overridesApplied) {
+    NSLog(@"WARNING: Running with overrides applied!");
   }
 #endif
   return forcedConfig;

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1227,7 +1227,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 #ifdef DEBUG
   if ([[[NSProcessInfo processInfo] processName] isEqualToString:@"xctest"] &&
       ![[[NSProcessInfo processInfo] environment] objectForKey:@"ENABLE_CONFIG_OVERRIDES"]) {
-    // By default, config overrides are not applied when runnings tests to help
+    // By default, config overrides are not applied when running tests to help
     // mitigate potential issues due to unexpected config values. This behavior
     // can be overriden if desired by using the env variable: `ENABLE_CONFIG_OVERRIDES`.
     //

--- a/Source/common/SNTConfigurator.m
+++ b/Source/common/SNTConfigurator.m
@@ -1225,7 +1225,7 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
 - (void)applyOverrides:(NSMutableDictionary *)forcedConfig {
   // Overrides should only be applied under debug builds.
 #ifdef DEBUG
-  if ([[[NSProcessInfo processInfo] environment] objectForKey:@"BAZEL_TEST"] &&
+  if ([[[NSProcessInfo processInfo] processName] isEqualToString:@"xctest"] &&
       ![[[NSProcessInfo processInfo] environment] objectForKey:@"ENABLE_CONFIG_OVERRIDES"]) {
     // By default, config overrides are not applied when runnings tests to help
     // mitigate potential issues due to unexpected config values. This behavior
@@ -1236,7 +1236,6 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
     return;
   }
 
-  BOOL overridesApplied = NO;
   NSDictionary *overrides = [NSDictionary dictionaryWithContentsOfFile:kConfigOverrideFilePath];
   for (NSString *key in overrides) {
     id obj = overrides[key];
@@ -1247,16 +1246,11 @@ static NSString *const kSyncTypeRequired = @"SyncTypeRequired";
     }
 
     forcedConfig[key] = obj;
-    overridesApplied = YES;
 
     if (self.forcedConfigKeyTypes[key] == [NSRegularExpression class]) {
       NSString *pattern = [obj isKindOfClass:[NSString class]] ? obj : nil;
       forcedConfig[key] = [self expressionForPattern:pattern];
     }
-  }
-
-  if (overridesApplied) {
-    NSLog(@"WARNING: Running with overrides applied!");
   }
 #endif
 }


### PR DESCRIPTION
This change disables applying the config overrides file when running tests by default. You can override this behavior by setting the environment variable `ENABLE_CONFIG_OVERRIDES`. E.g.:

```
bazel test --test_env=ENABLE_CONFIG_OVERRIDES=1 ...other test args...
```