### PR TITLE
Add metric for when the file on disk is not the file being evaluated

### DIFF
--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -657,6 +657,7 @@ objc_library(
     hdrs = ["EventProviders/EndpointSecurity/Message.h"],
     deps = [
         ":EndpointSecurityClient",
+        ":Metrics",
         ":WatchItemPolicy",
         "//Source/santad/ProcessTree:process_tree",
     ],

--- a/Source/santad/EventProviders/EndpointSecurity/Message.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+#include "Source/santad/Metrics.h"
 #include "Source/santad/ProcessTree/process_tree.h"
 
 namespace santa::santad::event_providers::endpoint_security {
@@ -53,12 +54,23 @@ class Message {
 
   std::string ParentProcessName() const;
 
+  void UpdateStatState(santa::santad::StatChangeStep step) const;
+
+  inline santa::santad::StatChangeStep StatChangeStep() const {
+    return stat_change_step_;
+  }
+  inline errno_t StatError() const { return stat_error_; }
+
  private:
   std::shared_ptr<EndpointSecurityAPI> esapi_;
   const es_message_t* es_msg_;
   std::optional<process_tree::ProcessToken> process_token_;
 
   std::string GetProcessName(pid_t pid) const;
+
+  mutable santa::santad::StatChangeStep stat_change_step_ =
+      santa::santad::StatChangeStep::kNoChange;
+  mutable errno_t stat_error_ = 0;
 };
 
 }  // namespace santa::santad::event_providers::endpoint_security

--- a/Source/santad/EventProviders/EndpointSecurity/Message.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.h
@@ -59,7 +59,7 @@ class Message {
   inline santa::santad::StatChangeStep StatChangeStep() const {
     return stat_change_step_;
   }
-  inline errno_t StatError() const { return stat_error_; }
+  inline StatResult StatError() const { return stat_result_; }
 
  private:
   std::shared_ptr<EndpointSecurityAPI> esapi_;
@@ -70,7 +70,8 @@ class Message {
 
   mutable santa::santad::StatChangeStep stat_change_step_ =
       santa::santad::StatChangeStep::kNoChange;
-  mutable errno_t stat_error_ = 0;
+  mutable santa::santad::StatResult stat_result_ =
+      santa::santad::StatResult::kOK;
 };
 
 }  // namespace santa::santad::event_providers::endpoint_security

--- a/Source/santad/EventProviders/EndpointSecurity/Message.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.mm
@@ -60,8 +60,7 @@ void Message::UpdateStatState(santa::santad::StatChangeStep step) const {
       stat_change_step_ == santa::santad::StatChangeStep::kNoChange &&
       // Note: The following checks are required due to tests that only
       // partially construct an es_message_t.
-      es_msg_->event.exec.target &&
-      es_msg_->event.exec.target->executable) {
+      es_msg_->event.exec.target && es_msg_->event.exec.target->executable) {
     struct stat &es_sb = es_msg_->event.exec.target->executable->stat;
     struct stat sb;
     errno = 0;

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -151,7 +151,8 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
     if ([self handleContextMessage:esMsg]) {
       int64_t processingEnd = clock_gettime_nsec_np(CLOCK_MONOTONIC);
       self->_metrics->SetEventMetrics(self->_processor, eventType, EventDisposition::kProcessed,
-                                      processingEnd - processingStart);
+                                      processingEnd - processingStart, esMsg.StatChangeStep(),
+                                      esMsg.StatError());
       return;
     }
 
@@ -160,12 +161,14 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
         recordEventMetrics:^(EventDisposition disposition) {
           int64_t processingEnd = clock_gettime_nsec_np(CLOCK_MONOTONIC);
           self->_metrics->SetEventMetrics(self->_processor, eventType, disposition,
-                                          processingEnd - processingStart);
+                                          processingEnd - processingStart, esMsg.StatChangeStep(),
+                                          esMsg.StatError());
         }];
     } else {
       int64_t processingEnd = clock_gettime_nsec_np(CLOCK_MONOTONIC);
       self->_metrics->SetEventMetrics(self->_processor, eventType, EventDisposition::kDropped,
-                                      processingEnd - processingStart);
+                                      processingEnd - processingStart, esMsg.StatChangeStep(),
+                                      esMsg.StatError());
     }
   });
 

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -57,10 +57,16 @@ enum class StatChangeStep {
   kCodesignValidation,
 };
 
+enum class StatResult {
+  kOK = 0,
+  kStatError,
+  kDevnoInodeMismatch,
+};
+
 using EventCountTuple = std::tuple<Processor, es_event_type_t, EventDisposition>;
 using EventTimesTuple = std::tuple<Processor, es_event_type_t>;
 using EventStatsTuple = std::tuple<Processor, es_event_type_t>;
-using EventStatChangeTuple = std::tuple<StatChangeStep, errno_t>;
+using EventStatChangeTuple = std::tuple<StatChangeStep, StatResult>;
 using FileAccessMetricsPolicyVersion = std::string;
 using FileAccessMetricsPolicyName = std::string;
 using FileAccessEventCountTuple =
@@ -92,7 +98,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
 
   void SetEventMetrics(Processor processor, es_event_type_t event_type,
                        EventDisposition disposition, int64_t nanos, StatChangeStep step,
-                       errno_t stat_error);
+                       StatResult stat_result);
 
   void SetRateLimitingMetrics(Processor processor, int64_t events_rate_limited_count);
 

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -54,6 +54,10 @@ static NSString *const kPseudoEventTypeGlobal = @"Global";
 static NSString *const kEventDispositionDropped = @"Dropped";
 static NSString *const kEventDispositionProcessed = @"Processed";
 
+static NSString *const kStatChangeStepNoChange = @"NoChange";
+static NSString *const kStatChangeStepMessageCreate = @"MessageCreate";
+static NSString *const kStatChangeStepCodesignValidation = @"CodesignValidation";
+
 // Compat values
 static NSString *const kFileAccessMetricStatusOK = @"OK";
 static NSString *const kFileAccessMetricStatusBlockedUser = @"BLOCKED_USER";
@@ -148,6 +152,18 @@ NSString *const FileAccessPolicyDecisionToString(FileAccessPolicyDecision decisi
   }
 }
 
+NSString *const StatChangeStepToString(StatChangeStep step) {
+  switch (step) {
+    case StatChangeStep::kNoChange: return kStatChangeStepNoChange;
+    case StatChangeStep::kMessageCreate: return kStatChangeStepMessageCreate;
+    case StatChangeStep::kCodesignValidation: return kStatChangeStepCodesignValidation;
+    default:
+      [NSException raise:@"Invalid stat change step"
+                  format:@"Unknown stat change step value: %d", static_cast<int>(step)];
+      return nil;
+  }
+}
+
 std::shared_ptr<Metrics> Metrics::Create(SNTMetricSet *metric_set, uint64_t interval) {
   dispatch_queue_t q = dispatch_queue_create("com.google.santa.santametricsservice.q",
                                              DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
@@ -181,9 +197,14 @@ std::shared_ptr<Metrics> Metrics::Create(SNTMetricSet *metric_set, uint64_t inte
                      fieldNames:@[ @"Processor", @"Event" ]
                        helpText:@"Count of the number of drops for each event"];
 
+  SNTMetricCounter *stat_change_counts =
+    [metric_set counterWithName:@"/santa/event_stat_change_count"
+                     fieldNames:@[ @"step", @"error" ]
+                       helpText:@"Count of times a stat info changed for a binary being evalauted"];
+
   std::shared_ptr<Metrics> metrics = std::make_shared<Metrics>(
     q, timer_source, interval, event_processing_times, event_counts, rate_limit_counts,
-    faa_event_counts, drop_counts, metric_set, ^(Metrics *metrics) {
+    faa_event_counts, drop_counts, stat_change_counts, metric_set, ^(Metrics *metrics) {
       SNTRegisterCoreMetrics();
       metrics->EstablishConnection();
     });
@@ -204,8 +225,8 @@ std::shared_ptr<Metrics> Metrics::Create(SNTMetricSet *metric_set, uint64_t inte
 Metrics::Metrics(dispatch_queue_t q, dispatch_source_t timer_source, uint64_t interval,
                  SNTMetricInt64Gauge *event_processing_times, SNTMetricCounter *event_counts,
                  SNTMetricCounter *rate_limit_counts, SNTMetricCounter *faa_event_counts,
-                 SNTMetricCounter *drop_counts, SNTMetricSet *metric_set,
-                 void (^run_on_first_start)(Metrics *))
+                 SNTMetricCounter *drop_counts, SNTMetricCounter *stat_change_counts,
+                 SNTMetricSet *metric_set, void (^run_on_first_start)(Metrics *))
     : q_(q),
       timer_source_(timer_source),
       interval_(interval),
@@ -214,6 +235,7 @@ Metrics::Metrics(dispatch_queue_t q, dispatch_source_t timer_source, uint64_t in
       rate_limit_counts_(rate_limit_counts),
       faa_event_counts_(faa_event_counts),
       drop_counts_(drop_counts),
+      stat_change_counts_(stat_change_counts),
       metric_set_(metric_set),
       run_on_first_start_(run_on_first_start) {
   SetInterval(interval_);
@@ -307,6 +329,15 @@ void Metrics::FlushMetrics() {
       }
     }
 
+    for (const auto &[key, count] : stat_change_cache_) {
+      if (count > 0) {
+        NSString *stepName = StatChangeStepToString(std::get<StatChangeStep>(key));
+        NSString *error = [@(std::get<errno_t>(key)) stringValue];
+
+        [stat_change_counts_ incrementBy:count forFieldValues:@[ stepName, error ]];
+      }
+    }
+
     // Reset the maps so the next cycle begins with a clean state
     // IMPORTANT: Do not reset drop_cache_, the sequence numbers must persist
     // for accurate accounting
@@ -314,6 +345,7 @@ void Metrics::FlushMetrics() {
     event_times_cache_ = {};
     rate_limit_counts_cache_ = {};
     faa_event_counts_cache_ = {};
+    stat_change_cache_ = {};
   });
 }
 
@@ -356,10 +388,12 @@ void Metrics::StopPoll() {
 }
 
 void Metrics::SetEventMetrics(Processor processor, es_event_type_t event_type,
-                              EventDisposition event_disposition, int64_t nanos) {
+                              EventDisposition event_disposition, int64_t nanos,
+                              StatChangeStep step, errno_t stat_error) {
   dispatch_sync(events_q_, ^{
     event_counts_cache_[EventCountTuple{processor, event_type, event_disposition}]++;
     event_times_cache_[EventTimesTuple{processor, event_type}] = nanos;
+    stat_change_cache_[EventStatChangeTuple{step, stat_error}]++;
   });
 }
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -256,9 +256,11 @@ static NSString *const kPrinterProxyPostMonterey =
   // TODO(markowsky): Maybe add a metric here for how many large executables we're seeing.
   // if (binInfo.fileSize > SomeUpperLimit) ...
 
-  SNTCachedDecision *cd = [self.policyProcessor
-           decisionForFileInfo:binInfo
-                 targetProcess:targetProc
+  SNTCachedDecision *cd = [self.policyProcessor decisionForFileInfo:binInfo
+    targetProcess:targetProc
+    preCodesignCheckCallback:^(void) {
+      esMsg.UpdateStatState(santa::santad::StatChangeStep::kCodesignValidation);
+    }
     entitlementsFilterCallback:^NSDictionary *(const char *teamID, NSDictionary *entitlements) {
       if (!entitlements) {
         return nil;

--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -51,6 +51,13 @@
                           (NSDictionary *_Nullable (^_Nonnull)(
                             const char *_Nullable teamID,
                             NSDictionary *_Nullable entitlements))entitlementsFilterCallback;
+- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
+                                     targetProcess:(nonnull const es_process_t *)targetProc
+                          preCodesignCheckCallback:(void (^_Nullable)(void))preCodesignCheckCallback
+                        entitlementsFilterCallback:
+                          (NSDictionary *_Nullable (^_Nonnull)(
+                            const char *_Nullable teamID,
+                            NSDictionary *_Nullable entitlements))entitlementsFilterCallback;
 
 ///
 ///  A wrapper for decisionForFileInfo:fileSHA256:certificateSHA256:. This method is slower as it


### PR DESCRIPTION
Adds a new metric that tracks cases where the file reported in EXEC events is not the same file currently on disk.

Test setup:
Create some binary named `t`. In one terminal, run the following to rapidly change `t` devno/inode pair:
```
cp t t1
cp t t2
while [[ true ]]; do rm ./t; cp ./t1 ./t; sleep 0; rm ./t; cp ./t2 ./t; sleep 0; done
```

In a second terminal, continuously execute the binary:
```
while [[ true ]]; do ./t > /dev/null; done
```

Sample `santactl metrics` output:
```
  Metric Name               | /santa/event_stat_change_count
  Description               | Count of times a stat info changed for a binary being evalauted
  Type                      | SNTMetricTypeCounter
  Field                     | step=MessageCreate,error=0
  Created                   | 2024-05-15T00:47:07.050Z
  Last Updated              | 2024-05-15T00:47:07.050Z
  Data                      | 70
  Field                     | step=MessageCreate,error=2
  Created                   | 2024-05-15T00:47:07.050Z
  Last Updated              | 2024-05-15T00:47:07.050Z
  Data                      | 62
  Field                     | step=NoChange,error=0
  Created                   | 2024-05-14T23:47:10.405Z
  Last Updated              | 2024-05-15T00:47:07.050Z
  Data                      | 1252973
  ```