### PR TITLE
docs(ISSUE-1325): Add Identifier Conventions

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -34,6 +34,16 @@ code should adhere to either the
 [Google Objective-C Style Guide](https://google.github.io/styleguide/objcguide.xml)
 or the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 
+### Identifier Conventions
+All submissions related to the use of different identifiers should adhere to the following conventions.
+
+| Identifier | Notes | Example |
+| -------- | ------- | ------- |
+| SHA-256  | lowercase |  `801d1dd8bc78984c126a269aca053642d16eef4389dfdc8df575af929fdcf279` |
+| CDHash | lowercase | `2d1cff4b1080058e7e5913e5a3398bcd0199b6a4` | 
+| TeamID | uppercase | `43AQ936H96` |
+| Signing ID | case insensitive | `EQHXZ8M8AV:com.google.Chrome` |
+
 ### The small print
 Contributions made by corporations are covered by a different agreement than
 the one above, the [Software Grant and Corporate Contributor License Agreement](https://developers.google.com/open-source/cla/corporate).


### PR DESCRIPTION
**What does this change?**

ISSUE-1325 ( #1325 ) identified that Identifier conventions were not documented.  This change modifies the `contributing.md` file to include the following information

-----

### Identifier Conventions
All submissions related to the use of different identifiers should adhere to the following conventions.

| Identifier | Notes | Example |
| -------- | ------- | ------- |
| SHA-256  | lowercase |  `801d1dd8bc78984c126a269aca053642d16eef4389dfdc8df575af929fdcf279` |
| CDHash | lowercase | `2d1cff4b1080058e7e5913e5a3398bcd0199b6a4` | 
| TeamID | uppercase | `43AQ936H96` |
| Signing ID | case insensitive | `EQHXZ8M8AV:com.google.Chrome` |


