### PR TITLE
santad: Drop QoS of notify handling queue

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -89,8 +89,10 @@ constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db"
       dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL,
                                               QOS_CLASS_USER_INTERACTIVE, 0));
 
-    _notifyQueue = dispatch_queue_create("com.google.santa.daemon.notify_queue",
-                                         DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL);
+    _notifyQueue = dispatch_queue_create(
+      "com.google.santa.daemon.notify_queue",
+      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL,
+                                              QOS_CLASS_UTILITY, 0));
   }
   return self;
 }


### PR DESCRIPTION
Bumping from BACKGROUND to DEFAULT had the desired impact of processing events faster and reducing memory usage but had a larger-than-expected increase in CPU usage. UTILITY is in the middle of these two and better fits the desired priority.