### PR TITLE
Add tests to ensure EventTypeToString handles all subscriptions

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -81,6 +81,10 @@ class MockAuthResultCache : public AuthResultCache {
 
   [authClient enable];
 
+  for (const auto &event : expectedEventSubs) {
+    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+  }
+
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -507,6 +507,10 @@ class MockAuthResultCache : public AuthResultCache {
 
   [deviceClient enable];
 
+  for (const auto &event : expectedEventSubs) {
+    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+  }
+
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -753,6 +753,10 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
 
   [fileAccessClient enable];
 
+  for (const auto &event : expectedEventSubs) {
+    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+  }
+
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -100,6 +100,10 @@ class MockLogger : public Logger {
 
   [recorderClient enable];
 
+  for (const auto &event : expectedEventSubs) {
+    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+  }
+
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
 }
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -80,6 +80,10 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 
   [mockTamperClient enable];
 
+  for (const auto &event : expectedEventSubs) {
+    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+  }
+
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());
   [mockTamperClient stopMocking];
 }

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -62,6 +62,8 @@ using FileAccessEventCountTuple =
   std::tuple<FileAccessMetricsPolicyVersion, FileAccessMetricsPolicyName, FileAccessMetricStatus,
              es_event_type_t, FileAccessPolicyDecision>;
 
+NSString *const EventTypeToString(es_event_type_t eventType);
+
 class Metrics : public std::enable_shared_from_this<Metrics> {
  public:
   static std::shared_ptr<Metrics> Create(SNTMetricSet *metric_set, uint64_t interval);


### PR DESCRIPTION
Regression tests for latent issues that can happen when adding subscriptions for new event types.