### PR TITLE
Update check-markdown workflow to only check modified files 

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -13,5 +13,7 @@ jobs:
         uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # ratchet:actions/checkout@master
       - name: "Check for deadlinks"
         uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # ratchet:gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          check-modified-files-only: 'yes'
       - name: "Check for trailing whitespace and newlines"
         run: "! git grep -EIn $'[ \t]+$' -- ':(exclude)*.patch'"

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -5,6 +5,7 @@ parent: Development
 
 # Building
 
+<!-- markdown-link-check-disable-next-line -->
 Santa uses [Bazel](https://bazel.build) for building, testing and releases. The
 `main` branch on GitHub is the source-of-truth with features developed in
 personal forks.


### PR DESCRIPTION
* Update check-markdown workflow to only check modified files 
* Ignore bazel.build