### PR TITLE
santad: Bump QoS of notify handling queue

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -91,8 +91,7 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
 
     _notifyQueue = dispatch_queue_create(
       "com.google.santa.daemon.notify_queue",
-      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL,
-                                              QOS_CLASS_DEFAULT, 0));
+      DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL);
   }
   return self;
 }

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -92,7 +92,7 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
     _notifyQueue = dispatch_queue_create(
       "com.google.santa.daemon.notify_queue",
       dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL,
-                                              QOS_CLASS_BACKGROUND, 0));
+                                              QOS_CLASS_DEFAULT, 0));
   }
   return self;
 }

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -89,9 +89,8 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
       dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL,
                                               QOS_CLASS_USER_INTERACTIVE, 0));
 
-    _notifyQueue = dispatch_queue_create(
-      "com.google.santa.daemon.notify_queue",
-      DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL);
+    _notifyQueue = dispatch_queue_create("com.google.santa.daemon.notify_queue",
+                                         DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL);
   }
   return self;
 }


### PR DESCRIPTION
The use of the background queue is a historical artifact from when Santa had its own kernel extension with separate in-kernel queues for processing AUTH & NOTIFY type events. With the move to ES and the larger number of event types that we now notify on, running at the background QoS carries a small risk that the thread processing these events is not given a chance to run often enough that the queue grows and increases memory usage.