### PR TITLE
[Bug] Restore `default button type` to `MessageWindow` for blocked events

### DIFF
--- a/Source/gui/Resources/MessageWindow.xib
+++ b/Source/gui/Resources/MessageWindow.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,18 +18,18 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Santa Blocked Execution" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" animationBehavior="none" id="9Bq-yh-54f" customClass="SNTMessageWindow">
-            <windowStyleMask key="styleMask" utility="YES"/>
+        <window title="Santa Blocked Execution" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" animationBehavior="none" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="9Bq-yh-54f" customClass="SNTMessageWindow">
+            <windowStyleMask key="styleMask" titled="YES" utility="YES"/>
             <rect key="contentRect" x="167" y="107" width="540" height="479"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1175"/>
             <view key="contentView" id="Iwq-Lx-rLv">
                 <rect key="frame" x="0.0" y="0.0" width="540" height="462"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <button focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kiB-jZ-69S">
-                        <rect key="frame" x="16" y="434" width="37" height="32"/>
+                        <rect key="frame" x="16" y="434" width="37" height="23"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Hidden Button" alternateTitle="This button exists so neither of the other two buttons is pre-selected when the dialog opens." bezelStyle="rounded" alignment="center" borderStyle="border" focusRingType="none" transparent="YES" imageScaling="proportionallyDown" inset="2" id="XGa-Sl-F4t">
+                        <buttonCell key="cell" type="roundTextured" title="Hidden Button" alternateTitle="This button exists so neither of the other two buttons is pre-selected when the dialog opens." bezelStyle="texturedRounded" alignment="center" borderStyle="border" focusRingType="none" transparent="YES" imageScaling="proportionallyDown" inset="2" id="XGa-Sl-F4t">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                             <userDefinedRuntimeAttributes>
@@ -128,10 +128,6 @@
                     </textField>
                     <button toolTip="Show code signing certificate chain" translatesAutoresizingMaskIntoConstraints="NO" id="cJf-k6-OxS" userLabel="Publisher Certs Button">
                         <rect key="frame" x="62" y="235" width="15" height="15"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="15" id="QTm-Iv-m5p"/>
-                            <constraint firstAttribute="height" constant="15" id="YwG-0s-jop"/>
-                        </constraints>
                         <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="NSInfo" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="R72-Qy-Xbb">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -139,6 +135,10 @@
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="accessibilityElement" value="NO"/>
                             </userDefinedRuntimeAttributes>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="15" id="QTm-Iv-m5p"/>
+                            <constraint firstAttribute="height" constant="15" id="YwG-0s-jop"/>
+                        </constraints>
                         <connections>
                             <action selector="showCertInfo:" target="-2" id="dB0-a3-X31"/>
                             <binding destination="-2" name="hidden" keyPath="self.publisherInfo" id="fFR-f3-Oiw">
@@ -241,9 +241,6 @@
                     </textField>
                     <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="7ua-5a-uSd">
                         <rect key="frame" x="147" y="30" width="126" height="32"/>
-                        <constraints>
-                            <constraint firstAttribute="width" priority="900" constant="112" id="Pec-Pa-4aZ"/>
-                        </constraints>
                         <buttonCell key="cell" type="push" title="Open..." bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="X1b-TF-1TL">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -251,6 +248,9 @@
 DQ
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" priority="900" constant="112" id="Pec-Pa-4aZ"/>
+                        </constraints>
                         <connections>
                             <action selector="openEventDetails:" target="-2" id="VhL-ql-rCV"/>
                             <outlet property="nextKeyView" destination="BbV-3h-mmL" id="Xkz-va-iGc"/>
@@ -272,23 +272,19 @@ DQ
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="5D8-GP-a4l">
                         <rect key="frame" x="110" y="80" width="319" height="29"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="25" id="KvD-X6-CsO"/>
-                        </constraints>
                         <buttonCell key="cell" type="check" title="Prevent future notifications for this application for a day" bezelStyle="regularSquare" imagePosition="left" alignment="center" inset="2" id="R5Y-Uc-rEP">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="25" id="KvD-X6-CsO"/>
+                        </constraints>
                         <connections>
                             <binding destination="-2" name="value" keyPath="self.silenceFutureNotifications" id="tEb-2A-sht"/>
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BbV-3h-mmL" userLabel="Dismiss Button">
                         <rect key="frame" x="271" y="28" width="124" height="34"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="110" id="6Uh-Bd-N64"/>
-                            <constraint firstAttribute="height" constant="22" id="GH6-nw-6rD"/>
-                        </constraints>
                         <buttonCell key="cell" type="push" title="Ignore" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="XR6-Xa-gP4">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -296,6 +292,10 @@ DQ
 Gw
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="110" id="6Uh-Bd-N64"/>
+                            <constraint firstAttribute="height" constant="22" id="GH6-nw-6rD"/>
+                        </constraints>
                         <accessibility description="Dismiss Dialog"/>
                         <connections>
                             <action selector="closeWindow:" target="-2" id="qQq-gh-8lw"/>

--- a/Source/gui/Resources/MessageWindow.xib
+++ b/Source/gui/Resources/MessageWindow.xib
@@ -21,7 +21,7 @@
         <window title="Santa Blocked Execution" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" animationBehavior="none" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="9Bq-yh-54f" customClass="SNTMessageWindow">
             <windowStyleMask key="styleMask" titled="YES" utility="YES"/>
             <rect key="contentRect" x="167" y="107" width="540" height="479"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1175"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1916" height="1099"/>
             <view key="contentView" id="Iwq-Lx-rLv">
                 <rect key="frame" x="0.0" y="0.0" width="540" height="462"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -247,6 +247,7 @@
                             <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
+                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                         </buttonCell>
                         <constraints>
                             <constraint firstAttribute="width" priority="900" constant="112" id="Pec-Pa-4aZ"/>

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -92,8 +92,9 @@
     NSString *eventDetailText = [[SNTConfigurator configurator] eventDetailText];
     if (eventDetailText) {
       [self.openEventButton setTitle:eventDetailText];
-      [self.openEventButton setKeyEquivalent:@"\r"];
-      [self.openEventButton setKeyEquivalentModifierMask:!NSEventModifierFlagCommand];
+      // Require the button keyEquivalent set to be CMD + Return
+      [self.openEventButton setKeyEquivalent:@"\r"]; // Return Key
+      [self.openEventButton setKeyEquivalentModifierMask:NSCommandKeyMask]; // Command Key
     }
   }
 

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -92,6 +92,8 @@
     NSString *eventDetailText = [[SNTConfigurator configurator] eventDetailText];
     if (eventDetailText) {
       [self.openEventButton setTitle:eventDetailText];
+      [self.openEventButton setKeyEquivalent:@"\r"];
+      [self.openEventButton setKeyEquivalentModifierMask:!NSEventModifierFlagCommand];
     }
   }
 

--- a/Source/gui/SNTBinaryMessageWindowController.m
+++ b/Source/gui/SNTBinaryMessageWindowController.m
@@ -94,7 +94,7 @@
       [self.openEventButton setTitle:eventDetailText];
       // Require the button keyEquivalent set to be CMD + Return
       [self.openEventButton setKeyEquivalent:@"\r"]; // Return Key
-      [self.openEventButton setKeyEquivalentModifierMask:NSCommandKeyMask]; // Command Key
+      [self.openEventButton setKeyEquivalentModifierMask:NSEventModifierFlagCommand]; // Command Key
     }
   }
 

--- a/Source/gui/SNTFileAccessMessageWindowView.swift
+++ b/Source/gui/SNTFileAccessMessageWindowView.swift
@@ -142,6 +142,8 @@ struct SNTFileAccessMessageWindowView: View {
 
               Text(customText ?? "Open Event...").frame(maxWidth:.infinity)
             })
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
           }
           Button(action: dismissButton, label: {
             Text("Dismiss").frame(maxWidth:.infinity)


### PR DESCRIPTION
[Bug] Restore default button type to MessageWindow for blocked events

### CONTEXT
At some point in macOS 14 with the latest few agent revisions, the MessageWindow needs a hidden titlebar in order for the default button to show.

This is more of a stop-gap measure until this can be rewritten in SwiftUI, which I don't mind taking in the coming weeks to help contribute that change back. 
@russellhancox --> #1006 --> I can probs take the MessageWindow in the coming weeks.

For now, this UI bug can be quickly restored without much effort and decrease UX issues/confusion reported from our users.

### CHANGES
- Add hidden title bar to the MessageWindow box so the default button from this prior PR, #788, works again
- Update other SwiftUI buttons to inherit the same behavior
  - Keep UX uniformity with this change
### TESTING
- from latest `dev/main branch`
<img width="1639" alt="Screenshot 2024-03-25 at 15 28 48" src="https://github.com/google/santa/assets/39590744/166d07d1-cf2e-44a3-bac1-19d5ef6817d2">

