### PR TITLE
santad: Add signal auth to tamper resistence.

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -173,6 +173,11 @@ es_auth_result_t ValidateLaunchctlExec(const Message &esMsg) {
   // Check for some allowed subcommands
   es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, 1);
   static const std::unordered_set<std::string> safe_commands{
+    "blame",
+    "help",
+    "hostinfo",
+    "list",
+    "plist",
     "print",
     "procinfo",
   };

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -173,13 +173,7 @@ es_auth_result_t ValidateLaunchctlExec(const Message &esMsg) {
   // Check for some allowed subcommands
   es_string_token_t arg = esApi->ExecArg(&esMsg->event.exec, 1);
   static const std::unordered_set<std::string> safe_commands{
-    "blame",
-    "help",
-    "hostinfo",
-    "list",
-    "plist",
-    "print",
-    "procinfo",
+    "blame", "help", "hostinfo", "list", "plist", "print", "procinfo",
   };
   if (safe_commands.find(std::string(arg.data, arg.length)) != safe_commands.end()) {
     return ES_AUTH_RESULT_ALLOW;

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -49,11 +49,8 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 - (void)testEnable {
   // Ensure the client subscribes to expected event types
   std::set<es_event_type_t> expectedEventSubs{
-    ES_EVENT_TYPE_AUTH_KEXTLOAD,
-    ES_EVENT_TYPE_AUTH_SIGNAL,
-    ES_EVENT_TYPE_AUTH_EXEC,
-    ES_EVENT_TYPE_AUTH_UNLINK,
-    ES_EVENT_TYPE_AUTH_RENAME,
+    ES_EVENT_TYPE_AUTH_KEXTLOAD, ES_EVENT_TYPE_AUTH_SIGNAL, ES_EVENT_TYPE_AUTH_EXEC,
+    ES_EVENT_TYPE_AUTH_UNLINK,   ES_EVENT_TYPE_AUTH_RENAME,
   };
 
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
@@ -248,7 +245,9 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 
     for (const auto &kv : pidsToResult) {
       Message msg(mockESApi, &esMsg);
-      esMsg.event.signal.target->audit_token = MakeAuditToken(kv.first.first, 42);
+      es_process_t target_proc = MakeESProcess(&file);
+      target_proc.audit_token = MakeAuditToken(kv.first.first, 42);
+      esMsg.event.signal.target = &target_proc;
       esMsg.process->audit_token = MakeAuditToken(kv.first.second, 42);
 
       [mockTamperClient

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -51,6 +51,7 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   std::set<es_event_type_t> expectedEventSubs{
     ES_EVENT_TYPE_AUTH_KEXTLOAD,
     ES_EVENT_TYPE_AUTH_SIGNAL,
+    ES_EVENT_TYPE_AUTH_EXEC,
     ES_EVENT_TYPE_AUTH_UNLINK,
     ES_EVENT_TYPE_AUTH_RENAME,
   };
@@ -71,6 +72,8 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   // Setup mocks to handle muting the rules db and events db
   EXPECT_CALL(*mockESApi, MuteTargetPath(testing::_, testing::_, WatchItemPathType::kLiteral))
     .WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*mockESApi, MuteTargetPath(testing::_, testing::_, WatchItemPathType::kPrefix))
+    .WillRepeatedly(testing::Return(true));
 
   SNTEndpointSecurityTamperResistance *tamperClient =
     [[SNTEndpointSecurityTamperResistance alloc] initWithESAPI:mockESApi
@@ -87,7 +90,7 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 - (void)testHandleMessage {
   es_file_t file = MakeESFile("foo");
   es_process_t proc = MakeESProcess(&file);
-  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_EXEC, &proc, ActionType::Auth);
+  es_message_t esMsg = MakeESMessage(ES_EVENT_TYPE_AUTH_LINK, &proc, ActionType::Auth);
 
   es_file_t fileEventsDB = MakeESFile(kEventsDBPath.data());
   es_file_t fileRulesDB = MakeESFile(kRulesDBPath.data());
@@ -105,6 +108,12 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   std::map<es_string_token_t *, es_auth_result_t> kextIdToResult{
     {&santaTok, ES_AUTH_RESULT_DENY},
     {&benignTok, ES_AUTH_RESULT_ALLOW},
+  };
+
+  std::map<std::pair<pid_t, pid_t>, es_auth_result_t> pidsToResult{
+    {{getpid(), 31838}, ES_AUTH_RESULT_DENY},
+    {{getpid(), 1}, ES_AUTH_RESULT_ALLOW},
+    {{435, 98381}, ES_AUTH_RESULT_ALLOW},
   };
 
   dispatch_semaphore_t semaMetrics = dispatch_semaphore_create(0);
@@ -237,9 +246,10 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   {
     esMsg.event_type = ES_EVENT_TYPE_AUTH_SIGNAL;
 
-    for (const auto &kv : kextIdToResult) {
+    for (const auto &kv : pidsToResult) {
       Message msg(mockESApi, &esMsg);
-      esMsg.event.kextload.identifier = *kv.first;
+      esMsg.event.signal.target->audit_token = MakeAuditToken(kv.first.first, 42);
+      esMsg.process->audit_token = MakeAuditToken(kv.first.second, 42);
 
       [mockTamperClient
              handleMessage:std::move(msg)


### PR DESCRIPTION
Root users can currently kill the `com.google.santa.daemon` process. It will be immediately restarted by sysextd but this opens a very brief window where protection is lost. Hooking `ES_EVENT_TYPE_AUTH_SIGNAL` and blocking all signals to the santad process prevents this and it doesn't interfere with upgrades.