### PR TITLE
Fix: Update code to use the  new MOLCodesignChecker interfaces for codesigning info

### DIFF
--- a/Source/common/SNTXPCControlInterface.m
+++ b/Source/common/SNTXPCControlInterface.m
@@ -34,8 +34,7 @@ NSString *const kBundleID = @"com.google.santa.daemon";
 #else
   MOLCodesignChecker *cs = [[MOLCodesignChecker alloc] initWithSelf];
   // "teamid.com.google.santa.daemon.xpc"
-  NSString *t = cs.signingInformation[@"teamid"];
-  return [NSString stringWithFormat:@"%@.%@.xpc", t, kBundleID];
+  return [NSString stringWithFormat:@"%@.%@.xpc", cs.teamID, kBundleID];
 #endif
 }
 

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -380,21 +380,16 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     NSError *err;
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:&err];
 
-    NSString *cdhash =
-      [csc.signingInformation objectForKey:(__bridge NSString *)kSecCodeInfoUnique];
-    NSString *teamID =
-      [csc.signingInformation objectForKey:(__bridge NSString *)kSecCodeInfoTeamIdentifier];
-    NSString *identifier =
-      [csc.signingInformation objectForKey:(__bridge NSString *)kSecCodeInfoIdentifier];
+    NSString *cdhash = csc.cdhash;
+    NSString *teamID = csc.teamID;
+    NSString *identifier = csc.signingID;
 
     NSString *signingID;
     if (identifier) {
       if (teamID) {
         signingID = [NSString stringWithFormat:@"%@:%@", teamID, identifier];
       } else {
-        id platformID =
-          [csc.signingInformation objectForKey:(__bridge NSString *)kSecCodeInfoPlatformIdentifier];
-        if ([platformID isKindOfClass:[NSNumber class]] && [platformID intValue] != 0) {
+        if (csc.platformBinary) {
           signingID = [NSString stringWithFormat:@"platform:%@", identifier];
         }
       }
@@ -522,21 +517,21 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 - (SNTAttributeBlock)teamID {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    return [csc.signingInformation valueForKey:@"teamid"];
+    return csc.teamID;
   };
 }
 
 - (SNTAttributeBlock)signingID {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    return [csc.signingInformation objectForKey:(__bridge NSString *)kSecCodeInfoIdentifier];
+    return csc.signingID;
   };
 }
 
 - (SNTAttributeBlock)cdhash {
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
-    return [csc.signingInformation objectForKey:(__bridge NSString *)kSecCodeInfoUnique];
+    return csc.cdhash;
   };
 }
 

--- a/Source/santactl/Commands/SNTCommandRule.m
+++ b/Source/santactl/Commands/SNTCommandRule.m
@@ -438,30 +438,6 @@ REGISTER_COMMAND_NAME(@"rule")
   exit(0);
 }
 
-- (void)printStateOfRuleAsJSON:(SNTRule *)rule daemonConnection:(MOLXPCConnection *)daemonConn {
-  id<SNTDaemonControlXPC> rop = [daemonConn synchronousRemoteObjectProxy];
-  __block NSString *output;
-
-  struct RuleIdentifiers identifiers = {
-    .cdhash = (rule.type == SNTRuleTypeCDHash) ? rule.identifier : nil,
-    .binarySHA256 = (rule.type == SNTRuleTypeBinary) ? rule.identifier : nil,
-    .certificateSHA256 = (rule.type == SNTRuleTypeCertificate) ? rule.identifier : nil,
-    .teamID = (rule.type == SNTRuleTypeTeamID) ? rule.identifier : nil,
-    .signingID = (rule.type == SNTRuleTypeSigningID) ? rule.identifier : nil,
-  };
-
-  [rop databaseRuleForIdentifiers:[[SNTRuleIdentifiers alloc] initWithRuleIdentifiers:identifiers]
-                            reply:^(SNTRule *r) {
-                              output = [SNTCommandRule stringifyRule:r
-                                                           withColor:(isatty(STDOUT_FILENO) == 1)];
-                            }];
-
-  printf("%s\n", output.UTF8String);
-  exit(0);
-}
-
-
-
 - (void)importJSONFile:(NSString *)jsonFilePath with:(SNTRuleCleanup)cleanupType {
   // If the file exists parse it and then add the rules one at a time.
   NSError *error;

--- a/Source/santad/SNTExecutionControllerTest.mm
+++ b/Source/santad/SNTExecutionControllerTest.mm
@@ -387,9 +387,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 }
 
 - (void)testTeamIDAllowRule {
-  OCMStub([self.mockCodesignChecker signingInformation]).andReturn((@{
-    (__bridge NSString *)kSecCodeInfoTeamIdentifier : @(kExampleTeamID),
-  }));
+  OCMStub([self.mockCodesignChecker teamID]).andReturn(@(kExampleTeamID));
 
   SNTRule *rule = [[SNTRule alloc] init];
   rule.state = SNTRuleStateAllow;
@@ -405,9 +403,7 @@ VerifyPostActionBlock verifyPostAction = ^PostActionBlock(SNTAction wantAction) 
 }
 
 - (void)testTeamIDBlockRule {
-  OCMStub([self.mockCodesignChecker signingInformation]).andReturn((@{
-    (__bridge NSString *)kSecCodeInfoTeamIdentifier : @(kExampleTeamID),
-  }));
+  OCMStub([self.mockCodesignChecker teamID]).andReturn(@(kExampleTeamID));
 
   SNTRule *rule = [[SNTRule alloc] init];
   rule.state = SNTRuleStateBlock;

--- a/Source/santad/SNTPolicyProcessor.m
+++ b/Source/santad/SNTPolicyProcessor.m
@@ -90,22 +90,17 @@
       cd.certSHA256 = csInfo.leafCertificate.SHA256;
       cd.certCommonName = csInfo.leafCertificate.commonName;
       cd.certChain = csInfo.certificates;
-      cd.teamID = teamID
-                    ?: [csInfo.signingInformation
-                         objectForKey:(__bridge NSString *)kSecCodeInfoTeamIdentifier];
+      cd.teamID = teamID ?: csInfo.teamID;
 
       // Ensure that if no teamID exists that the signing info confirms it is a
       // platform binary. If not, remove the signingID.
       if (!cd.teamID && cd.signingID) {
-        id platformID = [csInfo.signingInformation
-          objectForKey:(__bridge NSString *)kSecCodeInfoPlatformIdentifier];
-        if (![platformID isKindOfClass:[NSNumber class]] || [platformID intValue] == 0) {
+        if (!csInfo.platformBinary) {
           cd.signingID = nil;
         }
       }
 
-      NSDictionary *entitlements =
-        csInfo.signingInformation[(__bridge NSString *)kSecCodeInfoEntitlementsDict];
+      NSDictionary *entitlements = csInfo.entitlements;
 
       if (entitlementsFilterCallback) {
         cd.entitlements = entitlementsFilterCallback(entitlements);


### PR DESCRIPTION
This updates our use of MOLCodesignChecker to use the new interfaces provided in https://github.com/google/macops-molcodesignchecker/pull/13. 

This fixes #1318.