### PR TITLE
Adopt namespace naming guidelines - part 1

### DIFF
--- a/Source/common/PrefixTree.h
+++ b/Source/common/PrefixTree.h
@@ -28,7 +28,7 @@
 #define DEBUG_LOG(format, ...)  // NOP
 #endif
 
-namespace santa::common {
+namespace santa {
 
 template <typename ValueT>
 class PrefixTree {
@@ -300,6 +300,6 @@ class PrefixTree {
   absl::Mutex lock_;
 };
 
-}  // namespace santa::common
+}  // namespace santa
 
 #endif

--- a/Source/common/PrefixTreeTest.mm
+++ b/Source/common/PrefixTreeTest.mm
@@ -17,7 +17,7 @@
 #define SANTA_PREFIX_TREE_DEBUG 1
 #include "Source/common/PrefixTree.h"
 
-using santa::common::PrefixTree;
+using santa::PrefixTree;
 
 @interface PrefixTreeTest : XCTestCase
 @end

--- a/Source/common/ScopedCFTypeRef.h
+++ b/Source/common/ScopedCFTypeRef.h
@@ -19,11 +19,11 @@
 
 #include "Source/common/ScopedTypeRef.h"
 
-namespace santa::common {
+namespace santa {
 
 template <typename CFT>
 using ScopedCFTypeRef = ScopedTypeRef<CFT, (CFT)NULL, CFRetain, CFRelease>;
 
-}  // namespace santa::common
+}  // namespace santa
 
 #endif

--- a/Source/common/ScopedCFTypeRefTest.mm
+++ b/Source/common/ScopedCFTypeRefTest.mm
@@ -19,7 +19,7 @@
 
 #include "Source/common/ScopedCFTypeRef.h"
 
-using santa::common::ScopedCFTypeRef;
+using santa::ScopedCFTypeRef;
 
 @interface ScopedCFTypeRefTest : XCTestCase
 @end

--- a/Source/common/ScopedIOObjectRef.h
+++ b/Source/common/ScopedIOObjectRef.h
@@ -19,7 +19,7 @@
 
 #include "Source/common/ScopedTypeRef.h"
 
-namespace santa::common {
+namespace santa {
 
 template <typename IOT>
 using ScopedIOObjectRef =
@@ -27,4 +27,4 @@ using ScopedIOObjectRef =
 
 }
 
-#endif
+#endif  // namespace santa

--- a/Source/common/ScopedIOObjectRefTest.mm
+++ b/Source/common/ScopedIOObjectRefTest.mm
@@ -20,7 +20,7 @@
 #include "Source/common/ScopedIOObjectRef.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
-using santa::common::ScopedIOObjectRef;
+using santa::ScopedIOObjectRef;
 using santa::santad::logs::endpoint_security::serializers::Utilities::GetDefaultIOKitCommsPort;
 
 @interface ScopedIOObjectRefTest : XCTestCase

--- a/Source/common/ScopedTypeRef.h
+++ b/Source/common/ScopedTypeRef.h
@@ -18,7 +18,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <assert.h>
 
-namespace santa::common {
+namespace santa {
 
 template <typename ElementT, ElementT InvalidV, auto RetainFunc,
           auto ReleaseFunc>
@@ -75,6 +75,6 @@ class ScopedTypeRef {
   ElementT object_;
 };
 
-}  // namespace santa::common
+}  // namespace santa
 
 #endif

--- a/Source/common/String.h
+++ b/Source/common/String.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <string_view>
 
-namespace santa::common {
+namespace santa {
 
 static inline std::string_view NSStringToUTF8StringView(NSString *str) {
   return std::string_view(str.UTF8String, [str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
@@ -53,6 +53,6 @@ static inline std::string_view StringTokenToStringView(es_string_token_t es_str)
   return std::string_view(es_str.data, es_str.length);
 }
 
-}  // namespace santa::common
+}  // namespace santa
 
 #endif

--- a/Source/common/Unit.h
+++ b/Source/common/Unit.h
@@ -15,10 +15,10 @@
 #ifndef SANTA__COMMON__UNIT_H
 #define SANTA__COMMON__UNIT_H
 
-namespace santa::common {
+namespace santa {
 
 struct Unit {};
 
-}  // namespace santa::common
+}  // namespace santa
 
 #endif

--- a/Source/santad/DataLayer/WatchItemPolicy.h
+++ b/Source/santad/DataLayer/WatchItemPolicy.h
@@ -23,7 +23,7 @@
 #include <string_view>
 #include <vector>
 
-namespace santa::santad::data_layer {
+namespace santa {
 
 enum class WatchItemPathType {
   kPrefix,
@@ -117,6 +117,6 @@ struct WatchItemPolicy {
   std::string version = "temp_version";
 };
 
-}  // namespace santa::santad::data_layer
+}  // namespace santa
 
 #endif

--- a/Source/santad/DataLayer/WatchItems.h
+++ b/Source/santad/DataLayer/WatchItems.h
@@ -52,11 +52,11 @@ extern NSString *const kWatchItemConfigKeyProcessesCDHash;
 extern NSString *const kWatchItemConfigKeyProcessesPlatformBinary;
 
 // Forward declarations
-namespace santa::santad::data_layer {
+namespace santa {
 class WatchItemsPeer;
 }
 
-namespace santa::santad::data_layer {
+namespace santa {
 
 struct WatchItemsState {
   uint64_t rule_count;
@@ -69,7 +69,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
  public:
   using VersionAndPolicies =
     std::pair<std::string, std::vector<std::optional<std::shared_ptr<WatchItemPolicy>>>>;
-  using WatchItemsTree = santa::common::PrefixTree<std::shared_ptr<WatchItemPolicy>>;
+  using WatchItemsTree = santa::PrefixTree<std::shared_ptr<WatchItemPolicy>>;
 
   // Factory
   static std::shared_ptr<WatchItems> Create(NSString *config_path,
@@ -99,7 +99,7 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   std::pair<NSString *, NSString *> EventDetailLinkInfo(
     const std::shared_ptr<WatchItemPolicy> &watch_item);
 
-  friend class santa::santad::data_layer::WatchItemsPeer;
+  friend class santa::WatchItemsPeer;
 
  private:
   static std::shared_ptr<WatchItems> CreateInternal(NSString *config_path, NSDictionary *config,
@@ -135,6 +135,6 @@ class WatchItems : public std::enable_shared_from_this<WatchItems> {
   NSString *policy_event_detail_text_ ABSL_GUARDED_BY(lock_);
 };
 
-}  // namespace santa::santad::data_layer
+}  // namespace santa
 
 #endif

--- a/Source/santad/DataLayer/WatchItems.mm
+++ b/Source/santad/DataLayer/WatchItems.mm
@@ -38,12 +38,12 @@
 #import "Source/common/Unit.h"
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 
-using santa::common::NSStringToUTF8String;
-using santa::common::NSStringToUTF8StringView;
-using santa::common::PrefixTree;
-using santa::common::Unit;
-using santa::santad::data_layer::WatchItemPathType;
-using santa::santad::data_layer::WatchItemPolicy;
+using santa::NSStringToUTF8String;
+using santa::NSStringToUTF8StringView;
+using santa::PrefixTree;
+using santa::Unit;
+using santa::WatchItemPathType;
+using santa::WatchItemPolicy;
 
 NSString *const kWatchItemConfigKeyVersion = @"Version";
 NSString *const kWatchItemConfigKeyEventDetailURL = @"EventDetailURL";
@@ -96,7 +96,7 @@ static constexpr NSUInteger kWatchItemConfigEventDetailTextMaxLength = 48;
 // max is used here.
 static constexpr NSUInteger kWatchItemConfigEventDetailURLMaxLength = 6000;
 
-namespace santa::santad::data_layer {
+namespace santa {
 
 // Type aliases
 using ValidatorBlock = bool (^)(id, NSError **);
@@ -897,4 +897,4 @@ std::pair<NSString *, NSString *> WatchItems::EventDetailLinkInfo(
   return {url, text};
 }
 
-}  // namespace santa::santad::data_layer
+}  // namespace santa

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -32,15 +32,15 @@
 #include "Source/santad/DataLayer/WatchItemPolicy.h"
 #include "Source/santad/DataLayer/WatchItems.h"
 
-using santa::common::Unit;
-using santa::santad::data_layer::kWatchItemPolicyDefaultAllowReadAccess;
-using santa::santad::data_layer::kWatchItemPolicyDefaultAuditOnly;
-using santa::santad::data_layer::kWatchItemPolicyDefaultInvertProcessExceptions;
-using santa::santad::data_layer::kWatchItemPolicyDefaultPathType;
-using santa::santad::data_layer::WatchItemPathType;
-using santa::santad::data_layer::WatchItemPolicy;
-using santa::santad::data_layer::WatchItems;
-using santa::santad::data_layer::WatchItemsState;
+using santa::kWatchItemPolicyDefaultAllowReadAccess;
+using santa::kWatchItemPolicyDefaultAuditOnly;
+using santa::kWatchItemPolicyDefaultInvertProcessExceptions;
+using santa::kWatchItemPolicyDefaultPathType;
+using santa::Unit;
+using santa::WatchItemPathType;
+using santa::WatchItemPolicy;
+using santa::WatchItems;
+using santa::WatchItemsState;
 
 namespace santatest {
 using PathAndTypePair = std::pair<std::string, WatchItemPathType>;
@@ -48,7 +48,7 @@ using PathList = std::vector<PathAndTypePair>;
 using ProcessList = std::vector<WatchItemPolicy::Process>;
 }  // namespace santatest
 
-namespace santa::santad::data_layer {
+namespace santa {
 
 extern bool ParseConfig(NSDictionary *config,
                         std::vector<std::shared_ptr<WatchItemPolicy>> &policies, NSError **err);
@@ -72,14 +72,14 @@ class WatchItemsPeer : public WatchItems {
   using WatchItems::embedded_config_;
 };
 
-}  // namespace santa::santad::data_layer
+}  // namespace santa
 
-using santa::santad::data_layer::IsWatchItemNameValid;
-using santa::santad::data_layer::ParseConfig;
-using santa::santad::data_layer::ParseConfigSingleWatchItem;
-using santa::santad::data_layer::VerifyConfigWatchItemPaths;
-using santa::santad::data_layer::VerifyConfigWatchItemProcesses;
-using santa::santad::data_layer::WatchItemsPeer;
+using santa::IsWatchItemNameValid;
+using santa::ParseConfig;
+using santa::ParseConfigSingleWatchItem;
+using santa::VerifyConfigWatchItemPaths;
+using santa::VerifyConfigWatchItemProcesses;
+using santa::WatchItemsPeer;
 
 static constexpr std::string_view kBadPolicyName("__BAD_NAME__");
 static constexpr std::string_view kBadPolicyPath("__BAD_PATH__");

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h
@@ -43,9 +43,9 @@ class EndpointSecurityAPI : public std::enable_shared_from_this<EndpointSecurity
   virtual bool InvertTargetPathMuting(const Client &client);
 
   virtual bool MuteTargetPath(const Client &client, std::string_view path,
-                              santa::santad::data_layer::WatchItemPathType path_type);
+                              santa::WatchItemPathType path_type);
   virtual bool UnmuteTargetPath(const Client &client, std::string_view path,
-                                santa::santad::data_layer::WatchItemPathType path_type);
+                                santa::WatchItemPathType path_type);
 
   virtual void RetainMessage(const es_message_t *msg);
   virtual void ReleaseMessage(const es_message_t *msg);

--- a/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.mm
@@ -19,7 +19,7 @@
 
 #include "Source/common/Platform.h"
 
-using santa::santad::data_layer::WatchItemPathType;
+using santa::WatchItemPathType;
 
 namespace santa::santad::event_providers::endpoint_security {
 

--- a/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
+++ b/Source/santad/EventProviders/EndpointSecurity/Enricher.mm
@@ -31,7 +31,7 @@
 #include "Source/santad/ProcessTree/process_tree.h"
 #include "Source/santad/ProcessTree/process_tree_macos.h"
 
-using santa::common::StringTokenToStringView;
+using santa::StringTokenToStringView;
 
 namespace santa::santad::event_providers::endpoint_security {
 

--- a/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
+++ b/Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h
@@ -48,11 +48,9 @@ class MockEndpointSecurityAPI
   MOCK_METHOD(bool, InvertTargetPathMuting, (const Client &client));
 
   MOCK_METHOD(bool, MuteTargetPath,
-              (const Client &client, std::string_view path,
-               santa::santad::data_layer::WatchItemPathType path_type));
+              (const Client &client, std::string_view path, santa::WatchItemPathType path_type));
   MOCK_METHOD(bool, UnmuteTargetPath,
-              (const Client &client, std::string_view path,
-               santa::santad::data_layer::WatchItemPathType path_type));
+              (const Client &client, std::string_view path, santa::WatchItemPathType path_type));
 
   MOCK_METHOD(void, RetainMessage, (const es_message_t *msg));
   MOCK_METHOD(void, ReleaseMessage, (const es_message_t *msg));

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -37,10 +37,10 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Metrics.h"
 
+using santa::WatchItemPathType;
 using santa::santad::EventDisposition;
 using santa::santad::Metrics;
 using santa::santad::Processor;
-using santa::santad::data_layer::WatchItemPathType;
 using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -52,9 +52,9 @@
 - (bool)unmuteAllTargetPaths;
 - (bool)enableTargetPathWatching;
 - (bool)muteTargetPaths:
-  (const std::vector<std::pair<std::string, santa::santad::data_layer::WatchItemPathType>> &)paths;
+  (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)paths;
 - (bool)unmuteTargetPaths:
-  (const std::vector<std::pair<std::string, santa::santad::data_layer::WatchItemPathType>> &)paths;
+  (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)paths;
 
 /// Responds to the Message with the given auth result
 ///

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -34,8 +34,8 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityClient.h"
 #include "Source/santad/Metrics.h"
 
+using santa::WatchItemPathType;
 using santa::santad::Processor;
-using santa::santad::data_layer::WatchItemPathType;
 using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
 using santa::santad::event_providers::endpoint_security::EnrichedFile;

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -43,13 +43,10 @@
 // Called when a client should no longer receive events.
 - (void)disable;
 
-- (void)
-  watchItemsCount:(size_t)count
-         newPaths:
-           (const std::vector<std::pair<std::string, santa::santad::data_layer::WatchItemPathType>>
-              &)newPaths
-     removedPaths:
-       (const std::vector<std::pair<std::string, santa::santad::data_layer::WatchItemPathType>> &)
-         removedPaths;
+- (void)watchItemsCount:(size_t)count
+               newPaths:
+                 (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)newPaths
+           removedPaths:
+             (const std::vector<std::pair<std::string, santa::WatchItemPathType>> &)removedPaths;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -38,7 +38,7 @@ typedef void (^SNTFileAccessBlockCallback)(SNTFileAccessEvent *event, NSString *
     (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
         metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
          logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
-     watchItems:(std::shared_ptr<santa::santad::data_layer::WatchItems>)watchItems
+     watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
        enricher:
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>)enricher
   decisionCache:(SNTDecisionCache *)decisionCache

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -51,15 +51,15 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 
-using santa::common::OptionalStringToNSString;
-using santa::common::StringToNSString;
+using santa::OptionalStringToNSString;
+using santa::StringToNSString;
+using santa::WatchItemPathType;
+using santa::WatchItemPolicy;
+using santa::WatchItems;
 using santa::santad::EventDisposition;
 using santa::santad::FileAccessMetricStatus;
 using santa::santad::Metrics;
 using santa::santad::TTYWriter;
-using santa::santad::data_layer::WatchItemPathType;
-using santa::santad::data_layer::WatchItemPolicy;
-using santa::santad::data_layer::WatchItems;
 using santa::santad::event_providers::RateLimiter;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -44,7 +44,7 @@
 #include "Source/santad/Logs/EndpointSecurity/MockLogger.h"
 #include "Source/santad/SNTDecisionCache.h"
 
-using santa::santad::data_layer::WatchItemPolicy;
+using santa::WatchItemPolicy;
 using santa::santad::event_providers::endpoint_security::Message;
 
 extern NSString *kBadCertHash;

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
@@ -40,7 +40,7 @@
   compilerController:(SNTCompilerController *)compilerController
      authResultCache:
        (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
-          prefixTree:(std::shared_ptr<santa::common::PrefixTree<santa::common::Unit>>)prefixTree
+          prefixTree:(std::shared_ptr<santa::PrefixTree<santa::Unit>>)prefixTree
          processTree:(std::shared_ptr<santa::santad::process_tree::ProcessTree>)processTree;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -27,8 +27,8 @@
 #include "Source/santad/Metrics.h"
 #include "Source/santad/ProcessTree/process_tree.h"
 
-using santa::common::PrefixTree;
-using santa::common::Unit;
+using santa::PrefixTree;
+using santa::Unit;
 using santa::santad::EventDisposition;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
@@ -142,7 +142,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
       }
 
       // Only log file changes that match the given regex
-      NSString *targetPath = santa::common::StringToNSString(targetFile->path.data);
+      NSString *targetPath = santa::StringToNSString(targetFile->path.data);
       if (![[self.configurator fileChangesRegex]
             numberOfMatchesInString:targetPath
                             options:0

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -39,8 +39,8 @@
 #include "Source/santad/Metrics.h"
 #import "Source/santad/SNTCompilerController.h"
 
-using santa::common::PrefixTree;
-using santa::common::Unit;
+using santa::PrefixTree;
+using santa::Unit;
 using santa::santad::EventDisposition;
 using santa::santad::Processor;
 using santa::santad::event_providers::AuthResultCache;

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -24,8 +24,8 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Metrics.h"
 
+using santa::WatchItemPathType;
 using santa::santad::EventDisposition;
-using santa::santad::data_layer::WatchItemPathType;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::Logger;

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -31,8 +31,8 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h"
 #import "Source/santad/Metrics.h"
 
+using santa::WatchItemPathType;
 using santa::santad::EventDisposition;
-using santa::santad::data_layer::WatchItemPathType;
 using santa::santad::event_providers::endpoint_security::Client;
 using santa::santad::event_providers::endpoint_security::Message;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -43,8 +43,8 @@ using google::protobuf::Timestamp;
 using JsonPrintOptions = google::protobuf::json::PrintOptions;
 using google::protobuf::json::MessageToJsonString;
 
-using santa::common::NSStringToUTF8StringView;
-using santa::common::StringTokenToStringView;
+using santa::NSStringToUTF8StringView;
+using santa::StringTokenToStringView;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
 using santa::santad::event_providers::endpoint_security::EnrichedCSInvalidated;

--- a/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.mm
@@ -16,7 +16,7 @@
 
 #include "Source/common/String.h"
 
-using santa::common::NSStringToUTF8StringView;
+using santa::NSStringToUTF8StringView;
 
 namespace santa::santad::logs::endpoint_security::serializers {
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
@@ -109,7 +109,7 @@ NSString *MountFromName(NSString *path) {
     return nil;
   }
 
-  NSString *mntFromName = santa::common::StringToNSString(sfs.f_mntfromname);
+  NSString *mntFromName = santa::StringToNSString(sfs.f_mntfromname);
 
   return mntFromName.length > 0 ? mntFromName : nil;
 }

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -35,5 +35,5 @@
         notificationQueue:(SNTNotificationQueue *)notQueue
                syncdQueue:(SNTSyncdQueue *)syncdQueue
                    logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
-               watchItems:(std::shared_ptr<santa::santad::data_layer::WatchItems>)watchItems;
+               watchItems:(std::shared_ptr<santa::WatchItems>)watchItems;
 @end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -36,8 +36,8 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 #import "Source/santad/SNTSyncdQueue.h"
 
-using santa::santad::data_layer::WatchItems;
-using santa::santad::data_layer::WatchItemsState;
+using santa::WatchItems;
+using santa::WatchItemsState;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -52,8 +52,8 @@
 #import "Source/santad/SNTSyncdQueue.h"
 #include "absl/synchronization/mutex.h"
 
-using santa::common::PrefixTree;
-using santa::common::Unit;
+using santa::PrefixTree;
+using santa::Unit;
 using santa::santad::TTYWriter;
 using santa::santad::event_providers::endpoint_security::Message;
 
@@ -63,7 +63,7 @@ void UpdateTeamIDFilterLocked(std::set<std::string> &filterSet, NSArray<NSString
   filterSet.clear();
 
   for (NSString *prefix in filter) {
-    filterSet.insert(santa::common::NSStringToUTF8String(prefix));
+    filterSet.insert(santa::NSStringToUTF8String(prefix));
   }
 }
 

--- a/Source/santad/Santad.h
+++ b/Source/santad/Santad.h
@@ -38,7 +38,7 @@ void SantadMain(
         esapi,
     std::shared_ptr<santa::santad::logs::endpoint_security::Logger> logger,
     std::shared_ptr<santa::santad::Metrics> metrics,
-    std::shared_ptr<santa::santad::data_layer::WatchItems> watch_items,
+    std::shared_ptr<santa::WatchItems> watch_items,
     std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>
         enricher,
     std::shared_ptr<santa::santad::event_providers::AuthResultCache>
@@ -47,7 +47,7 @@ void SantadMain(
     SNTCompilerController* compiler_controller,
     SNTNotificationQueue* notifier_queue, SNTSyncdQueue* syncd_queue,
     SNTExecutionController* exec_controller,
-    std::shared_ptr<santa::common::PrefixTree<santa::common::Unit>> prefix_tree,
+    std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree,
     std::shared_ptr<santa::santad::TTYWriter> tty_writer,
     std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree);
 

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -39,11 +39,11 @@
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
-using santa::common::PrefixTree;
-using santa::common::Unit;
+using santa::PrefixTree;
+using santa::Unit;
+using santa::WatchItems;
 using santa::santad::Metrics;
 using santa::santad::TTYWriter;
-using santa::santad::data_layer::WatchItems;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
@@ -74,14 +74,13 @@ static void EstablishSyncServiceConnection(SNTSyncdQueue *syncd_queue) {
 }
 
 void SantadMain(std::shared_ptr<EndpointSecurityAPI> esapi, std::shared_ptr<Logger> logger,
-                std::shared_ptr<Metrics> metrics,
-                std::shared_ptr<santa::santad::data_layer::WatchItems> watch_items,
+                std::shared_ptr<Metrics> metrics, std::shared_ptr<santa::WatchItems> watch_items,
                 std::shared_ptr<Enricher> enricher,
                 std::shared_ptr<AuthResultCache> auth_result_cache,
                 MOLXPCConnection *control_connection, SNTCompilerController *compiler_controller,
                 SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
                 SNTExecutionController *exec_controller,
-                std::shared_ptr<santa::common::PrefixTree<santa::common::Unit>> prefix_tree,
+                std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree,
                 std::shared_ptr<TTYWriter> tty_writer,
                 std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree) {
   SNTConfigurator *configurator = [SNTConfigurator configurator];

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -50,17 +50,16 @@ class SantadDeps {
           esapi,
       std::unique_ptr<santa::santad::logs::endpoint_security::Logger> logger,
       std::shared_ptr<santa::santad::Metrics> metrics,
-      std::shared_ptr<santa::santad::data_layer::WatchItems> watch_items,
+      std::shared_ptr<santa::WatchItems> watch_items,
       std::shared_ptr<santa::santad::event_providers::AuthResultCache>
           auth_result_cache,
       MOLXPCConnection *control_connection,
       SNTCompilerController *compiler_controller,
       SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
       SNTExecutionController *exec_controller,
-      std::shared_ptr<santa::common::PrefixTree<santa::common::Unit>>
-          prefix_tree,
+      std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree,
       std::shared_ptr<santa::santad::TTYWriter> tty_writer,
-      std::shared_ptr<process_tree::ProcessTree> process_tree);
+      std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree);
 
   std::shared_ptr<santa::santad::event_providers::AuthResultCache>
   AuthResultCache();
@@ -71,15 +70,15 @@ class SantadDeps {
   ESAPI();
   std::shared_ptr<santa::santad::logs::endpoint_security::Logger> Logger();
   std::shared_ptr<santa::santad::Metrics> Metrics();
-  std::shared_ptr<santa::santad::data_layer::WatchItems> WatchItems();
+  std::shared_ptr<santa::WatchItems> WatchItems();
   MOLXPCConnection *ControlConnection();
   SNTCompilerController *CompilerController();
   SNTNotificationQueue *NotifierQueue();
   SNTSyncdQueue *SyncdQueue();
   SNTExecutionController *ExecController();
-  std::shared_ptr<santa::common::PrefixTree<santa::common::Unit>> PrefixTree();
+  std::shared_ptr<santa::PrefixTree<santa::Unit>> PrefixTree();
   std::shared_ptr<santa::santad::TTYWriter> TTYWriter();
-  std::shared_ptr<process_tree::ProcessTree> ProcessTree();
+  std::shared_ptr<santa::santad::process_tree::ProcessTree> ProcessTree();
 
  private:
   std::shared_ptr<
@@ -87,7 +86,7 @@ class SantadDeps {
       esapi_;
   std::shared_ptr<santa::santad::logs::endpoint_security::Logger> logger_;
   std::shared_ptr<santa::santad::Metrics> metrics_;
-  std::shared_ptr<santa::santad::data_layer::WatchItems> watch_items_;
+  std::shared_ptr<santa::WatchItems> watch_items_;
   std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>
       enricher_;
   std::shared_ptr<santa::santad::event_providers::AuthResultCache>
@@ -98,9 +97,9 @@ class SantadDeps {
   SNTNotificationQueue *notifier_queue_;
   SNTSyncdQueue *syncd_queue_;
   SNTExecutionController *exec_controller_;
-  std::shared_ptr<santa::common::PrefixTree<santa::common::Unit>> prefix_tree_;
+  std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree_;
   std::shared_ptr<santa::santad::TTYWriter> tty_writer_;
-  std::shared_ptr<process_tree::ProcessTree> process_tree_;
+  std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree_;
 };
 
 }  // namespace santa::santad

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -30,11 +30,11 @@
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
-using santa::common::PrefixTree;
-using santa::common::Unit;
+using santa::PrefixTree;
+using santa::Unit;
+using santa::WatchItems;
 using santa::santad::Metrics;
 using santa::santad::TTYWriter;
-using santa::santad::data_layer::WatchItems;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;

--- a/Source/santad/TTYWriter.mm
+++ b/Source/santad/TTYWriter.mm
@@ -48,7 +48,7 @@ void TTYWriter::Write(const es_process_t *proc, NSString *msg) {
 
   // Copy the data from the es_process_t so the ES message doesn't
   // need to be retained
-  NSString *tty = santa::common::StringToNSString(proc->tty->path.data);
+  NSString *tty = santa::StringToNSString(proc->tty->path.data);
 
   dispatch_async(q_, ^{
     int fd = open(tty.UTF8String, O_WRONLY | O_NOCTTY);
@@ -57,7 +57,7 @@ void TTYWriter::Write(const es_process_t *proc, NSString *msg) {
       return;
     }
 
-    std::string_view str = santa::common::NSStringToUTF8StringView(msg);
+    std::string_view str = santa::NSStringToUTF8StringView(msg);
     write(fd, str.data(), str.length());
 
     close(fd);

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -33,7 +33,7 @@
 #include "Source/santasyncservice/syncv1.pb.h"
 namespace pbv1 = ::santa::sync::v1;
 
-using santa::common::NSStringToUTF8String;
+using santa::NSStringToUTF8String;
 
 @implementation SNTSyncEventUpload
 
@@ -82,7 +82,7 @@ using santa::common::NSStringToUTF8String;
         [NSMutableArray arrayWithCapacity:response.event_upload_bundle_binaries_size()];
       for (const std::string &bundle_binary : response.event_upload_bundle_binaries()) {
         [(NSMutableArray *)self.syncState.bundleBinaryRequests
-          addObject:santa::common::StringToNSString(bundle_binary)];
+          addObject:santa::StringToNSString(bundle_binary)];
       }
     }
     SLOGI(@"Uploaded %d events", uploadEvents->size());

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -30,8 +30,8 @@
 #include "Source/santasyncservice/syncv1.pb.h"
 namespace pbv1 = ::santa::sync::v1;
 
-using santa::common::NSStringToUTF8String;
-using santa::common::StringToNSString;
+using santa::NSStringToUTF8String;
+using santa::StringToNSString;
 
 /*
 

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -29,7 +29,7 @@
 #include "Source/santasyncservice/syncv1.pb.h"
 namespace pbv1 = ::santa::sync::v1;
 
-using santa::common::StringToNSString;
+using santa::StringToNSString;
 
 SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
   switch (syncType) {

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -28,7 +28,7 @@
 
 #include <google/protobuf/json/json.h>
 
-using santa::common::NSStringToUTF8String;
+using santa::NSStringToUTF8String;
 
 @interface SNTSyncStage ()
 


### PR DESCRIPTION
The style guide prefers that a projects do not overly nest namespace names, and note that unless necessary, a single top-level namespace per project is the most effective strategy to limit exposure to collisions.

To keep PR size reasonable, part 1 only changes things in `santa::common` and `santa::santad::data_layer`. Other namespaces will be converted in a future PR.

References:
* [Namespaces style guide](https://google.github.io/styleguide/cppguide.html#Namespaces)
* [Namespace names style guide](https://google.github.io/styleguide/cppguide.html#Namespace_Names)
* [Tip of the Week #130: Namespace Naming](https://abseil.io/tips/130)