### PR TITLE
Add a Signing ID Format Helper

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -151,6 +151,17 @@ objc_library(
 )
 
 objc_library(
+    name = "SigningIDHelpers",
+    srcs = ["SigningIDHelpers.m"],
+    hdrs = ["SigningIDHelpers.h"],
+    deps = [
+        "@MOLCodesignChecker",
+	":SNTLogging",
+    ],
+)
+
+
+objc_library(
     name = "SNTBlockMessage",
     srcs = ["SNTBlockMessage.m"],
     hdrs = ["SNTBlockMessage.h"],

--- a/Source/common/SigningIDHelpers.h
+++ b/Source/common/SigningIDHelpers.h
@@ -1,4 +1,4 @@
-/// Copyright 2023 Google LLC
+/// Copyright 2024 Google LLC
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ __BEGIN_DECLS
 
   @param csc A MOLCodesignChecker instance
 
-  @return An NSString formated as teamID:signingID or "" if there isn't a valid signing ID.
+  @return An NSString formated as teamID:signingID or nil if there isn't a valid signing ID.
 */
 NSString *FormatSigningID(MOLCodesignChecker *csc);
 

--- a/Source/common/SigningIDHelpers.h
+++ b/Source/common/SigningIDHelpers.h
@@ -1,0 +1,30 @@
+/// Copyright 2023 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <MOLCodesignChecker/MOLCodesignChecker.h>
+
+__BEGIN_DECLS
+
+/**
+  Return a string representing normalized SigningID (prefixed with TeamID and a
+  colon).
+
+  @param csc A MOLCodesignChecker instance
+
+  @return An NSString formated as teamID:signingID or "" if there isn't a valid signing ID.
+*/
+NSString *FormatSigningID(MOLCodesignChecker *csc);
+
+__END_DECLS

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -16,7 +16,7 @@
 #import "Source/common/SNTLogging.h"
 
 NSString *FormatSigningID(MOLCodesignChecker *csc) {
-  if (csc == nil || !csc.signingID) {
+  if (!csc.signingID.length) {
     LOGD(@"unable to format signing ID as it's missing");
     return nil;
   }

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -21,7 +21,7 @@ NSString *FormatSigningID(MOLCodesignChecker *csc) {
     return nil;
   }
 
-  if (csc.teamID == nil) {
+  if (!csc.teamID.length) {
     if (csc.platformBinary) {
       return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
     } else {

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -1,0 +1,31 @@
+/// Copyright 2024 Google LLC
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#import "Source/common/SNTLogging.h"
+#import "Source/common/SigningIDHelpers.h"
+
+NSString *FormatSigningID(MOLCodesignChecker * csc) {
+      if (csc.signingID) {
+      	if (csc.platformBinary) {
+        	return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
+      	} else if (csc.teamID) {
+        	return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
+	} else {
+		LOGE(@"unable to format signing ID missing team ID");
+		return @"";
+	}
+      }
+      LOGE(@"unable to format signing ID as it's missing");
+      return @"";
+}

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -16,16 +16,19 @@
 #import "Source/common/SNTLogging.h"
 
 NSString *FormatSigningID(MOLCodesignChecker *csc) {
-  if (csc.signingID) {
-    if (csc.platformBinary) {
-      return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
-    } else if (csc.teamID) {
-      return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
-    } else {
-      LOGD(@"unable to format signing ID missing team ID for non-platform binary");
-      return nil;
-    }
-  }
-  LOGD(@"unable to format signing ID as it's missing");
-  return nil;
+	if (csc == nil || !csc.signingID) {
+ 		LOGD(@"unable to format signing ID as it's missing");
+		return nil;
+	}
+
+	if (csc.teamID == nil) {
+		if (csc.platformBinary) {
+			return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
+		} else {
+			LOGD(@"unable to format signing ID missing team ID for non-platform binary");
+			return nil;
+		}
+	}
+
+    return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
 }

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -16,19 +16,19 @@
 #import "Source/common/SNTLogging.h"
 
 NSString *FormatSigningID(MOLCodesignChecker *csc) {
-	if (csc == nil || !csc.signingID) {
- 		LOGD(@"unable to format signing ID as it's missing");
-		return nil;
-	}
+  if (csc == nil || !csc.signingID) {
+    LOGD(@"unable to format signing ID as it's missing");
+    return nil;
+  }
 
-	if (csc.teamID == nil) {
-		if (csc.platformBinary) {
-			return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
-		} else {
-			LOGD(@"unable to format signing ID missing team ID for non-platform binary");
-			return nil;
-		}
-	}
+  if (csc.teamID == nil) {
+    if (csc.platformBinary) {
+      return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
+    } else {
+      LOGD(@"unable to format signing ID missing team ID for non-platform binary");
+      return nil;
+    }
+  }
 
-    return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
+  return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
 }

--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -12,20 +12,20 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-#import "Source/common/SNTLogging.h"
 #import "Source/common/SigningIDHelpers.h"
+#import "Source/common/SNTLogging.h"
 
-NSString *FormatSigningID(MOLCodesignChecker * csc) {
-      if (csc.signingID) {
-      	if (csc.platformBinary) {
-        	return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
-      	} else if (csc.teamID) {
-        	return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
-	} else {
-		LOGE(@"unable to format signing ID missing team ID");
-		return @"";
-	}
-      }
-      LOGE(@"unable to format signing ID as it's missing");
-      return @"";
+NSString *FormatSigningID(MOLCodesignChecker *csc) {
+  if (csc.signingID) {
+    if (csc.platformBinary) {
+      return [NSString stringWithFormat:@"%@:%@", @"platform", csc.signingID];
+    } else if (csc.teamID) {
+      return [NSString stringWithFormat:@"%@:%@", csc.teamID, csc.signingID];
+    } else {
+      LOGD(@"unable to format signing ID missing team ID for non-platform binary");
+      return nil;
+    }
+  }
+  LOGD(@"unable to format signing ID as it's missing");
+  return nil;
 }

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -19,6 +19,7 @@ objc_library(
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTXPCBundleServiceInterface",
         "//Source/common:SNTXPCNotifierInterface",
+        "//Source/common:SigningIDHelpers",
         "@FMDB",
         "@MOLCodesignChecker",
         "@MOLXPCConnection",

--- a/Source/santabundleservice/SNTBundleService.m
+++ b/Source/santabundleservice/SNTBundleService.m
@@ -25,6 +25,7 @@
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTXPCNotifierInterface.h"
+#import "Source/common/SigningIDHelpers.h"
 
 @interface SNTBundleService ()
 @property MOLXPCConnection *notifierConnection;
@@ -228,13 +229,7 @@
       se.signingChain = cs.certificates;
       se.cdhash = cs.cdhash;
       se.teamID = cs.teamID;
-      if (cs.signingID) {
-        if (cs.teamID) {
-          se.signingID = [NSString stringWithFormat:@"%@:%@", cs.teamID, cs.signingID];
-        } else if (cs.platformBinary) {
-          se.signingID = [NSString stringWithFormat:@"platform:%@", cs.signingID];
-        }
-      }
+      se.signingID = FormatSigningID(cs);
 
       dispatch_sync(dispatch_get_main_queue(), ^{
         relatedEvents[se.fileSHA256] = se;

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -76,6 +76,7 @@ objc_library(
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SNTXPCSyncServiceInterface",
         "//Source/common:SNTXPCUnprivilegedControlInterface",
+        "//Source/common:SigningIDHelpers",
         "//Source/santasyncservice:sync_lib",
         "@FMDB",
         "@MOLCertificate",

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -122,6 +122,7 @@ santa_unit_test(
         "//Source/common:SNTStoredEvent",
         "//Source/common:SNTXPCBundleServiceInterface",
         "//Source/common:SNTXPCControlInterface",
+        "//Source/common:SigningIDHelpers",
         "@MOLCertificate",
         "@MOLCodesignChecker",
         "@MOLXPCConnection",

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -23,10 +23,10 @@
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
-#import "Source/common/SigningIDHelpers.h"
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTXPCBundleServiceInterface.h"
 #import "Source/common/SNTXPCControlInterface.h"
+#import "Source/common/SigningIDHelpers.h"
 #import "Source/santactl/SNTCommand.h"
 #import "Source/santactl/SNTCommandController.h"
 
@@ -383,9 +383,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
 
     NSString *cdhash = csc.cdhash;
     NSString *teamID = csc.teamID;
-    NSString *identifier = csc.signingID;
     NSString *signingID = FormatSigningID(csc);
-    
+
     struct RuleIdentifiers identifiers = {
       .cdhash = cdhash,
       .binarySHA256 = fileInfo.SHA256,
@@ -516,15 +515,7 @@ REGISTER_COMMAND_NAME(@"fileinfo")
   return ^id(SNTCommandFileInfo *cmd, SNTFileInfo *fileInfo) {
     MOLCodesignChecker *csc = [fileInfo codesignCheckerWithError:NULL];
 
-    NSString *identifier = csc.signingID;
-    NSString *teamID = csc.teamID;
-    if (!identifier) return nil;
-    if (teamID) {
-      return [NSString stringWithFormat:@"%@:%@", teamID, identifier];
-    } else if (csc.platformBinary) {
-      return [NSString stringWithFormat:@"platform:%@", identifier];
-    }
-    return nil;
+    return FormatSigningID(csc);
   };
 }
 

--- a/Source/santactl/Commands/SNTCommandFileInfo.m
+++ b/Source/santactl/Commands/SNTCommandFileInfo.m
@@ -23,6 +23,7 @@
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTRule.h"
 #import "Source/common/SNTRuleIdentifiers.h"
+#import "Source/common/SigningIDHelpers.h"
 #import "Source/common/SNTStoredEvent.h"
 #import "Source/common/SNTXPCBundleServiceInterface.h"
 #import "Source/common/SNTXPCControlInterface.h"
@@ -383,16 +384,8 @@ REGISTER_COMMAND_NAME(@"fileinfo")
     NSString *cdhash = csc.cdhash;
     NSString *teamID = csc.teamID;
     NSString *identifier = csc.signingID;
-
-    NSString *signingID;
-    if (identifier) {
-      if (teamID) {
-        signingID = [NSString stringWithFormat:@"%@:%@", teamID, identifier];
-      } else if (csc.platformBinary) {
-        signingID = [NSString stringWithFormat:@"platform:%@", identifier];
-      }
-    }
-
+    NSString *signingID = FormatSigningID(csc);
+    
     struct RuleIdentifiers identifiers = {
       .cdhash = cdhash,
       .binarySHA256 = fileInfo.SHA256,

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -205,6 +205,7 @@ objc_library(
         "//Source/common:SNTLogging",
         "//Source/common:SNTRule",
         "//Source/common:SNTRuleIdentifiers",
+        "//Source/common:SigningIDHelpers",
         "@FMDB",
         "@MOLCertificate",
         "@MOLCodesignChecker",

--- a/Source/santad/SNTPolicyProcessor.mm
+++ b/Source/santad/SNTPolicyProcessor.mm
@@ -26,6 +26,7 @@
 #import "Source/common/SNTFileInfo.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTRule.h"
+#import "Source/common/SigningIDHelpers.h"
 #import "Source/santad/DataLayer/SNTRuleTable.h"
 #include "absl/container/flat_hash_map.h"
 
@@ -136,6 +137,11 @@ static void UpdateCachedDecisionSigningInfo(
   // Check if we need to get teamID from code signing.
   if (!cd.teamID) {
     cd.teamID = csInfo.teamID;
+  }
+
+  // Check if we need to get signing ID from code signing.
+  if (!cd.signingID) {
+    cd.signingID = FormatSigningID(csInfo);
   }
 
   // Ensure that if no teamID exists that the signing info confirms it is a


### PR DESCRIPTION
This PR adds a helper function to format the Signing IDs in Santa and to ensure they're always handled and formatted the same way.

It's marked draft until we're sure that it's used everywhere it should be and that folks are happy with it.