### PR TITLE
Use class member access operator for underlying ES message

### DIFF
--- a/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h
@@ -151,9 +151,8 @@ class EnrichedEventType {
 
   virtual ~EnrichedEventType() = default;
 
-  const es_message_t *operator->() const { return es_msg_.operator->(); }
+  inline const es_message_t *operator->() const { return es_msg_.operator->(); }
 
-  const es_message_t &es_msg() const { return *es_msg_; }
   const EnrichedProcess &instigator() const { return instigator_; }
   struct timespec enrichment_time() const {
     // No reason to return a reference

--- a/Source/santad/EventProviders/EndpointSecurity/Message.h
+++ b/Source/santad/EventProviders/EndpointSecurity/Message.h
@@ -44,8 +44,8 @@ class Message {
   void SetProcessToken(process_tree::ProcessToken tok);
 
   // Operators to access underlying es_message_t
-  const es_message_t* operator->() const { return es_msg_; }
-  const es_message_t& operator*() const { return *es_msg_; }
+  inline const es_message_t* operator->() const { return es_msg_; }
+  inline const es_message_t& operator*() const { return *es_msg_; }
 
   // Helper to get the API associated with this message.
   // Used for things like es_exec_arg_count.

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -41,14 +41,12 @@ std::string_view Serializer::MachineID() {
 
 std::vector<uint8_t> Serializer::SerializeMessageTemplate(const es::EnrichedExec &msg) {
   SNTCachedDecision *cd;
-  const es_message_t &es_msg = msg.es_msg();
-  if (es_msg.action_type == ES_ACTION_TYPE_NOTIFY &&
-      es_msg.action.notify.result.auth == ES_AUTH_RESULT_ALLOW) {
+  if (msg->action_type == ES_ACTION_TYPE_NOTIFY &&
+      msg->action.notify.result.auth == ES_AUTH_RESULT_ALLOW) {
     // For allowed execs, cached decision timestamps must be updated
-    cd = [decision_cache_
-      resetTimestampForCachedDecision:msg.es_msg().event.exec.target->executable->stat];
+    cd = [decision_cache_ resetTimestampForCachedDecision:msg->event.exec.target->executable->stat];
   } else {
-    cd = [decision_cache_ cachedDecisionForFile:msg.es_msg().event.exec.target->executable->stat];
+    cd = [decision_cache_ cachedDecisionForFile:msg->event.exec.target->executable->stat];
   }
 
   return SerializeMessage(msg, cd);


### PR DESCRIPTION
Removes the instance method `es_msg()` from the base `EnrichedEventType` class in favor of using the class member access operator.