### PR TITLE
Fix NSSecureCoding adoption in SNTFileAccessEvent

### DIFF
--- a/Source/common/SNTFileAccessEvent.m
+++ b/Source/common/SNTFileAccessEvent.m
@@ -48,6 +48,7 @@
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
+  [super encodeWithCoder:coder];
   ENCODE(accessedPath);
   ENCODE(ruleVersion);
   ENCODE(ruleName);
@@ -55,7 +56,7 @@
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
-  self = [super init];
+  self = [super initWithCoder:decoder];
   if (self) {
     DECODE(accessedPath, NSString);
     DECODE(ruleVersion, NSString);


### PR DESCRIPTION
This prevented the FAA dialog popups from displaying.

Caused by: #1337 