### PR TITLE
Namespace simplification pt2

### DIFF
--- a/Source/common/ScopedIOObjectRefTest.mm
+++ b/Source/common/ScopedIOObjectRefTest.mm
@@ -21,7 +21,7 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
 using santa::ScopedIOObjectRef;
-using santa::santad::logs::endpoint_security::serializers::Utilities::GetDefaultIOKitCommsPort;
+using santa::GetDefaultIOKitCommsPort;
 
 @interface ScopedIOObjectRefTest : XCTestCase
 @end

--- a/Source/common/ScopedIOObjectRefTest.mm
+++ b/Source/common/ScopedIOObjectRefTest.mm
@@ -20,8 +20,8 @@
 #include "Source/common/ScopedIOObjectRef.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
-using santa::ScopedIOObjectRef;
 using santa::GetDefaultIOKitCommsPort;
+using santa::ScopedIOObjectRef;
 
 @interface ScopedIOObjectRefTest : XCTestCase
 @end

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -42,11 +42,11 @@ using santa::WatchItemPolicy;
 using santa::WatchItems;
 using santa::WatchItemsState;
 
-namespace santatest {
+namespace {
 using PathAndTypePair = std::pair<std::string, WatchItemPathType>;
 using PathList = std::vector<PathAndTypePair>;
 using ProcessList = std::vector<WatchItemPolicy::Process>;
-}  // namespace santatest
+}  // namespace
 
 namespace santa {
 
@@ -56,9 +56,9 @@ extern bool IsWatchItemNameValid(NSString *watch_item_name, NSError **err);
 extern bool ParseConfigSingleWatchItem(NSString *name, NSDictionary *watch_item,
                                        std::vector<std::shared_ptr<WatchItemPolicy>> &policies,
                                        NSError **err);
-extern std::variant<Unit, santatest::PathList> VerifyConfigWatchItemPaths(NSArray<id> *paths,
+extern std::variant<Unit, PathList> VerifyConfigWatchItemPaths(NSArray<id> *paths,
                                                                           NSError **err);
-extern std::variant<Unit, santatest::ProcessList> VerifyConfigWatchItemProcesses(
+extern std::variant<Unit, ProcessList> VerifyConfigWatchItemProcesses(
   NSDictionary *watch_item, NSError **err);
 class WatchItemsPeer : public WatchItems {
  public:
@@ -440,7 +440,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 }
 
 - (void)testVerifyConfigWatchItemPaths {
-  std::variant<Unit, santatest::PathList> path_list;
+  std::variant<Unit, PathList> path_list;
   NSError *err;
 
   // Test no paths specified
@@ -466,29 +466,29 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 
   // Test path array dictionary with default path type
   path_list = VerifyConfigWatchItemPaths(@[ @{kWatchItemConfigKeyPathsPath : @"A"} ], &err);
-  XCTAssertTrue(std::holds_alternative<santatest::PathList>(path_list));
-  XCTAssertEqual(std::get<santatest::PathList>(path_list).size(), 1);
-  XCTAssertCStringEqual(std::get<santatest::PathList>(path_list)[0].first.c_str(), "A");
-  XCTAssertEqual(std::get<santatest::PathList>(path_list)[0].second,
+  XCTAssertTrue(std::holds_alternative<PathList>(path_list));
+  XCTAssertEqual(std::get<PathList>(path_list).size(), 1);
+  XCTAssertCStringEqual(std::get<PathList>(path_list)[0].first.c_str(), "A");
+  XCTAssertEqual(std::get<PathList>(path_list)[0].second,
                  kWatchItemPolicyDefaultPathType);
 
   // Test path array dictionary with custom path type
   path_list = VerifyConfigWatchItemPaths(
     @[ @{kWatchItemConfigKeyPathsPath : @"A", kWatchItemConfigKeyPathsIsPrefix : @(YES)} ], &err);
-  XCTAssertTrue(std::holds_alternative<santatest::PathList>(path_list));
-  XCTAssertEqual(std::get<santatest::PathList>(path_list).size(), 1);
-  XCTAssertCStringEqual(std::get<santatest::PathList>(path_list)[0].first.c_str(), "A");
-  XCTAssertEqual(std::get<santatest::PathList>(path_list)[0].second, WatchItemPathType::kPrefix);
+  XCTAssertTrue(std::holds_alternative<PathList>(path_list));
+  XCTAssertEqual(std::get<PathList>(path_list).size(), 1);
+  XCTAssertCStringEqual(std::get<PathList>(path_list)[0].first.c_str(), "A");
+  XCTAssertEqual(std::get<PathList>(path_list)[0].second, WatchItemPathType::kPrefix);
 }
 
 - (void)testVerifyConfigWatchItemProcesses {
-  std::variant<Unit, santatest::ProcessList> proc_list;
+  std::variant<Unit, ProcessList> proc_list;
   NSError *err;
 
   // Non-existent process list parses successfully, but has no items
   proc_list = VerifyConfigWatchItemProcesses(@{}, &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 0);
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 0);
 
   // Process list fails to parse if contains non-array type
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @""}, &err);
@@ -498,7 +498,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @{}}, &err);
   XCTAssertTrue(std::holds_alternative<Unit>(proc_list));
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @[]}, &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
 
   // Test a process dictionary with no valid attributes set
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @[ @{} ]}, &err);
@@ -516,9 +516,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesBinaryPath : @"mypath"} ]},
     &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("mypath", "", "", {}, "", std::nullopt));
 
   // Test SigningID length limits
@@ -535,9 +535,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
       @[ @{kWatchItemConfigKeyProcessesSigningID : @"com.google.test"} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("", "com.google.test", "", {}, "", std::nullopt));
 
   // Test TeamID length limits
@@ -552,9 +552,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesTeamID : @"myvalidtid"} ]},
     &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "myvalidtid", {}, "", std::nullopt));
 
   // Test CDHash length limits
@@ -579,9 +579,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   std::fill(cdhashBytes.begin(), cdhashBytes.end(), 0xAA);
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesCDHash : cdhash} ]}, &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "", cdhashBytes, "", std::nullopt));
 
   // Test Cert Hash length limits
@@ -610,9 +610,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesCertificateSha256 : certHash} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "", {}, [certHash UTF8String], std::nullopt));
 
   // Test valid invalid PlatformBinary type
@@ -625,9 +625,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesPlatformBinary : @(YES)} ]},
     &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "", {}, "", std::make_optional(true)));
 
   // Test valid multiple attributes, multiple procs
@@ -652,12 +652,12 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<santatest::ProcessList>(proc_list));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list).size(), 2);
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 2);
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
                  WatchItemPolicy::Process("mypath1", "com.google.test1", "validtid_1", cdhashBytes,
                                           [certHash UTF8String], std::make_optional(true)));
-  XCTAssertEqual(std::get<santatest::ProcessList>(proc_list)[1],
+  XCTAssertEqual(std::get<ProcessList>(proc_list)[1],
                  WatchItemPolicy::Process("mypath2", "com.google.test2", "validtid_2", cdhashBytes,
                                           [certHash UTF8String], std::make_optional(false)));
 }

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -44,8 +44,8 @@ using santa::WatchItemsState;
 
 namespace {
 using PathAndTypePair = std::pair<std::string, WatchItemPathType>;
-using PathList = std::vector<PathAndTypePair>;
-using ProcessList = std::vector<WatchItemPolicy::Process>;
+using PathAndTypeVec = std::vector<PathAndTypePair>;
+using PolicyProcessVec = std::vector<WatchItemPolicy::Process>;
 }  // namespace
 
 namespace santa {
@@ -56,9 +56,10 @@ extern bool IsWatchItemNameValid(NSString *watch_item_name, NSError **err);
 extern bool ParseConfigSingleWatchItem(NSString *name, NSDictionary *watch_item,
                                        std::vector<std::shared_ptr<WatchItemPolicy>> &policies,
                                        NSError **err);
-extern std::variant<Unit, PathList> VerifyConfigWatchItemPaths(NSArray<id> *paths, NSError **err);
-extern std::variant<Unit, ProcessList> VerifyConfigWatchItemProcesses(NSDictionary *watch_item,
-                                                                      NSError **err);
+extern std::variant<Unit, PathAndTypeVec> VerifyConfigWatchItemPaths(NSArray<id> *paths,
+                                                                     NSError **err);
+extern std::variant<Unit, PolicyProcessVec> VerifyConfigWatchItemProcesses(NSDictionary *watch_item,
+                                                                           NSError **err);
 class WatchItemsPeer : public WatchItems {
  public:
   using WatchItems::WatchItems;
@@ -439,7 +440,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 }
 
 - (void)testVerifyConfigWatchItemPaths {
-  std::variant<Unit, PathList> path_list;
+  std::variant<Unit, PathAndTypeVec> path_list;
   NSError *err;
 
   // Test no paths specified
@@ -465,28 +466,28 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
 
   // Test path array dictionary with default path type
   path_list = VerifyConfigWatchItemPaths(@[ @{kWatchItemConfigKeyPathsPath : @"A"} ], &err);
-  XCTAssertTrue(std::holds_alternative<PathList>(path_list));
-  XCTAssertEqual(std::get<PathList>(path_list).size(), 1);
-  XCTAssertCStringEqual(std::get<PathList>(path_list)[0].first.c_str(), "A");
-  XCTAssertEqual(std::get<PathList>(path_list)[0].second, kWatchItemPolicyDefaultPathType);
+  XCTAssertTrue(std::holds_alternative<PathAndTypeVec>(path_list));
+  XCTAssertEqual(std::get<PathAndTypeVec>(path_list).size(), 1);
+  XCTAssertCStringEqual(std::get<PathAndTypeVec>(path_list)[0].first.c_str(), "A");
+  XCTAssertEqual(std::get<PathAndTypeVec>(path_list)[0].second, kWatchItemPolicyDefaultPathType);
 
   // Test path array dictionary with custom path type
   path_list = VerifyConfigWatchItemPaths(
     @[ @{kWatchItemConfigKeyPathsPath : @"A", kWatchItemConfigKeyPathsIsPrefix : @(YES)} ], &err);
-  XCTAssertTrue(std::holds_alternative<PathList>(path_list));
-  XCTAssertEqual(std::get<PathList>(path_list).size(), 1);
-  XCTAssertCStringEqual(std::get<PathList>(path_list)[0].first.c_str(), "A");
-  XCTAssertEqual(std::get<PathList>(path_list)[0].second, WatchItemPathType::kPrefix);
+  XCTAssertTrue(std::holds_alternative<PathAndTypeVec>(path_list));
+  XCTAssertEqual(std::get<PathAndTypeVec>(path_list).size(), 1);
+  XCTAssertCStringEqual(std::get<PathAndTypeVec>(path_list)[0].first.c_str(), "A");
+  XCTAssertEqual(std::get<PathAndTypeVec>(path_list)[0].second, WatchItemPathType::kPrefix);
 }
 
 - (void)testVerifyConfigWatchItemProcesses {
-  std::variant<Unit, ProcessList> proc_list;
+  std::variant<Unit, PolicyProcessVec> proc_list;
   NSError *err;
 
   // Non-existent process list parses successfully, but has no items
   proc_list = VerifyConfigWatchItemProcesses(@{}, &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 0);
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 0);
 
   // Process list fails to parse if contains non-array type
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @""}, &err);
@@ -496,7 +497,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @{}}, &err);
   XCTAssertTrue(std::holds_alternative<Unit>(proc_list));
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @[]}, &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
 
   // Test a process dictionary with no valid attributes set
   proc_list = VerifyConfigWatchItemProcesses(@{kWatchItemConfigKeyProcesses : @[ @{} ]}, &err);
@@ -514,9 +515,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesBinaryPath : @"mypath"} ]},
     &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("mypath", "", "", {}, "", std::nullopt));
 
   // Test SigningID length limits
@@ -533,9 +534,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
       @[ @{kWatchItemConfigKeyProcessesSigningID : @"com.google.test"} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("", "com.google.test", "", {}, "", std::nullopt));
 
   // Test TeamID length limits
@@ -550,9 +551,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesTeamID : @"myvalidtid"} ]},
     &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "myvalidtid", {}, "", std::nullopt));
 
   // Test CDHash length limits
@@ -577,9 +578,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   std::fill(cdhashBytes.begin(), cdhashBytes.end(), 0xAA);
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesCDHash : cdhash} ]}, &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "", cdhashBytes, "", std::nullopt));
 
   // Test Cert Hash length limits
@@ -608,9 +609,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesCertificateSha256 : certHash} ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "", {}, [certHash UTF8String], std::nullopt));
 
   // Test valid invalid PlatformBinary type
@@ -623,9 +624,9 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   proc_list = VerifyConfigWatchItemProcesses(
     @{kWatchItemConfigKeyProcesses : @[ @{kWatchItemConfigKeyProcessesPlatformBinary : @(YES)} ]},
     &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 1);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 1);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("", "", "", {}, "", std::make_optional(true)));
 
   // Test valid multiple attributes, multiple procs
@@ -650,12 +651,12 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
     ]
   },
                                              &err);
-  XCTAssertTrue(std::holds_alternative<ProcessList>(proc_list));
-  XCTAssertEqual(std::get<ProcessList>(proc_list).size(), 2);
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[0],
+  XCTAssertTrue(std::holds_alternative<PolicyProcessVec>(proc_list));
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list).size(), 2);
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[0],
                  WatchItemPolicy::Process("mypath1", "com.google.test1", "validtid_1", cdhashBytes,
                                           [certHash UTF8String], std::make_optional(true)));
-  XCTAssertEqual(std::get<ProcessList>(proc_list)[1],
+  XCTAssertEqual(std::get<PolicyProcessVec>(proc_list)[1],
                  WatchItemPolicy::Process("mypath2", "com.google.test2", "validtid_2", cdhashBytes,
                                           [certHash UTF8String], std::make_optional(false)));
 }

--- a/Source/santad/DataLayer/WatchItemsTest.mm
+++ b/Source/santad/DataLayer/WatchItemsTest.mm
@@ -56,10 +56,9 @@ extern bool IsWatchItemNameValid(NSString *watch_item_name, NSError **err);
 extern bool ParseConfigSingleWatchItem(NSString *name, NSDictionary *watch_item,
                                        std::vector<std::shared_ptr<WatchItemPolicy>> &policies,
                                        NSError **err);
-extern std::variant<Unit, PathList> VerifyConfigWatchItemPaths(NSArray<id> *paths,
-                                                                          NSError **err);
-extern std::variant<Unit, ProcessList> VerifyConfigWatchItemProcesses(
-  NSDictionary *watch_item, NSError **err);
+extern std::variant<Unit, PathList> VerifyConfigWatchItemPaths(NSArray<id> *paths, NSError **err);
+extern std::variant<Unit, ProcessList> VerifyConfigWatchItemProcesses(NSDictionary *watch_item,
+                                                                      NSError **err);
 class WatchItemsPeer : public WatchItems {
  public:
   using WatchItems::WatchItems;
@@ -469,8 +468,7 @@ static NSMutableDictionary *WrapWatchItemsConfig(NSDictionary *config) {
   XCTAssertTrue(std::holds_alternative<PathList>(path_list));
   XCTAssertEqual(std::get<PathList>(path_list).size(), 1);
   XCTAssertCStringEqual(std::get<PathList>(path_list)[0].first.c_str(), "A");
-  XCTAssertEqual(std::get<PathList>(path_list)[0].second,
-                 kWatchItemPolicyDefaultPathType);
+  XCTAssertEqual(std::get<PathList>(path_list)[0].second, kWatchItemPolicyDefaultPathType);
 
   // Test path array dictionary with custom path type
   path_list = VerifyConfigWatchItemPaths(

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h
@@ -44,7 +44,7 @@ typedef void (^SNTDeviceBlockCallback)(SNTDeviceEvent *event);
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)
            esApi
              metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
-              logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
+              logger:(std::shared_ptr<santa::Logger>)logger
      authResultCache:
        (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
        blockUSBMount:(BOOL)blockUSBMount

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -33,13 +33,13 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Metrics.h"
 
+using santa::Logger;
 using santa::santad::EventDisposition;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Logger;
 
 // Defined operations for startup metrics:
 // Device shouldn't be operated on (e.g. not a mass storage device)

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -39,7 +39,7 @@ using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 // Defined operations for startup metrics:
 // Device shouldn't be operated on (e.g. not a mass storage device)

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -37,7 +37,7 @@ typedef void (^SNTFileAccessBlockCallback)(SNTFileAccessEvent *event, NSString *
   initWithESAPI:
     (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
         metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
-         logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
+         logger:(std::shared_ptr<santa::Logger>)logger
      watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
        enricher:
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>)enricher

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -51,6 +51,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 
+using santa::Logger;
 using santa::OptionalStringToNSString;
 using santa::StringToNSString;
 using santa::WatchItemPathType;
@@ -65,7 +66,6 @@ using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::EnrichOptions;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Logger;
 
 NSString *kBadCertHash = @"BAD_CERT_HASH";
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -65,7 +65,7 @@ using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::EnrichOptions;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 NSString *kBadCertHash = @"BAD_CERT_HASH";
 
@@ -400,7 +400,7 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
   initWithESAPI:
     (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
         metrics:(std::shared_ptr<Metrics>)metrics
-         logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
+         logger:(std::shared_ptr<santa::Logger>)logger
      watchItems:(std::shared_ptr<WatchItems>)watchItems
        enricher:
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>)enricher

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
@@ -34,7 +34,7 @@
          (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)
            esApi
              metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
-              logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
+              logger:(std::shared_ptr<santa::Logger>)logger
             enricher:
               (std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>)enricher
   compilerController:(SNTCompilerController *)compilerController

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -35,7 +35,7 @@ using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 using santa::santad::process_tree::ProcessTree;
 
 es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -27,6 +27,7 @@
 #include "Source/santad/Metrics.h"
 #include "Source/santad/ProcessTree/process_tree.h"
 
+using santa::Logger;
 using santa::PrefixTree;
 using santa::Unit;
 using santa::santad::EventDisposition;
@@ -35,7 +36,6 @@ using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Logger;
 using santa::santad::process_tree::ProcessTree;
 
 es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -39,6 +39,7 @@
 #include "Source/santad/Metrics.h"
 #import "Source/santad/SNTCompilerController.h"
 
+using santa::Logger;
 using santa::PrefixTree;
 using santa::Unit;
 using santa::santad::EventDisposition;
@@ -47,7 +48,6 @@ using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Logger;
 
 class MockEnricher : public Enricher {
  public:

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -47,7 +47,7 @@ using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 class MockEnricher : public Enricher {
  public:

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h
@@ -30,6 +30,6 @@
   initWithESAPI:
     (std::shared_ptr<santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>)esApi
         metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
-         logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger;
+         logger:(std::shared_ptr<santa::Logger>)logger;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -28,7 +28,7 @@ using santa::WatchItemPathType;
 using santa::santad::EventDisposition;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-driver";
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -24,11 +24,11 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Metrics.h"
 
+using santa::Logger;
 using santa::WatchItemPathType;
 using santa::santad::EventDisposition;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Logger;
 
 static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-driver";
 

--- a/Source/santad/Logs/EndpointSecurity/Logger.h
+++ b/Source/santad/Logs/EndpointSecurity/Logger.h
@@ -44,8 +44,7 @@ class Logger {
     NSString *spool_log_path, size_t spool_dir_size_threshold, size_t spool_file_size_threshold,
     uint64_t spool_flush_timeout_ms);
 
-  Logger(std::shared_ptr<santa::Serializer> serializer,
-         std::shared_ptr<santa::Writer> writer);
+  Logger(std::shared_ptr<santa::Serializer> serializer, std::shared_ptr<santa::Writer> writer);
 
   virtual ~Logger() = default;
 

--- a/Source/santad/Logs/EndpointSecurity/Logger.h
+++ b/Source/santad/Logs/EndpointSecurity/Logger.h
@@ -30,11 +30,11 @@
 
 // Forward declarations
 @class SNTStoredEvent;
-namespace santa::santad::logs::endpoint_security {
+namespace santa {
 class LoggerPeer;
 }
 
-namespace santa::santad::logs::endpoint_security {
+namespace santa {
 
 class Logger {
  public:
@@ -68,13 +68,13 @@ class Logger {
 
   void Flush();
 
-  friend class santa::santad::logs::endpoint_security::LoggerPeer;
+  friend class santa::LoggerPeer;
 
  private:
   std::shared_ptr<santa::Serializer> serializer_;
   std::shared_ptr<santa::Writer> writer_;
 };
 
-}  // namespace santa::santad::logs::endpoint_security
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Logger.h
+++ b/Source/santad/Logs/EndpointSecurity/Logger.h
@@ -44,7 +44,7 @@ class Logger {
     NSString *spool_log_path, size_t spool_dir_size_threshold, size_t spool_file_size_threshold,
     uint64_t spool_flush_timeout_ms);
 
-  Logger(std::shared_ptr<serializers::Serializer> serializer,
+  Logger(std::shared_ptr<santa::Serializer> serializer,
          std::shared_ptr<santa::Writer> writer);
 
   virtual ~Logger() = default;
@@ -71,7 +71,7 @@ class Logger {
   friend class santa::santad::logs::endpoint_security::LoggerPeer;
 
  private:
-  std::shared_ptr<serializers::Serializer> serializer_;
+  std::shared_ptr<santa::Serializer> serializer_;
   std::shared_ptr<santa::Writer> writer_;
 };
 

--- a/Source/santad/Logs/EndpointSecurity/Logger.h
+++ b/Source/santad/Logs/EndpointSecurity/Logger.h
@@ -45,7 +45,7 @@ class Logger {
     uint64_t spool_flush_timeout_ms);
 
   Logger(std::shared_ptr<serializers::Serializer> serializer,
-         std::shared_ptr<writers::Writer> writer);
+         std::shared_ptr<santa::Writer> writer);
 
   virtual ~Logger() = default;
 
@@ -72,7 +72,7 @@ class Logger {
 
  private:
   std::shared_ptr<serializers::Serializer> serializer_;
-  std::shared_ptr<writers::Writer> writer_;
+  std::shared_ptr<santa::Writer> writer_;
 };
 
 }  // namespace santa::santad::logs::endpoint_security

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -27,17 +27,17 @@
 #include "Source/santad/Logs/EndpointSecurity/Writers/Syslog.h"
 #include "Source/santad/SNTDecisionCache.h"
 
+using santa::BasicString;
+using santa::Empty;
+using santa::File;
+using santa::Null;
+using santa::Protobuf;
+using santa::Spool;
+using santa::Syslog;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::BasicString;
-using santa::Empty;
-using santa::Protobuf;
-using santa::File;
-using santa::Null;
-using santa::Spool;
-using santa::Syslog;
 
 namespace santa {
 
@@ -81,8 +81,7 @@ std::unique_ptr<Logger> Logger::Create(std::shared_ptr<EndpointSecurityAPI> esap
   }
 }
 
-Logger::Logger(std::shared_ptr<santa::Serializer> serializer,
-               std::shared_ptr<santa::Writer> writer)
+Logger::Logger(std::shared_ptr<santa::Serializer> serializer, std::shared_ptr<santa::Writer> writer)
     : serializer_(std::move(serializer)), writer_(std::move(writer)) {}
 
 void Logger::Log(std::unique_ptr<EnrichedMessage> msg) {

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -34,10 +34,10 @@ using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::serializers::BasicString;
 using santa::santad::logs::endpoint_security::serializers::Empty;
 using santa::santad::logs::endpoint_security::serializers::Protobuf;
-using santa::santad::logs::endpoint_security::writers::File;
-using santa::santad::logs::endpoint_security::writers::Null;
-using santa::santad::logs::endpoint_security::writers::Spool;
-using santa::santad::logs::endpoint_security::writers::Syslog;
+using santa::File;
+using santa::Null;
+using santa::Spool;
+using santa::Syslog;
 
 namespace santa::santad::logs::endpoint_security {
 
@@ -82,7 +82,7 @@ std::unique_ptr<Logger> Logger::Create(std::shared_ptr<EndpointSecurityAPI> esap
 }
 
 Logger::Logger(std::shared_ptr<serializers::Serializer> serializer,
-               std::shared_ptr<writers::Writer> writer)
+               std::shared_ptr<santa::Writer> writer)
     : serializer_(std::move(serializer)), writer_(std::move(writer)) {}
 
 void Logger::Log(std::unique_ptr<EnrichedMessage> msg) {

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -39,7 +39,7 @@ using santa::Null;
 using santa::Spool;
 using santa::Syslog;
 
-namespace santa::santad::logs::endpoint_security {
+namespace santa {
 
 // Flush the write buffer every 5 seconds
 static const uint64_t kFlushBufferTimeoutMS = 10000;
@@ -120,4 +120,4 @@ void Logger::Flush() {
   writer_->Flush();
 }
 
-}  // namespace santa::santad::logs::endpoint_security
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Logger.mm
+++ b/Source/santad/Logs/EndpointSecurity/Logger.mm
@@ -31,9 +31,9 @@ using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::serializers::BasicString;
-using santa::santad::logs::endpoint_security::serializers::Empty;
-using santa::santad::logs::endpoint_security::serializers::Protobuf;
+using santa::BasicString;
+using santa::Empty;
+using santa::Protobuf;
 using santa::File;
 using santa::Null;
 using santa::Spool;
@@ -81,7 +81,7 @@ std::unique_ptr<Logger> Logger::Create(std::shared_ptr<EndpointSecurityAPI> esap
   }
 }
 
-Logger::Logger(std::shared_ptr<serializers::Serializer> serializer,
+Logger::Logger(std::shared_ptr<santa::Serializer> serializer,
                std::shared_ptr<santa::Writer> writer)
     : serializer_(std::move(serializer)), writer_(std::move(writer)) {}
 

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -44,7 +44,7 @@ using santa::santad::event_providers::endpoint_security::EnrichedFile;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 using santa::BasicString;
 using santa::Empty;
 using santa::Protobuf;
@@ -53,7 +53,7 @@ using santa::Null;
 using santa::Spool;
 using santa::Syslog;
 
-namespace santa::santad::logs::endpoint_security {
+namespace santa {
 
 class LoggerPeer : public Logger {
  public:
@@ -67,9 +67,9 @@ class LoggerPeer : public Logger {
   std::shared_ptr<santa::Writer> Writer() { return writer_; }
 };
 
-}  // namespace santa::santad::logs::endpoint_security
+}  // namespace santa
 
-using santa::santad::logs::endpoint_security::LoggerPeer;
+using santa::LoggerPeer;
 
 class MockSerializer : public Empty {
  public:

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -45,9 +45,9 @@ using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::Message;
 using santa::santad::logs::endpoint_security::Logger;
-using santa::santad::logs::endpoint_security::serializers::BasicString;
-using santa::santad::logs::endpoint_security::serializers::Empty;
-using santa::santad::logs::endpoint_security::serializers::Protobuf;
+using santa::BasicString;
+using santa::Empty;
+using santa::Protobuf;
 using santa::File;
 using santa::Null;
 using santa::Spool;
@@ -62,7 +62,7 @@ class LoggerPeer : public Logger {
 
   LoggerPeer(std::unique_ptr<Logger> l) : Logger(l->serializer_, l->writer_) {}
 
-  std::shared_ptr<serializers::Serializer> Serializer() { return serializer_; }
+  std::shared_ptr<santa::Serializer> Serializer() { return serializer_; }
 
   std::shared_ptr<santa::Writer> Writer() { return writer_; }
 };

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -39,19 +39,19 @@
 #include "Source/santad/Logs/EndpointSecurity/Writers/Syslog.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
 
+using santa::BasicString;
+using santa::Empty;
+using santa::File;
+using santa::Logger;
+using santa::Null;
+using santa::Protobuf;
+using santa::Spool;
+using santa::Syslog;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
 using santa::santad::event_providers::endpoint_security::EnrichedFile;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::EnrichedProcess;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Logger;
-using santa::BasicString;
-using santa::Empty;
-using santa::Protobuf;
-using santa::File;
-using santa::Null;
-using santa::Spool;
-using santa::Syslog;
 
 namespace santa {
 

--- a/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/LoggerTest.mm
@@ -48,10 +48,10 @@ using santa::santad::logs::endpoint_security::Logger;
 using santa::santad::logs::endpoint_security::serializers::BasicString;
 using santa::santad::logs::endpoint_security::serializers::Empty;
 using santa::santad::logs::endpoint_security::serializers::Protobuf;
-using santa::santad::logs::endpoint_security::writers::File;
-using santa::santad::logs::endpoint_security::writers::Null;
-using santa::santad::logs::endpoint_security::writers::Spool;
-using santa::santad::logs::endpoint_security::writers::Syslog;
+using santa::File;
+using santa::Null;
+using santa::Spool;
+using santa::Syslog;
 
 namespace santa::santad::logs::endpoint_security {
 
@@ -64,7 +64,7 @@ class LoggerPeer : public Logger {
 
   std::shared_ptr<serializers::Serializer> Serializer() { return serializer_; }
 
-  std::shared_ptr<writers::Writer> Writer() { return writer_; }
+  std::shared_ptr<santa::Writer> Writer() { return writer_; }
 };
 
 }  // namespace santa::santad::logs::endpoint_security

--- a/Source/santad/Logs/EndpointSecurity/MockLogger.h
+++ b/Source/santad/Logs/EndpointSecurity/MockLogger.h
@@ -21,7 +21,7 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Logs/EndpointSecurity/Logger.h"
 
-class MockLogger : public santa::santad::logs::endpoint_security::Logger {
+class MockLogger : public santa::Logger {
  public:
   using Logger::Logger;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.h
@@ -27,7 +27,7 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 #import "Source/santad/SNTDecisionCache.h"
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 class BasicString : public Serializer {
  public:
@@ -110,6 +110,6 @@ class BasicString : public Serializer {
   bool prefix_time_name_;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -35,6 +35,12 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 #import "Source/santad/SNTDecisionCache.h"
 
+using santa::MountFromName;
+using santa::NonNull;
+using santa::Pid;
+using santa::Pidversion;
+using santa::RealGroup;
+using santa::RealUser;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
 using santa::santad::event_providers::endpoint_security::EnrichedCSInvalidated;
@@ -58,12 +64,6 @@ using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingAt
 using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingDetach;
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::MountFromName;
-using santa::NonNull;
-using santa::Pid;
-using santa::Pidversion;
-using santa::RealGroup;
-using santa::RealUser;
 
 namespace santa {
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -65,7 +65,7 @@ using santa::Pidversion;
 using santa::RealGroup;
 using santa::RealUser;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 static inline SanitizableString FilePath(const es_file_t *file) {
   return SanitizableString(file);
@@ -768,4 +768,4 @@ std::vector<uint8_t> BasicString::SerializeDiskDisappeared(NSDictionary *props) 
   return FinalizeString(str);
 }
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicString.mm
@@ -58,12 +58,12 @@ using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingAt
 using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingDetach;
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
-using santa::santad::logs::endpoint_security::serializers::Utilities::NonNull;
-using santa::santad::logs::endpoint_security::serializers::Utilities::Pid;
-using santa::santad::logs::endpoint_security::serializers::Utilities::Pidversion;
-using santa::santad::logs::endpoint_security::serializers::Utilities::RealGroup;
-using santa::santad::logs::endpoint_security::serializers::Utilities::RealUser;
+using santa::MountFromName;
+using santa::NonNull;
+using santa::Pid;
+using santa::Pidversion;
+using santa::RealGroup;
+using santa::RealUser;
 
 namespace santa::santad::logs::endpoint_security::serializers {
 
@@ -365,7 +365,7 @@ std::vector<uint8_t> BasicString::SerializeMessage(const EnrichedExec &msg, SNTC
   str.append("|path=");
   str.append(FilePath(msg->event.exec.target->executable).Sanitized());
 
-  NSString *origPath = Utilities::OriginalPathForTranslocation(msg->event.exec.target);
+  NSString *origPath = santa::OriginalPathForTranslocation(msg->event.exec.target);
   if (origPath) {
     str.append("|origpath=");
     str.append(SanitizableString(origPath).Sanitized());
@@ -685,7 +685,7 @@ std::vector<uint8_t> BasicString::SerializeAllowlist(const Message &msg,
   str.append("|pidversion=");
   str.append(std::to_string(Pidversion(msg->process->audit_token)));
   str.append("|path=");
-  str.append(FilePath(Utilities::GetAllowListTargetFile(msg)).Sanitized());
+  str.append(FilePath(santa::GetAllowListTargetFile(msg)).Sanitized());
   str.append("|sha256=");
   str.append(hash);
 
@@ -715,9 +715,9 @@ std::vector<uint8_t> BasicString::SerializeDiskAppeared(NSDictionary *props) {
   NSString *dmg_path = nil;
   NSString *serial = nil;
   if ([props[@"DADeviceModel"] isEqual:@"Disk Image"]) {
-    dmg_path = Utilities::DiskImageForDevice(props[@"DADevicePath"]);
+    dmg_path = santa::DiskImageForDevice(props[@"DADevicePath"]);
   } else {
-    serial = Utilities::SerialForDevice(props[@"DADevicePath"]);
+    serial = santa::SerialForDevice(props[@"DADevicePath"]);
   }
 
   NSString *model = [NSString

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -50,11 +50,11 @@ extern std::string GetAccessTypeString(es_event_type_t event_type);
 extern std::string GetFileAccessPolicyDecisionString(FileAccessPolicyDecision decision);
 }  // namespace santa
 
-using santaGetAccessTypeString;
-using santaGetDecisionString;
-using santaGetFileAccessPolicyDecisionString;
-using santaGetModeString;
-using santaGetReasonString;
+using santa::GetAccessTypeString;
+using santa::GetDecisionString;
+using santa::GetFileAccessPolicyDecisionString;
+using santa::GetModeString;
+using santa::GetReasonString;
 
 std::string BasicStringSerializeMessage(std::shared_ptr<MockEndpointSecurityAPI> mockESApi,
                                         es_message_t *esMsg, SNTDecisionCache *decisionCache) {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -37,10 +37,10 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 #import "Source/santad/SNTDecisionCache.h"
 
-using santa::santad::event_providers::endpoint_security::Enricher;
-using santa::santad::event_providers::endpoint_security::Message;
 using santa::BasicString;
 using santa::Serializer;
+using santa::santad::event_providers::endpoint_security::Enricher;
+using santa::santad::event_providers::endpoint_security::Message;
 
 namespace santa {
 extern std::string GetDecisionString(SNTEventState event_state);

--- a/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/BasicStringTest.mm
@@ -39,22 +39,22 @@
 
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::serializers::BasicString;
-using santa::santad::logs::endpoint_security::serializers::Serializer;
+using santa::BasicString;
+using santa::Serializer;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 extern std::string GetDecisionString(SNTEventState event_state);
 extern std::string GetReasonString(SNTEventState event_state);
 extern std::string GetModeString(SNTClientMode mode);
 extern std::string GetAccessTypeString(es_event_type_t event_type);
 extern std::string GetFileAccessPolicyDecisionString(FileAccessPolicyDecision decision);
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
-using santa::santad::logs::endpoint_security::serializers::GetAccessTypeString;
-using santa::santad::logs::endpoint_security::serializers::GetDecisionString;
-using santa::santad::logs::endpoint_security::serializers::GetFileAccessPolicyDecisionString;
-using santa::santad::logs::endpoint_security::serializers::GetModeString;
-using santa::santad::logs::endpoint_security::serializers::GetReasonString;
+using santaGetAccessTypeString;
+using santaGetDecisionString;
+using santaGetFileAccessPolicyDecisionString;
+using santaGetModeString;
+using santaGetReasonString;
 
 std::string BasicStringSerializeMessage(std::shared_ptr<MockEndpointSecurityAPI> mockESApi,
                                         es_message_t *esMsg, SNTDecisionCache *decisionCache) {

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.h
@@ -23,7 +23,7 @@
 #include "Source/common/SNTCachedDecision.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 class Empty : public Serializer {
  public:
@@ -92,6 +92,6 @@ class Empty : public Serializer {
   std::vector<uint8_t> SerializeDiskDisappeared(NSDictionary *) override;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Empty.mm
@@ -36,7 +36,7 @@ using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingDe
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 std::shared_ptr<Empty> Empty::Create() {
   return std::make_shared<Empty>();
@@ -144,4 +144,4 @@ std::vector<uint8_t> Empty::SerializeDiskDisappeared(NSDictionary *props) {
   return {};
 }
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Serializers/EmptyTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/EmptyTest.mm
@@ -19,7 +19,7 @@
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Empty.h"
 
-using santaEmpty;
+using santa::Empty;
 
 namespace es = santa::santad::event_providers::endpoint_security;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/EmptyTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/EmptyTest.mm
@@ -19,7 +19,7 @@
 #include "Source/santad/EventProviders/EndpointSecurity/EnrichedTypes.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Empty.h"
 
-using santa::santad::logs::endpoint_security::serializers::Empty;
+using santaEmpty;
 
 namespace es = santa::santad::event_providers::endpoint_security;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.h
@@ -28,7 +28,7 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h"
 #import "Source/santad/SNTDecisionCache.h"
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 class Protobuf : public Serializer {
  public:
@@ -123,6 +123,6 @@ class Protobuf : public Serializer {
   bool json_;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -69,14 +69,14 @@ using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingAt
 using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingDetach;
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::serializers::Utilities::EffectiveGroup;
-using santa::santad::logs::endpoint_security::serializers::Utilities::EffectiveUser;
-using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
-using santa::santad::logs::endpoint_security::serializers::Utilities::NonNull;
-using santa::santad::logs::endpoint_security::serializers::Utilities::Pid;
-using santa::santad::logs::endpoint_security::serializers::Utilities::Pidversion;
-using santa::santad::logs::endpoint_security::serializers::Utilities::RealGroup;
-using santa::santad::logs::endpoint_security::serializers::Utilities::RealUser;
+using santa::EffectiveGroup;
+using santa::EffectiveUser;
+using santa::MountFromName;
+using santa::NonNull;
+using santa::Pid;
+using santa::Pidversion;
+using santa::RealGroup;
+using santa::RealUser;
 
 namespace pbv1 = ::santa::pb::v1;
 
@@ -678,7 +678,7 @@ std::vector<uint8_t> Protobuf::SerializeMessage(const EnrichedExec &msg, SNTCach
   EncodeString([pb_exec] { return pb_exec->mutable_explain(); }, cd.decisionExtra);
   EncodeString([pb_exec] { return pb_exec->mutable_quarantine_url(); }, cd.quarantineURL);
 
-  NSString *orig_path = Utilities::OriginalPathForTranslocation(msg->event.exec.target);
+  NSString *orig_path = santa::OriginalPathForTranslocation(msg->event.exec.target);
   EncodeString([pb_exec] { return pb_exec->mutable_original_path(); }, orig_path);
 
   EncodeEntitlements(pb_exec, cd);
@@ -1009,7 +1009,7 @@ std::vector<uint8_t> Protobuf::SerializeAllowlist(const Message &msg, const std:
   Arena arena;
   ::pbv1::SantaMessage *santa_msg = CreateDefaultProto(&arena);
 
-  const es_file_t *es_file = Utilities::GetAllowListTargetFile(msg);
+  const es_file_t *es_file = santa::GetAllowListTargetFile(msg);
 
   EnrichedFile enriched_file(std::nullopt, std::nullopt, std::nullopt);
   EnrichedProcess enriched_process;
@@ -1047,9 +1047,9 @@ static void EncodeDisk(::pbv1::Disk *pb_disk, ::pbv1::Disk_Action action, NSDict
   NSString *dmg_path = nil;
   NSString *serial = nil;
   if ([props[@"DADeviceModel"] isEqual:@"Disk Image"]) {
-    dmg_path = Utilities::DiskImageForDevice(props[@"DADevicePath"]);
+    dmg_path = santa::DiskImageForDevice(props[@"DADevicePath"]);
   } else {
-    serial = Utilities::SerialForDevice(props[@"DADevicePath"]);
+    serial = santa::SerialForDevice(props[@"DADevicePath"]);
   }
 
   NSString *model = [NSString

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -43,7 +43,15 @@ using google::protobuf::Timestamp;
 using JsonPrintOptions = google::protobuf::json::PrintOptions;
 using google::protobuf::json::MessageToJsonString;
 
+using santa::EffectiveGroup;
+using santa::EffectiveUser;
+using santa::MountFromName;
+using santa::NonNull;
 using santa::NSStringToUTF8StringView;
+using santa::Pid;
+using santa::Pidversion;
+using santa::RealGroup;
+using santa::RealUser;
 using santa::StringTokenToStringView;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::EnrichedClose;
@@ -69,14 +77,6 @@ using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingAt
 using santa::santad::event_providers::endpoint_security::EnrichedScreenSharingDetach;
 using santa::santad::event_providers::endpoint_security::EnrichedUnlink;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::EffectiveGroup;
-using santa::EffectiveUser;
-using santa::MountFromName;
-using santa::NonNull;
-using santa::Pid;
-using santa::Pidversion;
-using santa::RealGroup;
-using santa::RealUser;
 
 namespace pbv1 = ::santa::pb::v1;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Protobuf.mm
@@ -80,7 +80,7 @@ using santa::RealUser;
 
 namespace pbv1 = ::santa::pb::v1;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 static constexpr NSUInteger kMaxEncodeObjectEntries = 64;
 static constexpr NSUInteger kMaxEncodeObjectLevels = 5;
@@ -1103,4 +1103,4 @@ std::vector<uint8_t> Protobuf::SerializeDiskDisappeared(NSDictionary *props) {
   return FinalizeProto(santa_msg);
 }
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -50,12 +50,12 @@ using JsonPrintOptions = google::protobuf::json::PrintOptions;
 using JsonParseOptions = ::google::protobuf::json::ParseOptions;
 using google::protobuf::json::JsonStringToMessage;
 using google::protobuf::json::MessageToJsonString;
+using santa::Protobuf;
+using santa::Serializer;
 using santa::santad::event_providers::endpoint_security::EnrichedEventType;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::Protobuf;
-using santa::Serializer;
 
 namespace pbv1 = ::santa::pb::v1;
 

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -54,12 +54,12 @@ using santa::santad::event_providers::endpoint_security::EnrichedEventType;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::serializers::Protobuf;
-using santa::santad::logs::endpoint_security::serializers::Serializer;
+using santaProtobuf;
+using santaSerializer;
 
 namespace pbv1 = ::santa::pb::v1;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 extern void EncodeExitStatus(::pbv1::Exit *pbExit, int exitStatus);
 extern void EncodeEntitlements(::pbv1::Execution *pb_exec, SNTCachedDecision *cd);
 extern ::pbv1::Execution::Decision GetDecisionEnum(SNTEventState event_state);
@@ -72,19 +72,19 @@ extern ::pbv1::FileAccess::PolicyDecision GetPolicyDecision(FileAccessPolicyDeci
 extern ::pbv1::SocketAddress::Type GetSocketAddressType(es_address_type_t type);
 extern ::pbv1::OpenSSHLogin::Result GetOpenSSHLoginResultType(es_openssh_login_result_type_t type);
 #endif  // HAVE_MACOS_13
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
-using santa::santad::logs::endpoint_security::serializers::EncodeEntitlements;
-using santa::santad::logs::endpoint_security::serializers::EncodeExitStatus;
-using santa::santad::logs::endpoint_security::serializers::GetAccessType;
-using santa::santad::logs::endpoint_security::serializers::GetDecisionEnum;
-using santa::santad::logs::endpoint_security::serializers::GetFileDescriptorType;
-using santa::santad::logs::endpoint_security::serializers::GetModeEnum;
-using santa::santad::logs::endpoint_security::serializers::GetPolicyDecision;
-using santa::santad::logs::endpoint_security::serializers::GetReasonEnum;
+using santaEncodeEntitlements;
+using santaEncodeExitStatus;
+using santaGetAccessType;
+using santaGetDecisionEnum;
+using santaGetFileDescriptorType;
+using santaGetModeEnum;
+using santaGetPolicyDecision;
+using santaGetReasonEnum;
 #if HAVE_MACOS_13
-using santa::santad::logs::endpoint_security::serializers::GetOpenSSHLoginResultType;
-using santa::santad::logs::endpoint_security::serializers::GetSocketAddressType;
+using santaGetOpenSSHLoginResultType;
+using santaGetSocketAddressType;
 #endif  // HAVE_MACOS_13
 
 @interface ProtobufTest : XCTestCase

--- a/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/ProtobufTest.mm
@@ -54,8 +54,8 @@ using santa::santad::event_providers::endpoint_security::EnrichedEventType;
 using santa::santad::event_providers::endpoint_security::EnrichedMessage;
 using santa::santad::event_providers::endpoint_security::Enricher;
 using santa::santad::event_providers::endpoint_security::Message;
-using santaProtobuf;
-using santaSerializer;
+using santa::Protobuf;
+using santa::Serializer;
 
 namespace pbv1 = ::santa::pb::v1;
 
@@ -74,17 +74,17 @@ extern ::pbv1::OpenSSHLogin::Result GetOpenSSHLoginResultType(es_openssh_login_r
 #endif  // HAVE_MACOS_13
 }  // namespace santa
 
-using santaEncodeEntitlements;
-using santaEncodeExitStatus;
-using santaGetAccessType;
-using santaGetDecisionEnum;
-using santaGetFileDescriptorType;
-using santaGetModeEnum;
-using santaGetPolicyDecision;
-using santaGetReasonEnum;
+using santa::EncodeEntitlements;
+using santa::EncodeExitStatus;
+using santa::GetAccessType;
+using santa::GetDecisionEnum;
+using santa::GetFileDescriptorType;
+using santa::GetModeEnum;
+using santa::GetPolicyDecision;
+using santa::GetReasonEnum;
 #if HAVE_MACOS_13
-using santaGetOpenSSHLoginResultType;
-using santaGetSocketAddressType;
+using santa::GetOpenSSHLoginResultType;
+using santa::GetSocketAddressType;
 #endif  // HAVE_MACOS_13
 
 @interface ProtobufTest : XCTestCase

--- a/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.h
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <string>
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 // Small helper class that will sanitize a given string, but will only use new
 // memory if the string required sanitization. If the string is already
@@ -56,6 +56,6 @@ class SanitizableString {
   mutable std::optional<std::string> sanitized_string_;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableString.mm
@@ -18,7 +18,7 @@
 
 using santa::NSStringToUTF8StringView;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 SanitizableString::SanitizableString(const es_file_t *file)
     : data_(file->path.data, file->path.length) {}
@@ -108,4 +108,4 @@ std::optional<std::string> SanitizableString::SanitizeString(const char *str, si
   return std::nullopt;
 }
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableStringTest.mm
@@ -22,7 +22,7 @@
 
 #include "Source/common/TestUtils.h"
 
-using santaSanitizableString;
+using santa::SanitizableString;
 
 @interface SanitizableStringTest : XCTestCase
 @end

--- a/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableStringTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/SanitizableStringTest.mm
@@ -22,7 +22,7 @@
 
 #include "Source/common/TestUtils.h"
 
-using santa::santad::logs::endpoint_security::serializers::SanitizableString;
+using santaSanitizableString;
 
 @interface SanitizableStringTest : XCTestCase
 @end

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.h
@@ -28,7 +28,7 @@
 
 @class SNTStoredEvent;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 class Serializer {
  public:
@@ -118,6 +118,6 @@ class Serializer {
   SNTDecisionCache *decision_cache_;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::serializers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Serializer.mm
@@ -22,7 +22,7 @@
 
 namespace es = santa::santad::event_providers::endpoint_security;
 
-namespace santa::santad::logs::endpoint_security::serializers {
+namespace santa {
 
 Serializer::Serializer(SNTDecisionCache *decision_cache) : decision_cache_(decision_cache) {
   if ([[SNTConfigurator configurator] enableMachineIDDecoration]) {
@@ -52,4 +52,4 @@ std::vector<uint8_t> Serializer::SerializeMessageTemplate(const es::EnrichedExec
   return SerializeMessage(msg, cd);
 }
 
-};  // namespace santa::santad::logs::endpoint_security::serializers
+};  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h
@@ -21,7 +21,7 @@
 
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 
-namespace santa::santad::logs::endpoint_security::serializers::Utilities {
+namespace santa {
 
 static inline pid_t Pid(const audit_token_t &tok) {
   return audit_token_to_pid(tok);
@@ -61,6 +61,6 @@ es_file_t *GetAllowListTargetFile(
 
 const mach_port_t GetDefaultIOKitCommsPort();
 
-}  // namespace santa::santad::logs::endpoint_security::serializers::Utilities
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/Utilities.mm
@@ -30,7 +30,7 @@ extern "C" CFURLRef __nullable SecTranslocateCreateOriginalPathForURL(CFURLRef t
 
 using santa::santad::event_providers::endpoint_security::Message;
 
-namespace santa::santad::logs::endpoint_security::serializers::Utilities {
+namespace santa {
 
 NSString *OriginalPathForTranslocation(const es_process_t *es_proc) {
   // Cache vnodes that have been determined to not be translocated
@@ -148,4 +148,4 @@ es_file_t *GetAllowListTargetFile(const Message &msg) {
   }
 }
 
-}  // namespace santa::santad::logs::endpoint_security::serializers::Utilities
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
@@ -22,9 +22,9 @@
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
-using santa::santad::event_providers::endpoint_security::Message;
 using santa::GetAllowListTargetFile;
 using santa::MountFromName;
+using santa::santad::event_providers::endpoint_security::Message;
 
 @interface UtilitiesTest : XCTestCase
 @end

--- a/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Serializers/UtilitiesTest.mm
@@ -23,8 +23,8 @@
 #include "Source/santad/Logs/EndpointSecurity/Serializers/Utilities.h"
 
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::serializers::Utilities::GetAllowListTargetFile;
-using santa::santad::logs::endpoint_security::serializers::Utilities::MountFromName;
+using santa::GetAllowListTargetFile;
+using santa::MountFromName;
 
 @interface UtilitiesTest : XCTestCase
 @end

--- a/Source/santad/Logs/EndpointSecurity/Writers/File.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.h
@@ -24,11 +24,11 @@
 #include <vector>
 
 // Forward declarations
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 class FilePeer;
 }
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 class File : public Writer, public std::enable_shared_from_this<File> {
  public:
@@ -44,7 +44,7 @@ class File : public Writer, public std::enable_shared_from_this<File> {
   void Write(std::vector<uint8_t> &&bytes) override;
   void Flush() override;
 
-  friend class santa::santad::logs::endpoint_security::writers::FilePeer;
+  friend class santa::FilePeer;
 
  private:
   void OpenFileHandleLocked();
@@ -70,6 +70,6 @@ class File : public Writer, public std::enable_shared_from_this<File> {
   size_t buffer_offset_ = 0;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Writers/File.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/File.mm
@@ -18,7 +18,7 @@
 
 #include "Source/common/BranchPrediction.h"
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 std::shared_ptr<File> File::Create(NSString *path, uint64_t flush_timeout_ms,
                                    size_t batch_size_bytes, size_t max_expected_write_size_bytes) {
@@ -143,4 +143,4 @@ void File::FlushLocked() {
   }
 }
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Writers/FileTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/FileTest.mm
@@ -22,7 +22,7 @@
 #include "Source/common/TestUtils.h"
 #import "Source/santad/Logs/EndpointSecurity/Writers/File.h"
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 class FilePeer : public File {
  public:
@@ -59,9 +59,9 @@ class FilePeer : public File {
   }
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
-using santa::santad::logs::endpoint_security::writers::FilePeer;
+using santa::FilePeer;
 
 bool WaitFor(bool (^condition)(void)) {
   int attempts = 0;

--- a/Source/santad/Logs/EndpointSecurity/Writers/Null.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Null.h
@@ -20,7 +20,7 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 class Null : public Writer {
  public:
@@ -31,6 +31,6 @@ class Null : public Writer {
   void Flush() override;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Writers/Null.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Null.mm
@@ -14,7 +14,7 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/Null.h"
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 std::shared_ptr<Null> Null::Create() {
   return std::make_shared<Null>();
@@ -28,4 +28,4 @@ void Null::Flush() {
   // Intentionally do nothing
 }
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.h
@@ -28,11 +28,11 @@
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
 
 // Forward declarations
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 class SpoolPeer;
 }
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 class Spool : public Writer, public std::enable_shared_from_this<Spool> {
  public:
   // Factory
@@ -51,7 +51,7 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   void BeginFlushTask();
 
   // Peer class for testing
-  friend class santa::santad::logs::endpoint_security::writers::SpoolPeer;
+  friend class santa::SpoolPeer;
 
  private:
   bool FlushLocked();
@@ -73,6 +73,6 @@ class Spool : public Writer, public std::enable_shared_from_this<Spool> {
   size_t accumulated_bytes_ = 0;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Spool.mm
@@ -20,7 +20,7 @@
 
 static const char *kTypeGoogleApisComPrefix = "type.googleapis.com/";
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 std::shared_ptr<Spool> Spool::Create(std::string_view base_dir, size_t max_spool_disk_size,
                                      size_t max_spool_batch_size, uint64_t flush_timeout_ms) {
@@ -149,4 +149,4 @@ void Spool::Write(std::vector<uint8_t> &&bytes) {
   });
 }
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Writers/SpoolTest.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/SpoolTest.mm
@@ -23,7 +23,7 @@
 #include "Source/santad/Logs/EndpointSecurity/Writers/FSSpool/fsspool_log_batch_writer.h"
 #include "Source/santad/Logs/EndpointSecurity/Writers/Spool.h"
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 class SpoolPeer : public Spool {
  public:
@@ -34,9 +34,9 @@ class SpoolPeer : public Spool {
   std::string GetTypeUrl() { return type_url_; }
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
-using santa::santad::logs::endpoint_security::writers::SpoolPeer;
+using santa::SpoolPeer;
 
 @interface SpoolTest : XCTestCase
 @property dispatch_queue_t q;

--- a/Source/santad/Logs/EndpointSecurity/Writers/Syslog.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Syslog.h
@@ -19,7 +19,7 @@
 
 #include "Source/santad/Logs/EndpointSecurity/Writers/Writer.h"
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 class Syslog : public Writer {
  public:
@@ -29,6 +29,6 @@ class Syslog : public Writer {
   void Flush() override;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
 #endif

--- a/Source/santad/Logs/EndpointSecurity/Writers/Syslog.mm
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Syslog.mm
@@ -16,7 +16,7 @@
 
 #include <os/log.h>
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 std::shared_ptr<Syslog> Syslog::Create() {
   return std::make_shared<Syslog>();
@@ -30,4 +30,4 @@ void Syslog::Flush() {
   // Nothing to do here
 }
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa

--- a/Source/santad/Logs/EndpointSecurity/Writers/Writer.h
+++ b/Source/santad/Logs/EndpointSecurity/Writers/Writer.h
@@ -17,7 +17,7 @@
 
 #include <vector>
 
-namespace santa::santad::logs::endpoint_security::writers {
+namespace santa {
 
 class Writer {
  public:
@@ -27,6 +27,6 @@ class Writer {
   virtual void Flush() = 0;
 };
 
-}  // namespace santa::santad::logs::endpoint_security::writers
+}  // namespace santa
 
 #endif

--- a/Source/santad/SNTCompilerController.h
+++ b/Source/santad/SNTCompilerController.h
@@ -25,7 +25,7 @@
 // This function will determine if the instigating process was a compiler and,
 // for appropriate events, will create appropriate transitive rules.
 - (BOOL)handleEvent:(const santa::santad::event_providers::endpoint_security::Message &)msg
-         withLogger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger;
+         withLogger:(std::shared_ptr<santa::Logger>)logger;
 
 // Set whether or not the given audit token should be tracked as a compiler
 - (void)setProcess:(const audit_token_t &)tok isCompiler:(bool)isCompiler;

--- a/Source/santad/SNTCompilerController.mm
+++ b/Source/santad/SNTCompilerController.mm
@@ -30,8 +30,8 @@
 #import "Source/santad/SNTDatabaseController.h"
 #import "Source/santad/SNTDecisionCache.h"
 
-using santa::santad::event_providers::endpoint_security::Message;
 using santa::Logger;
+using santa::santad::event_providers::endpoint_security::Message;
 
 static const pid_t PID_MAX = 99999;
 static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";

--- a/Source/santad/SNTCompilerController.mm
+++ b/Source/santad/SNTCompilerController.mm
@@ -31,7 +31,7 @@
 #import "Source/santad/SNTDecisionCache.h"
 
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 static const pid_t PID_MAX = 99999;
 static constexpr std::string_view kIgnoredCompilerProcessPathPrefix = "/dev/";

--- a/Source/santad/SNTCompilerControllerTest.mm
+++ b/Source/santad/SNTCompilerControllerTest.mm
@@ -33,7 +33,7 @@
 #import "Source/santad/SNTDecisionCache.h"
 
 using santa::santad::event_providers::endpoint_security::Message;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 static const pid_t PID_MAX = 99999;
 

--- a/Source/santad/SNTCompilerControllerTest.mm
+++ b/Source/santad/SNTCompilerControllerTest.mm
@@ -32,8 +32,8 @@
 #import "Source/santad/SNTCompilerController.h"
 #import "Source/santad/SNTDecisionCache.h"
 
-using santa::santad::event_providers::endpoint_security::Message;
 using santa::Logger;
+using santa::santad::event_providers::endpoint_security::Message;
 
 static const pid_t PID_MAX = 99999;
 

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -29,11 +29,10 @@
 ///
 @interface SNTDaemonControlController : NSObject <SNTDaemonControlXPC>
 
-- (instancetype)
-  initWithAuthResultCache:
-    (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
-        notificationQueue:(SNTNotificationQueue *)notQueue
-               syncdQueue:(SNTSyncdQueue *)syncdQueue
-                   logger:(std::shared_ptr<santa::Logger>)logger
-               watchItems:(std::shared_ptr<santa::WatchItems>)watchItems;
+- (instancetype)initWithAuthResultCache:
+                  (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
+                      notificationQueue:(SNTNotificationQueue *)notQueue
+                             syncdQueue:(SNTSyncdQueue *)syncdQueue
+                                 logger:(std::shared_ptr<santa::Logger>)logger
+                             watchItems:(std::shared_ptr<santa::WatchItems>)watchItems;
 @end

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -34,6 +34,6 @@
     (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
         notificationQueue:(SNTNotificationQueue *)notQueue
                syncdQueue:(SNTSyncdQueue *)syncdQueue
-                   logger:(std::shared_ptr<santa::santad::logs::endpoint_security::Logger>)logger
+                   logger:(std::shared_ptr<santa::Logger>)logger
                watchItems:(std::shared_ptr<santa::WatchItems>)watchItems;
 @end

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -36,12 +36,12 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 #import "Source/santad/SNTSyncdQueue.h"
 
+using santa::Logger;
 using santa::WatchItems;
 using santa::WatchItemsState;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
-using santa::Logger;
 
 // Globals used by the santad watchdog thread
 uint64_t watchdogCPUEvents = 0;

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -41,7 +41,7 @@ using santa::WatchItemsState;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 // Globals used by the santad watchdog thread
 uint64_t watchdogCPUEvents = 0;

--- a/Source/santad/Santad.h
+++ b/Source/santad/Santad.h
@@ -36,7 +36,7 @@ void SantadMain(
     std::shared_ptr<
         santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>
         esapi,
-    std::shared_ptr<santa::santad::logs::endpoint_security::Logger> logger,
+    std::shared_ptr<santa::Logger> logger,
     std::shared_ptr<santa::santad::Metrics> metrics,
     std::shared_ptr<santa::WatchItems> watch_items,
     std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -39,6 +39,7 @@
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
+using santa::Logger;
 using santa::PrefixTree;
 using santa::Unit;
 using santa::WatchItems;
@@ -49,7 +50,6 @@ using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;
-using santa::Logger;
 
 static void EstablishSyncServiceConnection(SNTSyncdQueue *syncd_queue) {
   // The syncBaseURL check is here to stop retrying if the sync server is removed.

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -49,7 +49,7 @@ using santa::santad::event_providers::FlushCacheMode;
 using santa::santad::event_providers::FlushCacheReason;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 static void EstablishSyncServiceConnection(SNTSyncdQueue *syncd_queue) {
   // The syncBaseURL check is here to stop retrying if the sync server is removed.

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -48,7 +48,7 @@ class SantadDeps {
       std::shared_ptr<santa::santad::event_providers::endpoint_security::
                           EndpointSecurityAPI>
           esapi,
-      std::unique_ptr<santa::santad::logs::endpoint_security::Logger> logger,
+      std::unique_ptr<santa::Logger> logger,
       std::shared_ptr<santa::santad::Metrics> metrics,
       std::shared_ptr<santa::WatchItems> watch_items,
       std::shared_ptr<santa::santad::event_providers::AuthResultCache>
@@ -68,7 +68,7 @@ class SantadDeps {
   std::shared_ptr<
       santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>
   ESAPI();
-  std::shared_ptr<santa::santad::logs::endpoint_security::Logger> Logger();
+  std::shared_ptr<santa::Logger> Logger();
   std::shared_ptr<santa::santad::Metrics> Metrics();
   std::shared_ptr<santa::WatchItems> WatchItems();
   MOLXPCConnection *ControlConnection();
@@ -84,7 +84,7 @@ class SantadDeps {
   std::shared_ptr<
       santa::santad::event_providers::endpoint_security::EndpointSecurityAPI>
       esapi_;
-  std::shared_ptr<santa::santad::logs::endpoint_security::Logger> logger_;
+  std::shared_ptr<santa::Logger> logger_;
   std::shared_ptr<santa::santad::Metrics> metrics_;
   std::shared_ptr<santa::WatchItems> watch_items_;
   std::shared_ptr<santa::santad::event_providers::endpoint_security::Enricher>

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -38,7 +38,7 @@ using santa::santad::TTYWriter;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;
-using santa::santad::logs::endpoint_security::Logger;
+using santa::Logger;
 
 namespace santa::santad {
 

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -30,6 +30,7 @@
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
+using santa::Logger;
 using santa::PrefixTree;
 using santa::Unit;
 using santa::WatchItems;
@@ -38,7 +39,6 @@ using santa::santad::TTYWriter;
 using santa::santad::event_providers::AuthResultCache;
 using santa::santad::event_providers::endpoint_security::EndpointSecurityAPI;
 using santa::santad::event_providers::endpoint_security::Enricher;
-using santa::Logger;
 
 namespace santa::santad {
 


### PR DESCRIPTION
The style guide prefers that a projects do not overly nest namespace names, and note that unless necessary, a single top-level namespace per project is the most effective strategy to limit exposure to collisions.

This is part 2 in a series of PRs to convert namespaces. This is being done piecemeal to keep PR sizes manageable. This PR converts the namespaces:

* `santa::santad::logs::endpoint_security::serializers::Utilities`
* `santa::santad::logs::endpoint_security::writers`
* `santa::santad::logs::endpoint_security::serializers`
* `santa::santad::logs::endpoint_security`
* `santatest`

To keep PR size reasonable, part 1 only changes things in santa::common and santa::santad::data_layer. Other namespaces will be converted in a future PR.

References:

* [Namespaces style guide](https://google.github.io/styleguide/cppguide.html#Namespaces)
* [Namespace names style guide](https://google.github.io/styleguide/cppguide.html#Namespace_Names)
* [Tip of the Week #130: Namespace Naming](https://abseil.io/tips/130)
* Part 1: #1384 
