### PR TITLE
Drop macos 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3

--- a/Source/common/Platform.h
+++ b/Source/common/Platform.h
@@ -17,13 +17,6 @@
 
 #include <Availability.h>
 
-#if defined(MAC_OS_VERSION_12_0) && \
-    MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_12_0
-#define HAVE_MACOS_12 1
-#else
-#define HAVE_MACOS_12 0
-#endif
-
 #if defined(MAC_OS_VERSION_13_0) && \
     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_13_0
 #define HAVE_MACOS_13 1

--- a/Source/common/Platform.h
+++ b/Source/common/Platform.h
@@ -31,4 +31,11 @@
 #define HAVE_MACOS_14 0
 #endif
 
+#if defined(MAC_OS_VERSION_15_0) && \
+    MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_15_0
+#define HAVE_MACOS_15 1
+#else
+#define HAVE_MACOS_15 0
+#endif
+
 #endif

--- a/Source/common/SNTMetricSet.m
+++ b/Source/common/SNTMetricSet.m
@@ -639,20 +639,9 @@ NSString *SNTMetricStringFromMetricFormatType(SNTMetricFormatType format) {
 NSDictionary *SNTMetricConvertDatesToISO8601Strings(NSDictionary *metrics) {
   NSMutableDictionary *mutableMetrics = [metrics mutableCopy];
 
-  id formatter;
-
-  if (@available(macOS 10.13, *)) {
-    NSISO8601DateFormatter *isoFormatter = [[NSISO8601DateFormatter alloc] init];
-
-    isoFormatter.formatOptions =
-      NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
-    formatter = isoFormatter;
-  } else {
-    NSDateFormatter *localFormatter = [[NSDateFormatter alloc] init];
-    [localFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
-    [localFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-    formatter = localFormatter;
-  }
+  NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
+  formatter.formatOptions =
+    NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
 
   for (NSString *metricName in mutableMetrics[@"metrics"]) {
     NSMutableDictionary *metric = mutableMetrics[@"metrics"][metricName];

--- a/Source/common/TestUtils.mm
+++ b/Source/common/TestUtils.mm
@@ -117,21 +117,27 @@ void SleepMS(long ms) {
 }
 
 uint32_t MaxSupportedESMessageVersionForCurrentOS() {
-  // Notes:
-  //   1. ES message v3 was only in betas.
-  //   2. Message v7 appeared in macOS 13.3, v8 in macOS 15, but features from
-  //      those versions are not currently used. Leaving off support here so as
-  //      to not require adding unnecessary test JSON files.
+  // Note 1: This function only returns a subset of versions. This is due to the
+  // minimum supported OS build version as well as features in latest versions
+  // not currently being used. Capping the max means unnecessary duuplicate test
+  // JSON files are not needed.
+  //
+  // Note 2: The following table maps ES message versions to lmin macOS version:
+  //   ES Version | macOS Version
+  //            1 | 10.15.0
+  //            2 | 10.15.4
+  //            3 | Only in a beta
+  //            4 | 11.0
+  //            5 | 12.3
+  //            6 | 13.0
+  //            7 | 14.0
+  //            8 | 15.0
   if (@available(macOS 13.0, *)) {
     return 6;
   } else if (@available(macOS 12.3, *)) {
     return 5;
-  } else if (@available(macOS 11.0, *)) {
-    return 4;
-  } else if (@available(macOS 10.15.4, *)) {
-    return 2;
   } else {
-    return 1;
+    return 4;
   }
 }
 
@@ -250,7 +256,6 @@ uint32_t MinSupportedESMessageVersion(es_event_type_t event_type) {
     case ES_EVENT_TYPE_NOTIFY_GET_TASK_READ:
     case ES_EVENT_TYPE_NOTIFY_GET_TASK_INSPECT: return 4;
 
-#if HAVE_MACOS_12
     // The following events are available beginning in macOS 12.0
     case ES_EVENT_TYPE_NOTIFY_SETUID:
     case ES_EVENT_TYPE_NOTIFY_SETGID:
@@ -260,7 +265,6 @@ uint32_t MinSupportedESMessageVersion(es_event_type_t event_type) {
     case ES_EVENT_TYPE_NOTIFY_SETREGID:
     case ES_EVENT_TYPE_AUTH_COPYFILE:
     case ES_EVENT_TYPE_NOTIFY_COPYFILE: return 4;
-#endif
 
 #if HAVE_MACOS_13
     // The following events are available beginning in macOS 13.0
@@ -303,6 +307,10 @@ uint32_t MinSupportedESMessageVersion(es_event_type_t event_type) {
     case ES_EVENT_TYPE_NOTIFY_OD_DELETE_USER:
     case ES_EVENT_TYPE_NOTIFY_OD_DELETE_GROUP:
     case ES_EVENT_TYPE_NOTIFY_XPC_CONNECT: return 7;
+#endif
+
+#if HAVE_MACOS_15
+    case ES_EVENT_TYPE_NOTIFY_GATEKEEPER_USER_OVERRIDE: return 8;
 #endif
 
     default: return UINT32_MAX;

--- a/Source/gui/BUILD
+++ b/Source/gui/BUILD
@@ -119,7 +119,7 @@ macos_application(
         "//conditions:default": None,
     }),
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/gui/main.m
+++ b/Source/gui/main.m
@@ -28,24 +28,22 @@
 
 - (OSSystemExtensionReplacementAction)request:(OSSystemExtensionRequest *)request
                   actionForReplacingExtension:(OSSystemExtensionProperties *)old
-                                withExtension:
-                                  (OSSystemExtensionProperties *)new API_AVAILABLE(macos(10.15)) {
+                                withExtension:(OSSystemExtensionProperties *)new {
   NSLog(@"SystemExtension \"%@\" request for replacement", request.identifier);
   return OSSystemExtensionReplacementActionReplace;
 }
 
-- (void)requestNeedsUserApproval:(OSSystemExtensionRequest *)request API_AVAILABLE(macos(10.15)) {
+- (void)requestNeedsUserApproval:(OSSystemExtensionRequest *)request {
   NSLog(@"SystemExtension \"%@\" request needs user approval", request.identifier);
 }
 
-- (void)request:(OSSystemExtensionRequest *)request
-  didFailWithError:(NSError *)error API_AVAILABLE(macos(10.15)) {
+- (void)request:(OSSystemExtensionRequest *)request didFailWithError:(NSError *)error {
   NSLog(@"SystemExtension \"%@\" request did fail: %@", request.identifier, error);
   exit((int)error.code);
 }
 
 - (void)request:(OSSystemExtensionRequest *)request
-  didFinishWithResult:(OSSystemExtensionRequestResult)result API_AVAILABLE(macos(10.15)) {
+  didFinishWithResult:(OSSystemExtensionRequestResult)result {
   NSLog(@"SystemExtension \"%@\" request did finish: %ld", request.identifier, (long)result);
   exit(0);
 }

--- a/Source/santabundleservice/BUILD
+++ b/Source/santabundleservice/BUILD
@@ -35,7 +35,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/santactl/BUILD
+++ b/Source/santactl/BUILD
@@ -94,7 +94,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -838,7 +838,7 @@ macos_bundle(
     }),
     infoplists = ["Info.plist"],
     linkopts = ["-execute"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:daemon_dev",
@@ -929,7 +929,6 @@ santa_unit_test(
 santa_unit_test(
     name = "SantadTest",
     srcs = ["SantadTest.mm"],
-    minimum_os_version = "11.0",
     sdk_dylibs = [
         "bsm",
         "EndpointSecurity",
@@ -965,7 +964,6 @@ santa_unit_test(
     srcs = [
         "SNTApplicationCoreMetricsTest.mm",
     ],
-    minimum_os_version = "11.0",
     deps = [
         ":SNTApplicationCoreMetrics",
         "//Source/common:SNTCommonEnums",

--- a/Source/santad/DataLayer/SNTRuleTable.m
+++ b/Source/santad/DataLayer/SNTRuleTable.m
@@ -33,13 +33,7 @@ static const int64_t kTransitiveRuleCullingThreshold = 500000;
 // Consider transitive rules out of date if they haven't been used in six months.
 static const NSUInteger kTransitiveRuleExpirationSeconds = 6 * 30 * 24 * 3600;
 
-static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABLE(macos(12.0)) {
-  // Note: This function uses API introduced in macOS 12, but we want to continue to support
-  // building in older environments. API Availability checks do not help for this use case,
-  // instead we use the following preprocessor macros to conditionally compile these API. The
-  // drawback here is that if a pre-macOS 12 SDK is used to build Santa and it is then deployed
-  // on macOS 12 or later, the dynamic mute set will not be computed.
-#if HAVE_MACOS_12
+static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) {
   // Create a temporary ES client in order to grab the default set of muted paths.
   // TODO(mlw): Reorganize this code so that a temporary ES client doesn't need to be created
   es_client_t *client = NULL;
@@ -69,7 +63,6 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
 
   es_release_muted_paths(mps);
   es_delete_client(client);
-#endif
 }
 
 @interface SNTRuleTable ()
@@ -125,10 +118,8 @@ static void addPathsFromDefaultMuteSet(NSMutableSet *criticalPaths) API_AVAILABL
     NSMutableSet *superSet = [NSMutableSet setWithSet:fallbackDefaultMuteSet];
     [superSet unionSet:santaDefinedCriticalPaths];
 
-    if (@available(macOS 12.0, *)) {
-      // Attempt to add the real default mute set
-      addPathsFromDefaultMuteSet(superSet);
-    }
+    // Attempt to add the real default mute set
+    addPathsFromDefaultMuteSet(superSet);
 
     criticalPaths = [superSet allObjects];
   });

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -156,19 +156,11 @@ es_string_token_t EndpointSecurityAPI::ExecEnv(const es_event_exec_t *event, uin
 }
 
 uint32_t EndpointSecurityAPI::ExecFDCount(const es_event_exec_t *event) {
-  if (@available(macOS 11.0, *)) {
-    return es_exec_fd_count(event);
-  } else {
-    return 0;
-  }
+  return es_exec_fd_count(event);
 }
 
 const es_fd_t *EndpointSecurityAPI::ExecFD(const es_event_exec_t *event, uint32_t index) {
-  if (@available(macOS 11.0, *)) {
-    return es_exec_fd(event, index);
-  } else {
-    return NULL;
-  }
+  return es_exec_fd(event, index);
 }
 
 }  // namespace santa::santad::event_providers::endpoint_security

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -834,16 +834,11 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
 
 - (void)enable {
   std::set<es_event_type_t> events = {
-    ES_EVENT_TYPE_AUTH_CLONE,    ES_EVENT_TYPE_AUTH_CREATE, ES_EVENT_TYPE_AUTH_EXCHANGEDATA,
-    ES_EVENT_TYPE_AUTH_LINK,     ES_EVENT_TYPE_AUTH_OPEN,   ES_EVENT_TYPE_AUTH_RENAME,
-    ES_EVENT_TYPE_AUTH_TRUNCATE, ES_EVENT_TYPE_AUTH_UNLINK, ES_EVENT_TYPE_NOTIFY_EXIT,
+    ES_EVENT_TYPE_AUTH_CLONE,        ES_EVENT_TYPE_AUTH_COPYFILE, ES_EVENT_TYPE_AUTH_CREATE,
+    ES_EVENT_TYPE_AUTH_EXCHANGEDATA, ES_EVENT_TYPE_AUTH_LINK,     ES_EVENT_TYPE_AUTH_OPEN,
+    ES_EVENT_TYPE_AUTH_RENAME,       ES_EVENT_TYPE_AUTH_TRUNCATE, ES_EVENT_TYPE_AUTH_UNLINK,
+    ES_EVENT_TYPE_NOTIFY_EXIT,
   };
-
-#if HAVE_MACOS_12
-  if (@available(macOS 12.0, *)) {
-    events.insert(ES_EVENT_TYPE_AUTH_COPYFILE);
-  }
-#endif
 
   if (!self.isSubscribed) {
     if ([super subscribe:events]) {

--- a/Source/santad/SNTApplicationCoreMetricsTest.mm
+++ b/Source/santad/SNTApplicationCoreMetricsTest.mm
@@ -89,11 +89,8 @@
   NSString *shortOSVersion = [SNTSystemInfo osVersion];
 
   NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
-
-  if (@available(macOS 10.13, *)) {
-    formatter.formatOptions =
-      NSISO8601DateFormatWithFractionalSeconds | NSISO8601DateFormatWithInternetDateTime;
-  }
+  formatter.formatOptions =
+    NSISO8601DateFormatWithFractionalSeconds | NSISO8601DateFormatWithInternetDateTime;
 
   NSDate *fixedDate = [formatter dateFromString:@"2021-09-16T21:07:34.826Z"];
   NSString *hostname = [NSProcessInfo processInfo].hostName;

--- a/Source/santametricservice/BUILD
+++ b/Source/santametricservice/BUILD
@@ -65,7 +65,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
+++ b/Source/santametricservice/Formats/SNTMetricFormatTestHelper.m
@@ -19,21 +19,9 @@
 
 @implementation SNTMetricFormatTestHelper
 + (NSDictionary *)convertDatesToFixedDateWithExportDict:(NSMutableDictionary *)exportDict {
-  id formatter;
-
-  if (@available(macOS 10.13, *)) {
-    NSISO8601DateFormatter *isoFormatter = [[NSISO8601DateFormatter alloc] init];
-
-    isoFormatter.formatOptions =
-      NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
-    formatter = isoFormatter;
-  } else {
-    NSDateFormatter *localFormatter = [[NSDateFormatter alloc] init];
-    localFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    localFormatter.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601];
-    localFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
-    formatter = localFormatter;
-  }
+  NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
+  formatter.formatOptions =
+    NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
 
   NSDate *fixedDate = [formatter dateFromString:@"2021-09-16T21:07:34.826Z"];
 

--- a/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
+++ b/Source/santametricservice/Formats/SNTMetricMonarchJSONFormat.m
@@ -46,11 +46,8 @@ const NSString *kKey = @"key";
   self = [super init];
   if (self) {
     _dateFormatter = [[NSISO8601DateFormatter alloc] init];
-    _dateFormatter.formatOptions = NSISO8601DateFormatWithInternetDateTime;
-
-    if (@available(macOS 10.13, *)) {
-      _dateFormatter.formatOptions |= NSISO8601DateFormatWithFractionalSeconds;
-    }
+    _dateFormatter.formatOptions =
+      NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
   }
   return self;
 }

--- a/Source/santasyncservice/BUILD
+++ b/Source/santasyncservice/BUILD
@@ -184,7 +184,7 @@ macos_command_line_application(
         "--options library,kill,runtime",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     provisioning_profile = select({
         "//:adhoc_build": None,
         "//conditions:default": "//profiles:santa_dev",

--- a/Testing/integration/BUILD
+++ b/Testing/integration/BUILD
@@ -14,7 +14,7 @@ santa_unit_test(
     data = [
         "//Source/santad/testdata:binaryrules_testdata",
     ],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     deps = [],
 )
 

--- a/helper.bzl
+++ b/helper.bzl
@@ -23,7 +23,7 @@ def santa_unit_test(
         deps = [],
         data = [],
         size = "medium",
-        minimum_os_version = "11.0",
+        minimum_os_version = "12.0",
         resources = [],
         structured_resources = [],
         copts = [],


### PR DESCRIPTION
Set the minimum supported OS to macOS 12, dropping support for macOS 11.

Justification is twofold:
1. Apple only supports "current - 2" versions with security updates. Santa aims to meet this goal as well. This means macOS 11 hasn't been supported in some time already.
2. The macOS 11 test runners are being removed on GitHub, so we don't have a automated test pipeline anymore.