### PR TITLE
SNTBlockMessage: add more template options

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -210,7 +210,7 @@ objc_library(
     ],
     deps = [
         ":CertificateHelpers",
-        "@MOLCertificate",
+        ":SNTStoredEvent",
     ],
 )
 

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -145,6 +145,10 @@
 //   %file_identifier%           - The SHA-256 of the binary being executed.
 //   %bundle_or_file_identifier% - The hash of the bundle containing this file or the file itself,
 //                                 if no bundle hash is present.
+//   %file_bundle_id%            - The bundle id of the binary, if any.
+//   %team_id%                   - The Team ID if present in the signature information.
+//   %signing_id%                - The Signing ID if present in the signature information.
+//   %cdhash%                    - If signed, the CDHash.
 //   %username%                  - The executing user's name.
 //   %machine_id%                - The configured machine ID for this host.
 //   %hostname%                  - The machine's FQDN.
@@ -177,6 +181,10 @@
       ^{ return event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil; },
                                                  @"%bundle_or_file_identifier%",
       ^{ return event.executingUser; },          @"%username%",
+      ^{ return event.fileBundleID; },           @"%file_bundle_id%",
+      ^{ return event.teamID; },                 @"%team_id%",
+      ^{ return event.signingID; },              @"%signing_id%",
+      ^{ return event.cdhash; },                 @"%cdhash%",
       ^{ return config.machineID; },             @"%machine_id%",
       ^{ return [SNTSystemInfo longHostname]; }, @"%hostname%",
       ^{ return [SNTSystemInfo hardwareUUID]; }, @"%uuid%",
@@ -204,6 +212,10 @@
 //   %file_identifier% - The SHA-256 of the binary being executed.
 //   %accessed_path%   - The path accessed by the binary.
 //   %username%        - The executing user's name.
+//   %file_bundle_id%  - The bundle id of the binary, if any.
+//   %team_id%         - The Team ID if present in the signature information.
+//   %signing_id%      - The Signing ID if present in the signature information.
+//   %cdhash%          - If signed, the CDHash.
 //   %machine_id%      - The configured machine ID for this host.
 //   %hostname%        - The machine's FQDN.
 //   %uuid%            - The machine's UUID.
@@ -228,6 +240,10 @@
       ^{ return event.fileSHA256; },             @"%file_identifier%",
       ^{ return event.accessedPath; },           @"%accessed_path%",
       ^{ return event.executingUser; },          @"%username%",
+      ^{ return event.fileBundleID; },           @"%file_bundle_id%",
+      ^{ return event.teamID; },                 @"%team_id%",
+      ^{ return event.signingID; },              @"%signing_id%",
+      ^{ return event.cdhash; },                 @"%cdhash%",
       ^{ return config.machineID; },             @"%machine_id%",
       ^{ return [SNTSystemInfo longHostname]; }, @"%hostname%",
       ^{ return [SNTSystemInfo hardwareUUID]; }, @"%uuid%",

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -20,6 +20,10 @@
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTSystemInfo.h"
 
+static id ValueOrNull(id value) {
+  return value ?: [NSNull null];
+}
+
 @implementation SNTBlockMessage
 
 + (NSAttributedString *)formatMessage:(NSString *)message {
@@ -127,7 +131,7 @@
   __block NSString *formatStr = str;
 
   [replacements enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
-    if (value) {
+    if ((id)value != [NSNull null]) {
       formatStr = [formatStr stringByReplacingOccurrencesOfString:key withString:value];
     }
   }];
@@ -149,23 +153,22 @@
 //   %uuid%                      - The machine's UUID.
 //   %serial%                    - The machine's serial number.
 //
-+ (NSDictionary<NSString *, NSString *> *)eventDetailTemplateMappingForEvent:
-  (SNTStoredEvent *)event {
++ (NSDictionary *)eventDetailTemplateMappingForEvent:(SNTStoredEvent *)event {
   SNTConfigurator *config = [SNTConfigurator configurator];
   return @{
-    @"%file_sha%" : event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil,
-    @"%file_identifier%" : event.fileSHA256,
-    @"%bundle_or_file_identifier%" : event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256
-                                                      : nil,
-    @"%username%" : event.executingUser,
-    @"%file_bundle_id%" : event.fileBundleID,
-    @"%team_id%" : event.teamID,
-    @"%signing_id%" : event.signingID,
-    @"%cdhash%" : event.cdhash,
-    @"%machine_id%" : config.machineID,
-    @"%hostname%" : [SNTSystemInfo longHostname],
-    @"%uuid%" : [SNTSystemInfo hardwareUUID],
-    @"%serial%" : [SNTSystemInfo serialNumber],
+    @"%file_sha%" : ValueOrNull(event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil),
+    @"%file_identifier%" : ValueOrNull(event.fileSHA256),
+    @"%bundle_or_file_identifier%" :
+      ValueOrNull(event.fileSHA256 ? event.fileBundleHash ?: event.fileSHA256 : nil),
+    @"%username%" : ValueOrNull(event.executingUser),
+    @"%file_bundle_id%" : ValueOrNull(event.fileBundleID),
+    @"%team_id%" : ValueOrNull(event.teamID),
+    @"%signing_id%" : ValueOrNull(event.signingID),
+    @"%cdhash%" : ValueOrNull(event.cdhash),
+    @"%machine_id%" : ValueOrNull(config.machineID),
+    @"%hostname%" : ValueOrNull([SNTSystemInfo longHostname]),
+    @"%uuid%" : ValueOrNull([SNTSystemInfo hardwareUUID]),
+    @"%serial%" : ([SNTSystemInfo serialNumber]),
   };
 }
 
@@ -177,13 +180,12 @@
 //   %rule_name%       - The name of the rule that was violated.
 //   %accessed_path%   - The path accessed by the binary.
 //
-+ (NSDictionary<NSString *, NSString *> *)fileAccessEventDetailTemplateMappingForEvent:
-  (SNTFileAccessEvent *)event {
++ (NSDictionary *)fileAccessEventDetailTemplateMappingForEvent:(SNTFileAccessEvent *)event {
   NSMutableDictionary *d = [self eventDetailTemplateMappingForEvent:event].mutableCopy;
   [d addEntriesFromDictionary:@{
-    @"%rule_version%" : event.ruleVersion,
-    @"%rule_name%" : event.ruleName,
-    @"%accessed_path%" : event.accessedPath,
+    @"%rule_version%" : ValueOrNull(event.ruleVersion),
+    @"%rule_name%" : ValueOrNull(event.ruleName),
+    @"%accessed_path%" : ValueOrNull(event.accessedPath),
   }];
   return d;
 }

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -168,7 +168,7 @@ static id ValueOrNull(id value) {
     @"%machine_id%" : ValueOrNull(config.machineID),
     @"%hostname%" : ValueOrNull([SNTSystemInfo longHostname]),
     @"%uuid%" : ValueOrNull([SNTSystemInfo hardwareUUID]),
-    @"%serial%" : ([SNTSystemInfo serialNumber]),
+    @"%serial%" : ValueOrNull([SNTSystemInfo serialNumber]),
   };
 }
 

--- a/Source/common/SNTBlockMessage.m
+++ b/Source/common/SNTBlockMessage.m
@@ -140,6 +140,9 @@ static id ValueOrNull(id value) {
 }
 
 //
+//   The following "format strings" will be replaced in the URL provided by
+//   `+eventDetailURLForEvent:customURL:templateMapping:`.
+//
 //   %file_identifier%           - The SHA-256 of the binary being executed.
 //   %bundle_or_file_identifier% - The hash of the bundle containing this file or the file itself,
 //                                 if no bundle hash is present.
@@ -193,7 +196,7 @@ static id ValueOrNull(id value) {
 // Returns either the generated URL for the passed in event, or an NSURL from the passed in custom
 // URL string. If the custom URL string is the string "null", nil will be returned. If no custom
 // URL is passed and there is no configured EventDetailURL template, nil will be returned.
-// The following "format strings" will be replaced in the URL, if they are present:
+// The "format strings" in `templateMapping` will be replaced in the URL, if they are present.
 + (NSURL *)eventDetailURLForEvent:(SNTStoredEvent *)event
                         customURL:(NSString *)url
                   templateMapping:(NSDictionary *)templateMapping {

--- a/Source/common/SNTBlockMessageTest.m
+++ b/Source/common/SNTBlockMessageTest.m
@@ -76,35 +76,35 @@
   XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:@"null"]);
 }
 
-- (void)testEventDetailURLForFileAccessEvent {
-  SNTFileAccessEvent *fae = [[SNTFileAccessEvent alloc] init];
+// - (void)testEventDetailURLForFileAccessEvent {
+//   SNTFileAccessEvent *fae = [[SNTFileAccessEvent alloc] init];
 
-  fae.ruleVersion = @"my_rv";
-  fae.ruleName = @"my_rn";
-  fae.fileSHA256 = @"my_fi";
-  fae.fileBundleID = @"s.n.t";
-  fae.cdhash = @"abc";
-  fae.teamID = @"SNT";
-  fae.signingID = @"SNT:s.n.t";
-  fae.accessedPath = @"my_ap";
-  fae.executingUser = @"my_un";
+//   fae.ruleVersion = @"my_rv";
+//   fae.ruleName = @"my_rn";
+//   fae.fileSHA256 = @"my_fi";
+//   fae.fileBundleID = @"s.n.t";
+//   fae.cdhash = @"abc";
+//   fae.teamID = @"SNT";
+//   fae.signingID = @"SNT:s.n.t";
+//   fae.accessedPath = @"my_ap";
+//   fae.executingUser = @"my_un";
 
-  NSString *url =
-    @"http://"
-    @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&"
-    @"fbid=%file_bundle_id%&ti=%team_id%&si=%signing_id%&ch=%cdhash%&"
-    @"ap=%accessed_path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
-  NSString *wantUrl = @"http://"
-                      @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&"
-                      @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
-                      @"ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+//   NSString *url =
+//     @"http://"
+//     @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&"
+//     @"fbid=%file_bundle_id%&ti=%team_id%&si=%signing_id%&ch=%cdhash%&"
+//     @"ap=%accessed_path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
+//   NSString *wantUrl = @"http://"
+//                       @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&"
+//                       @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+//                       @"ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
-  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
+//   NSURL *gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
 
-  XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
+//   XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
 
-  XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:nil]);
-  XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
-}
+//   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:nil]);
+//   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
+// }
 
 @end

--- a/Source/common/SNTBlockMessageTest.m
+++ b/Source/common/SNTBlockMessageTest.m
@@ -107,4 +107,17 @@
   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
 }
 
+- (void)testEventDetailURLMissingDetails {
+  SNTStoredEvent *se = [[SNTStoredEvent alloc] init];
+
+  se.fileSHA256 = @"my_fi";
+
+  NSString *url = @"http://localhost?fi=%file_identifier%";
+  NSString *wantUrl = @"http://localhost?fi=my_fi";
+
+  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
+
+  XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
+}
+
 @end

--- a/Source/common/SNTBlockMessageTest.m
+++ b/Source/common/SNTBlockMessageTest.m
@@ -44,13 +44,19 @@
 
   se.fileSHA256 = @"my_fi";
   se.executingUser = @"my_un";
+  se.fileBundleID = @"s.n.t";
+  se.cdhash = @"abc";
+  se.teamID = @"SNT";
+  se.signingID = @"SNT:s.n.t";
 
   NSString *url = @"http://"
                   @"localhost?fs=%file_sha%&fi=%file_identifier%&bfi=%bundle_or_file_identifier%&"
+                  @"fbid=%file_bundle_id%&ti=%team_id%&si=%signing_id%&ch=%cdhash%&"
                   @"un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
-  NSString *wantUrl =
-    @"http://"
-    @"localhost?fs=my_fi&fi=my_fi&bfi=my_fi&bfi=my_fi&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+  NSString *wantUrl = @"http://"
+                      @"localhost?fs=my_fi&fi=my_fi&bfi=my_fi&"
+                      @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+                      @"un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
   NSURL *gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
 
@@ -58,7 +64,9 @@
   se.fileBundleHash = @"my_fbh";
 
   wantUrl = @"http://"
-            @"localhost?fs=my_fbh&fi=my_fi&bfi=my_fbh&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+            @"localhost?fs=my_fbh&fi=my_fi&bfi=my_fbh&"
+            @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+            @"un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
   gotUrl = [SNTBlockMessage eventDetailURLForEvent:se customURL:url];
 
@@ -74,15 +82,22 @@
   fae.ruleVersion = @"my_rv";
   fae.ruleName = @"my_rn";
   fae.fileSHA256 = @"my_fi";
+  fae.fileBundleID = @"s.n.t";
+  fae.cdhash = @"abc";
+  fae.teamID = @"SNT";
+  fae.signingID = @"SNT:s.n.t";
   fae.accessedPath = @"my_ap";
   fae.executingUser = @"my_un";
 
-  NSString *url = @"http://"
-                  @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&ap=%accessed_"
-                  @"path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
-  NSString *wantUrl =
+  NSString *url =
     @"http://"
-    @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+    @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&"
+    @"fbid=%file_bundle_id%&ti=%team_id%&si=%signing_id%&ch=%cdhash%&"
+    @"ap=%accessed_path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
+  NSString *wantUrl = @"http://"
+                      @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&"
+                      @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+                      @"ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
   NSURL *gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
 

--- a/Source/common/SNTBlockMessageTest.m
+++ b/Source/common/SNTBlockMessageTest.m
@@ -76,35 +76,35 @@
   XCTAssertNil([SNTBlockMessage eventDetailURLForEvent:se customURL:@"null"]);
 }
 
-// - (void)testEventDetailURLForFileAccessEvent {
-//   SNTFileAccessEvent *fae = [[SNTFileAccessEvent alloc] init];
+- (void)testEventDetailURLForFileAccessEvent {
+  SNTFileAccessEvent *fae = [[SNTFileAccessEvent alloc] init];
 
-//   fae.ruleVersion = @"my_rv";
-//   fae.ruleName = @"my_rn";
-//   fae.fileSHA256 = @"my_fi";
-//   fae.fileBundleID = @"s.n.t";
-//   fae.cdhash = @"abc";
-//   fae.teamID = @"SNT";
-//   fae.signingID = @"SNT:s.n.t";
-//   fae.accessedPath = @"my_ap";
-//   fae.executingUser = @"my_un";
+  fae.ruleVersion = @"my_rv";
+  fae.ruleName = @"my_rn";
+  fae.fileSHA256 = @"my_fi";
+  fae.fileBundleID = @"s.n.t";
+  fae.cdhash = @"abc";
+  fae.teamID = @"SNT";
+  fae.signingID = @"SNT:s.n.t";
+  fae.accessedPath = @"my_ap";
+  fae.executingUser = @"my_un";
 
-//   NSString *url =
-//     @"http://"
-//     @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&"
-//     @"fbid=%file_bundle_id%&ti=%team_id%&si=%signing_id%&ch=%cdhash%&"
-//     @"ap=%accessed_path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
-//   NSString *wantUrl = @"http://"
-//                       @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&"
-//                       @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
-//                       @"ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
+  NSString *url =
+    @"http://"
+    @"localhost?rv=%rule_version%&rn=%rule_name%&fi=%file_identifier%&"
+    @"fbid=%file_bundle_id%&ti=%team_id%&si=%signing_id%&ch=%cdhash%&"
+    @"ap=%accessed_path%&un=%username%&mid=%machine_id%&hn=%hostname%&u=%uuid%&s=%serial%";
+  NSString *wantUrl = @"http://"
+                      @"localhost?rv=my_rv&rn=my_rn&fi=my_fi&"
+                      @"fbid=s.n.t&ti=SNT&si=SNT:s.n.t&ch=abc&"
+                      @"ap=my_ap&un=my_un&mid=my_mid&hn=my_hn&u=my_u&s=my_s";
 
-//   NSURL *gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
+  NSURL *gotUrl = [SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:url];
 
-//   XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
+  XCTAssertEqualObjects(gotUrl.absoluteString, wantUrl);
 
-//   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:nil]);
-//   XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
-// }
+  XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:nil]);
+  XCTAssertNil([SNTBlockMessage eventDetailURLForFileAccessEvent:fae customURL:@"null"]);
+}
 
 @end

--- a/Source/common/SNTFileAccessEvent.h
+++ b/Source/common/SNTFileAccessEvent.h
@@ -14,12 +14,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import <MOLCertificate/MOLCertificate.h>
+#import "Source/common/SNTStoredEvent.h"
 
 ///
 ///  Represents an event stored in the database.
 ///
-@interface SNTFileAccessEvent : NSObject <NSSecureCoding>
+@interface SNTFileAccessEvent : SNTStoredEvent <NSSecureCoding>
 
 ///
 /// The watched path that was accessed
@@ -33,55 +33,9 @@
 @property NSString *ruleName;
 
 ///
-/// The SHA256 of the process that accessed the path
-///
-@property NSString *fileSHA256;
-
-///
-/// The path of the process that accessed the watched path
-///
-@property NSString *filePath;
-
-///
 /// If the process is part of a bundle, the name of the application
 ///
 @property NSString *application;
-
-///
-/// If the executed file was signed, this is the Team ID if present in the signature information.
-///
-@property NSString *teamID;
-
-///
-/// If the executed file was signed, this is the Signing ID if present in the signature information.
-///
-@property NSString *signingID;
-
-///
-///  The user who executed the binary.
-///
-@property NSString *executingUser;
-
-///
-///  The process ID of the binary being executed.
-///
-@property NSNumber *pid;
-
-///
-///  The parent process ID of the binary being executed.
-///
-@property NSNumber *ppid;
-
-///
-///  The name of the parent process.
-///
-@property NSString *parentName;
-
-///
-/// If the executed file was signed, this is an NSArray of MOLCertificate's
-/// representing the signing chain.
-///
-@property NSArray<MOLCertificate *> *signingChain;
 
 ///
 /// A string representing the publisher based on the signingChain

--- a/Source/common/SNTFileAccessEvent.m
+++ b/Source/common/SNTFileAccessEvent.m
@@ -51,15 +51,7 @@
   ENCODE(accessedPath);
   ENCODE(ruleVersion);
   ENCODE(ruleName);
-  ENCODE(fileSHA256);
-  ENCODE(filePath);
   ENCODE(application);
-  ENCODE(teamID);
-  ENCODE(teamID);
-  ENCODE(pid);
-  ENCODE(ppid);
-  ENCODE(parentName);
-  ENCODE(signingChain);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
@@ -68,15 +60,7 @@
     DECODE(accessedPath, NSString);
     DECODE(ruleVersion, NSString);
     DECODE(ruleName, NSString);
-    DECODE(fileSHA256, NSString);
-    DECODE(filePath, NSString);
     DECODE(application, NSString);
-    DECODE(teamID, NSString);
-    DECODE(teamID, NSString);
-    DECODE(pid, NSNumber);
-    DECODE(ppid, NSNumber);
-    DECODE(parentName, NSString);
-    DECODEARRAY(signingChain, MOLCertificate);
   }
   return self;
 }


### PR DESCRIPTION
Add the following template keys to SNTBlockMessage:
* `%file_bundle_id%`  The bundle id of the binary, if any.
* `%team_id%` The Team ID if present in the signature information.
* `%signing_id%` The Signing ID if present in the signature information.
* `%cdhash%`  If signed, the CDHash.

Also refactor `SNTFileAccessEvent` slightly. Make it a subclass of `SNTStoredEvent` to avoid redefining common properties.