### PR TITLE
Add necessary dep for SNTPolicyProcessorTest

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -218,6 +218,7 @@ santa_unit_test(
     srcs = ["SNTPolicyProcessorTest.mm"],
     deps = [
         ":SNTPolicyProcessor",
+        "//Source/common:SNTCachedDecision",
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTRule",
         "//Source/common:TestUtils",


### PR DESCRIPTION
This is to fix an issue with the dependencies for the SNTPolicyProcessor test.