### PR TITLE
Namespace simplification pt4 (final)

### DIFF
--- a/Source/santad/EventProviders/AuthResultCache.h
+++ b/Source/santad/EventProviders/AuthResultCache.h
@@ -27,7 +27,7 @@
 #import "Source/common/SantaVnode.h"
 #include "Source/santad/EventProviders/EndpointSecurity/EndpointSecurityAPI.h"
 
-namespace santa::santad::event_providers {
+namespace santa {
 
 enum class FlushCacheMode {
   kNonRootOnly,
@@ -87,6 +87,6 @@ class AuthResultCache {
   dispatch_queue_t q_;
 };
 
-}  // namespace santa::santad::event_providers
+}  // namespace santa
 
 #endif

--- a/Source/santad/EventProviders/AuthResultCache.mm
+++ b/Source/santad/EventProviders/AuthResultCache.mm
@@ -36,7 +36,7 @@ static NSString *const kFlushCacheReasonEntitlementsPrefixFilterChanged =
 static NSString *const kFlushCacheReasonEntitlementsTeamIDFilterChanged =
   @"EntitlementsTeamIDFilterChanged";
 
-namespace santa::santad::event_providers {
+namespace santa {
 
 static inline uint64_t GetCurrentUptime() {
   return clock_gettime_nsec_np(CLOCK_MONOTONIC);
@@ -185,4 +185,4 @@ NSArray<NSNumber *> *AuthResultCache::CacheCounts() {
   return @[ @(root_cache_->count()), @(nonroot_cache_->count()) ];
 }
 
-}  // namespace santa::santad::event_providers
+}  // namespace santa

--- a/Source/santad/EventProviders/AuthResultCacheTest.mm
+++ b/Source/santad/EventProviders/AuthResultCacheTest.mm
@@ -27,15 +27,15 @@
 #include "Source/santad/EventProviders/AuthResultCache.h"
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 
-using santa::santad::event_providers::AuthResultCache;
-using santa::santad::event_providers::FlushCacheMode;
-using santa::santad::event_providers::FlushCacheReason;
+using santa::AuthResultCache;
+using santa::FlushCacheMode;
+using santa::FlushCacheReason;
 
-namespace santa::santad::event_providers {
+namespace santa {
 extern NSString *const FlushCacheReasonToString(FlushCacheReason reason);
-}
+}  // namespace santa
 
-using santa::santad::event_providers::FlushCacheReasonToString;
+using santa::FlushCacheReasonToString;
 
 // Grab the st_dev number of the root volume to match the root cache
 static uint64_t RootDevno() {

--- a/Source/santad/EventProviders/RateLimiter.h
+++ b/Source/santad/EventProviders/RateLimiter.h
@@ -23,11 +23,11 @@
 #include "Source/santad/Metrics.h"
 
 // Forward declarations
-namespace santa::santad::event_providers {
+namespace santa {
 class RateLimiterPeer;
-}
+}  // namespace santa
 
-namespace santa::santad::event_providers {
+namespace santa {
 
 // Very basic rate limiting infrastructure.
 // Currently only handles X events per duration.
@@ -39,12 +39,11 @@ class RateLimiter {
  public:
   // Factory
   static std::shared_ptr<RateLimiter> Create(
-      std::shared_ptr<santa::santad::Metrics> metrics,
-      santa::santad::Processor processor, uint16_t max_qps,
-      NSTimeInterval reset_duration = kDefaultResetDuration);
+      std::shared_ptr<santa::Metrics> metrics, santa::Processor processor,
+      uint16_t max_qps, NSTimeInterval reset_duration = kDefaultResetDuration);
 
-  RateLimiter(std::shared_ptr<santa::santad::Metrics> metrics,
-              santa::santad::Processor processor, uint16_t max_qps,
+  RateLimiter(std::shared_ptr<santa::Metrics> metrics,
+              santa::Processor processor, uint16_t max_qps,
               NSTimeInterval reset_duration);
 
   enum class Decision {
@@ -54,7 +53,7 @@ class RateLimiter {
 
   Decision Decide(uint64_t cur_mach_time);
 
-  friend class santa::santad::event_providers::RateLimiterPeer;
+  friend class santa::RateLimiterPeer;
 
  private:
   bool ShouldRateLimitLocked();
@@ -63,8 +62,8 @@ class RateLimiter {
 
   static constexpr NSTimeInterval kDefaultResetDuration = 15.0;
 
-  std::shared_ptr<santa::santad::Metrics> metrics_;
-  santa::santad::Processor processor_;
+  std::shared_ptr<santa::Metrics> metrics_;
+  santa::Processor processor_;
   size_t log_count_total_ = 0;
   size_t max_log_count_total_;
   uint64_t reset_mach_time_;
@@ -72,6 +71,6 @@ class RateLimiter {
   dispatch_queue_t q_;
 };
 
-}  // namespace santa::santad::event_providers
+}  // namespace santa
 
 #endif

--- a/Source/santad/EventProviders/RateLimiter.mm
+++ b/Source/santad/EventProviders/RateLimiter.mm
@@ -17,10 +17,10 @@
 #include "Source/common/BranchPrediction.h"
 #include "Source/common/SystemResources.h"
 
-using santa::santad::Metrics;
-using santa::santad::Processor;
+using santa::Metrics;
+using santa::Processor;
 
-namespace santa::santad::event_providers {
+namespace santa {
 
 std::shared_ptr<RateLimiter> RateLimiter::Create(std::shared_ptr<Metrics> metrics,
                                                  Processor processor, uint16_t max_qps,
@@ -82,4 +82,4 @@ RateLimiter::Decision RateLimiter::Decide(uint64_t cur_mach_time) {
   return decision;
 }
 
-}  // namespace santa::santad::event_providers
+}  // namespace santa

--- a/Source/santad/EventProviders/RateLimiterTest.mm
+++ b/Source/santad/EventProviders/RateLimiterTest.mm
@@ -20,12 +20,11 @@
 #include "Source/common/SystemResources.h"
 #include "Source/santad/Metrics.h"
 
-using santa::santad::event_providers::RateLimiter;
+using santa::RateLimiter;
 
-static const santa::santad::Processor kDefaultProcessor =
-  santa::santad::Processor::kFileAccessAuthorizer;
+static const santa::Processor kDefaultProcessor = santa::Processor::kFileAccessAuthorizer;
 
-namespace santa::santad::event_providers {
+namespace santa {
 
 class RateLimiterPeer : public RateLimiter {
  public:
@@ -39,9 +38,9 @@ class RateLimiterPeer : public RateLimiter {
   using RateLimiter::reset_mach_time_;
 };
 
-}  // namespace santa::santad::event_providers
+}  // namespace santa
 
-using santa::santad::event_providers::RateLimiterPeer;
+using santa::RateLimiterPeer;
 
 @interface RateLimiterTest : XCTestCase
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.h
@@ -28,10 +28,9 @@
     : SNTEndpointSecurityClient <SNTEndpointSecurityEventHandler>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                execController:(SNTExecutionController *)execController
            compilerController:(SNTCompilerController *)compilerController
-              authResultCache:
-                (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache;
+              authResultCache:(std::shared_ptr<santa::AuthResultCache>)authResultCache;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
@@ -26,10 +26,10 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Metrics.h"
 
+using santa::AuthResultCache;
 using santa::EndpointSecurityAPI;
+using santa::EventDisposition;
 using santa::Message;
-using santa::santad::EventDisposition;
-using santa::santad::event_providers::AuthResultCache;
 
 @interface SNTEndpointSecurityAuthorizer ()
 @property SNTCompilerController *compilerController;
@@ -41,13 +41,13 @@ using santa::santad::event_providers::AuthResultCache;
 }
 
 - (instancetype)initWithESAPI:(std::shared_ptr<EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                execController:(SNTExecutionController *)execController
            compilerController:(SNTCompilerController *)compilerController
               authResultCache:(std::shared_ptr<AuthResultCache>)authResultCache {
   self = [super initWithESAPI:std::move(esApi)
                       metrics:std::move(metrics)
-                    processor:santa::santad::Processor::kAuthorizer];
+                    processor:santa::Processor::kAuthorizer];
   if (self) {
     _execController = execController;
     _compilerController = compilerController;

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizerTest.mm
@@ -33,9 +33,9 @@
 #import "Source/santad/SNTCompilerController.h"
 #import "Source/santad/SNTExecutionController.h"
 
+using santa::AuthResultCache;
+using santa::EventDisposition;
 using santa::Message;
-using santa::santad::EventDisposition;
-using santa::santad::event_providers::AuthResultCache;
 
 class MockAuthResultCache : public AuthResultCache {
  public:
@@ -72,7 +72,7 @@ class MockAuthResultCache : public AuthResultCache {
   id authClient =
     [[SNTEndpointSecurityAuthorizer alloc] initWithESAPI:mockESApi
                                                  metrics:nullptr
-                                               processor:santa::santad::Processor::kAuthorizer];
+                                               processor:santa::Processor::kAuthorizer];
 
   EXPECT_CALL(*mockESApi, ClearCache)
     .After(EXPECT_CALL(*mockESApi, Subscribe(testing::_, expectedEventSubs))
@@ -82,7 +82,7 @@ class MockAuthResultCache : public AuthResultCache {
   [authClient enable];
 
   for (const auto &event : expectedEventSubs) {
-    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+    XCTAssertNoThrow(santa::EventTypeToString(event));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClient.mm
@@ -40,11 +40,11 @@
 using santa::Client;
 using santa::EndpointSecurityAPI;
 using santa::EnrichedMessage;
+using santa::EventDisposition;
 using santa::Message;
+using santa::Metrics;
+using santa::Processor;
 using santa::WatchItemPathType;
-using santa::santad::EventDisposition;
-using santa::santad::Metrics;
-using santa::santad::Processor;
 
 constexpr std::string_view kProtectedFiles[] = {"/private/var/db/santa/rules.db",
                                                 "/private/var/db/santa/events.db"};

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientBase.h
@@ -30,8 +30,8 @@
 @protocol SNTEndpointSecurityClientBase
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
-                    processor:(santa::santad::Processor)processor;
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
+                    processor:(santa::Processor)processor;
 
 /// @note If this fails to establish a new ES client via `es_new_client`, an exception is raised
 /// that should terminate the program.

--- a/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityClientTest.mm
@@ -40,15 +40,15 @@ using santa::EnrichedFile;
 using santa::EnrichedMessage;
 using santa::EnrichedProcess;
 using santa::Message;
+using santa::Processor;
 using santa::WatchItemPathType;
-using santa::santad::Processor;
 
 @interface SNTEndpointSecurityClient (Testing)
 - (void)establishClientOrDie;
 - (bool)muteSelf;
 - (NSString *)errorMessageForNewClientResult:(es_new_client_result_t)result;
 - (void)handleMessage:(Message &&)esMsg
-   recordEventMetrics:(void (^)(santa::santad::EventDisposition disposition))recordEventMetrics;
+   recordEventMetrics:(void (^)(santa::EventDisposition disposition))recordEventMetrics;
 - (BOOL)shouldHandleMessage:(const Message &)esMsg;
 - (int64_t)computeBudgetForDeadline:(uint64_t)deadline currentTime:(uint64_t)currentTime;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h
@@ -40,10 +40,9 @@ typedef void (^SNTDeviceBlockCallback)(SNTDeviceEvent *event);
 @property(nonatomic, nullable) SNTDeviceBlockCallback deviceBlockCallback;
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<santa::Logger>)logger
-              authResultCache:
-                (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
+              authResultCache:(std::shared_ptr<santa::AuthResultCache>)authResultCache
                 blockUSBMount:(BOOL)blockUSBMount
                remountUSBMode:(nullable NSArray<NSString *> *)remountUSBMode
            startupPreferences:(SNTDeviceManagerStartupPreferences)startupPrefs;

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.mm
@@ -33,13 +33,13 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/Metrics.h"
 
+using santa::AuthResultCache;
 using santa::EndpointSecurityAPI;
+using santa::EventDisposition;
+using santa::FlushCacheMode;
+using santa::FlushCacheReason;
 using santa::Logger;
 using santa::Message;
-using santa::santad::EventDisposition;
-using santa::santad::event_providers::AuthResultCache;
-using santa::santad::event_providers::FlushCacheMode;
-using santa::santad::event_providers::FlushCacheReason;
 
 // Defined operations for startup metrics:
 // Device shouldn't be operated on (e.g. not a mass storage device)
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithESAPI:(std::shared_ptr<EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<Logger>)logger
               authResultCache:(std::shared_ptr<AuthResultCache>)authResultCache
                 blockUSBMount:(BOOL)blockUSBMount
@@ -186,7 +186,7 @@ NS_ASSUME_NONNULL_BEGIN
            startupPreferences:(SNTDeviceManagerStartupPreferences)startupPrefs {
   self = [super initWithESAPI:std::move(esApi)
                       metrics:std::move(metrics)
-                    processor:santa::santad::Processor::kDeviceManager];
+                    processor:santa::Processor::kDeviceManager];
   if (self) {
     _logger = logger;
     _authResultCache = authResultCache;

--- a/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityDeviceManagerTest.mm
@@ -38,11 +38,11 @@
 #import "Source/santad/EventProviders/SNTEndpointSecurityDeviceManager.h"
 #include "Source/santad/Metrics.h"
 
+using santa::AuthResultCache;
+using santa::EventDisposition;
+using santa::FlushCacheMode;
+using santa::FlushCacheReason;
 using santa::Message;
-using santa::santad::EventDisposition;
-using santa::santad::event_providers::AuthResultCache;
-using santa::santad::event_providers::FlushCacheMode;
-using santa::santad::event_providers::FlushCacheReason;
 
 class MockAuthResultCache : public AuthResultCache {
  public:
@@ -498,10 +498,10 @@ class MockAuthResultCache : public AuthResultCache {
   };
   auto mockESApi = std::make_shared<MockEndpointSecurityAPI>();
 
-  id deviceClient = [[SNTEndpointSecurityDeviceManager alloc]
-    initWithESAPI:mockESApi
-          metrics:nullptr
-        processor:santa::santad::Processor::kDeviceManager];
+  id deviceClient =
+    [[SNTEndpointSecurityDeviceManager alloc] initWithESAPI:mockESApi
+                                                    metrics:nullptr
+                                                  processor:santa::Processor::kDeviceManager];
 
   EXPECT_CALL(*mockESApi, ClearCache(testing::_))
     .After(EXPECT_CALL(*mockESApi, Subscribe(testing::_, expectedEventSubs))
@@ -511,7 +511,7 @@ class MockAuthResultCache : public AuthResultCache {
   [deviceClient enable];
 
   for (const auto &event : expectedEventSubs) {
-    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+    XCTAssertNoThrow(santa::EventTypeToString(event));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityEventHandler.h
@@ -27,7 +27,7 @@
 // Called Synchronously and serially for each message provided by the
 // EndpointSecurity framework.
 - (void)handleMessage:(santa::Message &&)esMsg
-   recordEventMetrics:(void (^)(santa::santad::EventDisposition))recordEventMetrics;
+   recordEventMetrics:(void (^)(santa::EventDisposition))recordEventMetrics;
 
 // Called after Santa has finished initializing itself.
 // This is an optimal place to subscribe to ES events

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.h
@@ -34,12 +34,12 @@ typedef void (^SNTFileAccessBlockCallback)(SNTFileAccessEvent *event, NSString *
     : SNTEndpointSecurityClient <SNTEndpointSecurityDynamicEventHandler>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<santa::Logger>)logger
                    watchItems:(std::shared_ptr<santa::WatchItems>)watchItems
                      enricher:(std::shared_ptr<santa::Enricher>)enricher
                 decisionCache:(SNTDecisionCache *)decisionCache
-                    ttyWriter:(std::shared_ptr<santa::santad::TTYWriter>)ttyWriter;
+                    ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter;
 
 @property SNTFileAccessBlockCallback fileAccessBlockCallback;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizer.mm
@@ -54,18 +54,18 @@
 using santa::EndpointSecurityAPI;
 using santa::Enricher;
 using santa::EnrichOptions;
+using santa::EventDisposition;
+using santa::FileAccessMetricStatus;
 using santa::Logger;
 using santa::Message;
+using santa::Metrics;
 using santa::OptionalStringToNSString;
+using santa::RateLimiter;
 using santa::StringToNSString;
+using santa::TTYWriter;
 using santa::WatchItemPathType;
 using santa::WatchItemPolicy;
 using santa::WatchItems;
-using santa::santad::EventDisposition;
-using santa::santad::FileAccessMetricStatus;
-using santa::santad::Metrics;
-using santa::santad::TTYWriter;
-using santa::santad::event_providers::RateLimiter;
 
 NSString *kBadCertHash = @"BAD_CERT_HASH";
 
@@ -402,10 +402,10 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
                    watchItems:(std::shared_ptr<WatchItems>)watchItems
                      enricher:(std::shared_ptr<santa::Enricher>)enricher
                 decisionCache:(SNTDecisionCache *)decisionCache
-                    ttyWriter:(std::shared_ptr<santa::santad::TTYWriter>)ttyWriter {
+                    ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter {
   self = [super initWithESAPI:std::move(esApi)
                       metrics:metrics
-                    processor:santa::santad::Processor::kFileAccessAuthorizer];
+                    processor:santa::Processor::kFileAccessAuthorizer];
   if (self) {
     _watchItems = std::move(watchItems);
     _logger = std::move(logger);
@@ -416,8 +416,8 @@ bool ShouldMessageTTY(const std::shared_ptr<WatchItemPolicy> &policy, const Mess
 
     _configurator = [SNTConfigurator configurator];
 
-    _rateLimiter = RateLimiter::Create(_metrics, santa::santad::Processor::kFileAccessAuthorizer,
-                                       kDefaultRateLimitQPS);
+    _rateLimiter =
+      RateLimiter::Create(_metrics, santa::Processor::kFileAccessAuthorizer, kDefaultRateLimitQPS);
 
     SNTMetricBooleanGauge *famEnabled = [[SNTMetricSet sharedInstance]
       booleanGaugeWithName:@"/santa/fam_enabled"

--- a/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityFileAccessAuthorizerTest.mm
@@ -744,12 +744,12 @@ void ClearWatchItemPolicyProcess(WatchItemPolicy::Process &proc) {
   id fileAccessClient = [[SNTEndpointSecurityFileAccessAuthorizer alloc]
     initWithESAPI:mockESApi
           metrics:nullptr
-        processor:santa::santad::Processor::kFileAccessAuthorizer];
+        processor:santa::Processor::kFileAccessAuthorizer];
 
   [fileAccessClient enable];
 
   for (const auto &event : expectedEventSubs) {
-    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+    XCTAssertNoThrow(santa::EventTypeToString(event));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.h
@@ -30,12 +30,11 @@
     : SNTEndpointSecurityTreeAwareClient <SNTEndpointSecurityEventHandler>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<santa::Logger>)logger
                      enricher:(std::shared_ptr<santa::Enricher>)enricher
            compilerController:(SNTCompilerController *)compilerController
-              authResultCache:
-                (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
+              authResultCache:(std::shared_ptr<santa::AuthResultCache>)authResultCache
                    prefixTree:(std::shared_ptr<santa::PrefixTree<santa::Unit>>)prefixTree
                   processTree:
                     (std::shared_ptr<santa::santad::process_tree::ProcessTree>)processTree;

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorder.mm
@@ -27,15 +27,15 @@
 #include "Source/santad/Metrics.h"
 #include "Source/santad/ProcessTree/process_tree.h"
 
+using santa::AuthResultCache;
 using santa::EndpointSecurityAPI;
 using santa::EnrichedMessage;
 using santa::Enricher;
+using santa::EventDisposition;
 using santa::Logger;
 using santa::Message;
 using santa::PrefixTree;
 using santa::Unit;
-using santa::santad::EventDisposition;
-using santa::santad::event_providers::AuthResultCache;
 using santa::santad::process_tree::ProcessTree;
 
 es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
@@ -62,7 +62,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
 }
 
 - (instancetype)initWithESAPI:(std::shared_ptr<EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<Logger>)logger
                      enricher:(std::shared_ptr<Enricher>)enricher
            compilerController:(SNTCompilerController *)compilerController
@@ -71,7 +71,7 @@ es_file_t *GetTargetFileForPrefixTree(const es_message_t *msg) {
                   processTree:(std::shared_ptr<ProcessTree>)processTree {
   self = [super initWithESAPI:std::move(esApi)
                       metrics:std::move(metrics)
-                    processor:santa::santad::Processor::kRecorder
+                    processor:santa::Processor::kRecorder
                   processTree:std::move(processTree)];
   if (self) {
     _enricher = enricher;

--- a/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityRecorderTest.mm
@@ -39,15 +39,15 @@
 #include "Source/santad/Metrics.h"
 #import "Source/santad/SNTCompilerController.h"
 
+using santa::AuthResultCache;
 using santa::EnrichedMessage;
 using santa::Enricher;
+using santa::EventDisposition;
 using santa::Logger;
 using santa::Message;
 using santa::PrefixTree;
+using santa::Processor;
 using santa::Unit;
-using santa::santad::EventDisposition;
-using santa::santad::Processor;
-using santa::santad::event_providers::AuthResultCache;
 
 class MockEnricher : public Enricher {
  public:
@@ -120,7 +120,7 @@ class MockLogger : public Logger {
   [recorderClient enable];
 
   for (const auto &event : expectedEventSubs) {
-    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+    XCTAssertNoThrow(santa::EventTypeToString(event));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.h
@@ -27,7 +27,7 @@
     : SNTEndpointSecurityClient <SNTEndpointSecurityEventHandler>
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<santa::Logger>)logger;
 
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistance.mm
@@ -25,10 +25,10 @@
 #include "Source/santad/Metrics.h"
 
 using santa::EndpointSecurityAPI;
+using santa::EventDisposition;
 using santa::Logger;
 using santa::Message;
 using santa::WatchItemPathType;
-using santa::santad::EventDisposition;
 
 static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-driver";
 
@@ -37,11 +37,11 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
 }
 
 - (instancetype)initWithESAPI:(std::shared_ptr<EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
                        logger:(std::shared_ptr<Logger>)logger {
   self = [super initWithESAPI:std::move(esApi)
                       metrics:std::move(metrics)
-                    processor:santa::santad::Processor::kTamperResistance];
+                    processor:santa::Processor::kTamperResistance];
   if (self) {
     _logger = logger;
 

--- a/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTamperResistanceTest.mm
@@ -32,9 +32,9 @@
 #import "Source/santad/Metrics.h"
 
 using santa::Client;
+using santa::EventDisposition;
 using santa::Message;
 using santa::WatchItemPathType;
-using santa::santad::EventDisposition;
 
 static constexpr std::string_view kEventsDBPath = "/private/var/db/santa/events.db";
 static constexpr std::string_view kRulesDBPath = "/private/var/db/santa/rules.db";
@@ -81,7 +81,7 @@ static constexpr std::string_view kSantaKextIdentifier = "com.google.santa-drive
   [mockTamperClient enable];
 
   for (const auto &event : expectedEventSubs) {
-    XCTAssertNoThrow(santa::santad::EventTypeToString(event));
+    XCTAssertNoThrow(santa::EventTypeToString(event));
   }
 
   XCTBubbleMockVerifyAndClearExpectations(mockESApi.get());

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.h
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.h
@@ -22,8 +22,8 @@
 @property std::shared_ptr<santa::santad::process_tree::ProcessTree> processTree;
 
 - (instancetype)initWithESAPI:(std::shared_ptr<santa::EndpointSecurityAPI>)esApi
-                      metrics:(std::shared_ptr<santa::santad::Metrics>)metrics
-                    processor:(santa::santad::Processor)processor
+                      metrics:(std::shared_ptr<santa::Metrics>)metrics
+                    processor:(santa::Processor)processor
                   processTree:
                     (std::shared_ptr<santa::santad::process_tree::ProcessTree>)processTree;
 @end

--- a/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityTreeAwareClient.mm
@@ -24,10 +24,10 @@
 #include "Source/santad/ProcessTree/process_tree_macos.h"
 
 using santa::EndpointSecurityAPI;
+using santa::EventDisposition;
 using santa::Message;
-using santa::santad::EventDisposition;
-using santa::santad::Metrics;
-using santa::santad::Processor;
+using santa::Metrics;
+using santa::Processor;
 
 @implementation SNTEndpointSecurityTreeAwareClient {
   std::vector<bool> _addedEvents;

--- a/Source/santad/Metrics.h
+++ b/Source/santad/Metrics.h
@@ -28,7 +28,7 @@
 #import "Source/common/SNTMetricSet.h"
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 
-namespace santa::santad {
+namespace santa {
 
 // Test interface - forward declaration
 class MetricsPeer;
@@ -96,7 +96,7 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
                                  FileAccessMetricStatus status, es_event_type_t event_type,
                                  FileAccessPolicyDecision decision);
 
-  friend class santa::santad::MetricsPeer;
+  friend class santa::MetricsPeer;
 
  private:
   struct SequenceStats {
@@ -137,6 +137,6 @@ class Metrics : public std::enable_shared_from_this<Metrics> {
   std::map<EventStatChangeTuple, int64_t> stat_change_cache_;
 };
 
-}  // namespace santa::santad
+}  // namespace santa
 
 #endif

--- a/Source/santad/Metrics.mm
+++ b/Source/santad/Metrics.mm
@@ -87,7 +87,7 @@ static NSString *const kFileAccessPolicyDecisionAllowedAuditOnly = @"AllowedAudi
 
 static NSString *const kFileAccessMetricsAccessType = @"access";
 
-namespace santa::santad {
+namespace santa {
 
 NSString *const ProcessorToString(Processor processor) {
   switch (processor) {
@@ -494,4 +494,4 @@ void Metrics::SetFileAccessEventMetrics(std::string policy_version, std::string 
   });
 }
 
-}  // namespace santa::santad
+}  // namespace santa

--- a/Source/santad/MetricsTest.mm
+++ b/Source/santad/MetricsTest.mm
@@ -29,15 +29,15 @@
 #include "Source/santad/EventProviders/EndpointSecurity/Message.h"
 #include "Source/santad/EventProviders/EndpointSecurity/MockEndpointSecurityAPI.h"
 
-using santa::santad::EventCountTuple;
-using santa::santad::EventDisposition;
-using santa::santad::EventStatChangeTuple;
-using santa::santad::EventStatsTuple;
-using santa::santad::EventTimesTuple;
-using santa::santad::FileAccessEventCountTuple;
-using santa::santad::Processor;
+using santa::EventCountTuple;
+using santa::EventDisposition;
+using santa::EventStatChangeTuple;
+using santa::EventStatsTuple;
+using santa::EventTimesTuple;
+using santa::FileAccessEventCountTuple;
+using santa::Processor;
 
-namespace santa::santad {
+namespace santa {
 
 extern NSString *const ProcessorToString(Processor processor);
 extern NSString *const EventTypeToString(es_event_type_t eventType);
@@ -68,7 +68,7 @@ class MetricsPeer : public Metrics {
   using Metrics::SequenceStats;
 };
 
-}  // namespace santa::santad
+}  // namespace santa
 
 namespace santa {
 
@@ -84,17 +84,17 @@ class MessagePeer : public Message {
 
 }  // namespace santa
 
+using santa::EventDispositionToString;
+using santa::EventTypeToString;
+using santa::FileAccessMetricStatus;
+using santa::FileAccessMetricStatusToString;
+using santa::FileAccessPolicyDecisionToString;
 using santa::MessagePeer;
-using santa::santad::EventDispositionToString;
-using santa::santad::EventTypeToString;
-using santa::santad::FileAccessMetricStatus;
-using santa::santad::FileAccessMetricStatusToString;
-using santa::santad::FileAccessPolicyDecisionToString;
-using santa::santad::Metrics;
-using santa::santad::MetricsPeer;
-using santa::santad::ProcessorToString;
-using santa::santad::StatChangeStepToString;
-using santa::santad::StatResultToString;
+using santa::Metrics;
+using santa::MetricsPeer;
+using santa::ProcessorToString;
+using santa::StatChangeStepToString;
+using santa::StatResultToString;
 
 std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^block)(Metrics *)) {
   dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
@@ -478,7 +478,7 @@ std::shared_ptr<MetricsPeer> CreateBasicMetricsPeer(dispatch_queue_t q, void (^b
   auto metrics = std::make_shared<MetricsPeer>(self.q, timer, 100, mockEventProcessingTimes,
                                                mockEventCounts, mockEventCounts, mockEventCounts,
                                                mockEventCounts, mockEventCounts, nil,
-                                               ^(santa::santad::Metrics *m){
+                                               ^(santa::Metrics *m){
                                                  // This block intentionally left blank
                                                });
 

--- a/Source/santad/SNTDaemonControlController.h
+++ b/Source/santad/SNTDaemonControlController.h
@@ -29,8 +29,7 @@
 ///
 @interface SNTDaemonControlController : NSObject <SNTDaemonControlXPC>
 
-- (instancetype)initWithAuthResultCache:
-                  (std::shared_ptr<santa::santad::event_providers::AuthResultCache>)authResultCache
+- (instancetype)initWithAuthResultCache:(std::shared_ptr<santa::AuthResultCache>)authResultCache
                       notificationQueue:(SNTNotificationQueue *)notQueue
                              syncdQueue:(SNTSyncdQueue *)syncdQueue
                                  logger:(std::shared_ptr<santa::Logger>)logger

--- a/Source/santad/SNTDaemonControlController.mm
+++ b/Source/santad/SNTDaemonControlController.mm
@@ -36,12 +36,12 @@
 #import "Source/santad/SNTPolicyProcessor.h"
 #import "Source/santad/SNTSyncdQueue.h"
 
+using santa::AuthResultCache;
+using santa::FlushCacheMode;
+using santa::FlushCacheReason;
 using santa::Logger;
 using santa::WatchItems;
 using santa::WatchItemsState;
-using santa::santad::event_providers::AuthResultCache;
-using santa::santad::event_providers::FlushCacheMode;
-using santa::santad::event_providers::FlushCacheReason;
 
 // Globals used by the santad watchdog thread
 uint64_t watchdogCPUEvents = 0;

--- a/Source/santad/SNTExecutionController.h
+++ b/Source/santad/SNTExecutionController.h
@@ -59,7 +59,7 @@ const static NSString *kBlockLongPath = @"BlockLongPath";
                        eventTable:(SNTEventTable *)eventTable
                     notifierQueue:(SNTNotificationQueue *)notifierQueue
                        syncdQueue:(SNTSyncdQueue *)syncdQueue
-                        ttyWriter:(std::shared_ptr<santa::santad::TTYWriter>)ttyWriter
+                        ttyWriter:(std::shared_ptr<santa::TTYWriter>)ttyWriter
          entitlementsPrefixFilter:(NSArray<NSString *> *)prefixFilter
          entitlementsTeamIDFilter:(NSArray<NSString *> *)teamIDFilter;
 

--- a/Source/santad/SNTExecutionController.mm
+++ b/Source/santad/SNTExecutionController.mm
@@ -54,8 +54,8 @@
 
 using santa::Message;
 using santa::PrefixTree;
+using santa::TTYWriter;
 using santa::Unit;
-using santa::santad::TTYWriter;
 
 static const size_t kMaxAllowedPathLength = MAXPATHLEN - 1;  // -1 to account for null terminator
 

--- a/Source/santad/Santad.h
+++ b/Source/santad/Santad.h
@@ -35,17 +35,16 @@
 void SantadMain(
     std::shared_ptr<santa::EndpointSecurityAPI> esapi,
     std::shared_ptr<santa::Logger> logger,
-    std::shared_ptr<santa::santad::Metrics> metrics,
+    std::shared_ptr<santa::Metrics> metrics,
     std::shared_ptr<santa::WatchItems> watch_items,
     std::shared_ptr<santa::Enricher> enricher,
-    std::shared_ptr<santa::santad::event_providers::AuthResultCache>
-        auth_result_cache,
+    std::shared_ptr<santa::AuthResultCache> auth_result_cache,
     MOLXPCConnection* control_connection,
     SNTCompilerController* compiler_controller,
     SNTNotificationQueue* notifier_queue, SNTSyncdQueue* syncd_queue,
     SNTExecutionController* exec_controller,
     std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree,
-    std::shared_ptr<santa::santad::TTYWriter> tty_writer,
+    std::shared_ptr<santa::TTYWriter> tty_writer,
     std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree);
 
 #endif

--- a/Source/santad/Santad.mm
+++ b/Source/santad/Santad.mm
@@ -39,17 +39,17 @@
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
+using santa::AuthResultCache;
 using santa::EndpointSecurityAPI;
 using santa::Enricher;
+using santa::FlushCacheMode;
+using santa::FlushCacheReason;
 using santa::Logger;
+using santa::Metrics;
 using santa::PrefixTree;
+using santa::TTYWriter;
 using santa::Unit;
 using santa::WatchItems;
-using santa::santad::Metrics;
-using santa::santad::TTYWriter;
-using santa::santad::event_providers::AuthResultCache;
-using santa::santad::event_providers::FlushCacheMode;
-using santa::santad::event_providers::FlushCacheReason;
 
 static void EstablishSyncServiceConnection(SNTSyncdQueue *syncd_queue) {
   // The syncBaseURL check is here to stop retrying if the sync server is removed.

--- a/Source/santad/SantadDeps.h
+++ b/Source/santad/SantadDeps.h
@@ -37,7 +37,7 @@
 #import "Source/santad/SNTSyncdQueue.h"
 #include "Source/santad/TTYWriter.h"
 
-namespace santa::santad {
+namespace santa {
 
 class SantadDeps {
  public:
@@ -47,24 +47,22 @@ class SantadDeps {
   SantadDeps(
       std::shared_ptr<santa::EndpointSecurityAPI> esapi,
       std::unique_ptr<santa::Logger> logger,
-      std::shared_ptr<santa::santad::Metrics> metrics,
+      std::shared_ptr<santa::Metrics> metrics,
       std::shared_ptr<santa::WatchItems> watch_items,
-      std::shared_ptr<santa::santad::event_providers::AuthResultCache>
-          auth_result_cache,
+      std::shared_ptr<santa::AuthResultCache> auth_result_cache,
       MOLXPCConnection *control_connection,
       SNTCompilerController *compiler_controller,
       SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
       SNTExecutionController *exec_controller,
       std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree,
-      std::shared_ptr<santa::santad::TTYWriter> tty_writer,
+      std::shared_ptr<santa::TTYWriter> tty_writer,
       std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree);
 
-  std::shared_ptr<santa::santad::event_providers::AuthResultCache>
-  AuthResultCache();
+  std::shared_ptr<santa::AuthResultCache> AuthResultCache();
   std::shared_ptr<santa::Enricher> Enricher();
   std::shared_ptr<santa::EndpointSecurityAPI> ESAPI();
   std::shared_ptr<santa::Logger> Logger();
-  std::shared_ptr<santa::santad::Metrics> Metrics();
+  std::shared_ptr<santa::Metrics> Metrics();
   std::shared_ptr<santa::WatchItems> WatchItems();
   MOLXPCConnection *ControlConnection();
   SNTCompilerController *CompilerController();
@@ -72,17 +70,16 @@ class SantadDeps {
   SNTSyncdQueue *SyncdQueue();
   SNTExecutionController *ExecController();
   std::shared_ptr<santa::PrefixTree<santa::Unit>> PrefixTree();
-  std::shared_ptr<santa::santad::TTYWriter> TTYWriter();
+  std::shared_ptr<santa::TTYWriter> TTYWriter();
   std::shared_ptr<santa::santad::process_tree::ProcessTree> ProcessTree();
 
  private:
   std::shared_ptr<santa::EndpointSecurityAPI> esapi_;
   std::shared_ptr<santa::Logger> logger_;
-  std::shared_ptr<santa::santad::Metrics> metrics_;
+  std::shared_ptr<santa::Metrics> metrics_;
   std::shared_ptr<santa::WatchItems> watch_items_;
   std::shared_ptr<santa::Enricher> enricher_;
-  std::shared_ptr<santa::santad::event_providers::AuthResultCache>
-      auth_result_cache_;
+  std::shared_ptr<santa::AuthResultCache> auth_result_cache_;
 
   MOLXPCConnection *control_connection_;
   SNTCompilerController *compiler_controller_;
@@ -90,10 +87,10 @@ class SantadDeps {
   SNTSyncdQueue *syncd_queue_;
   SNTExecutionController *exec_controller_;
   std::shared_ptr<santa::PrefixTree<santa::Unit>> prefix_tree_;
-  std::shared_ptr<santa::santad::TTYWriter> tty_writer_;
+  std::shared_ptr<santa::TTYWriter> tty_writer_;
   std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree_;
 };
 
-}  // namespace santa::santad
+}  // namespace santa
 
 #endif

--- a/Source/santad/SantadDeps.mm
+++ b/Source/santad/SantadDeps.mm
@@ -30,17 +30,17 @@
 #include "Source/santad/SNTDecisionCache.h"
 #include "Source/santad/TTYWriter.h"
 
+using santa::AuthResultCache;
 using santa::EndpointSecurityAPI;
 using santa::Enricher;
 using santa::Logger;
+using santa::Metrics;
 using santa::PrefixTree;
+using santa::TTYWriter;
 using santa::Unit;
 using santa::WatchItems;
-using santa::santad::Metrics;
-using santa::santad::TTYWriter;
-using santa::santad::event_providers::AuthResultCache;
 
-namespace santa::santad {
+namespace santa {
 
 std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
                                                SNTMetricSet *metric_set) {
@@ -156,18 +156,18 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
     exit(EXIT_FAILURE);
   }
 
-  std::shared_ptr<process_tree::ProcessTree> process_tree;
-  std::vector<std::unique_ptr<process_tree::Annotator>> annotators;
+  std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree;
+  std::vector<std::unique_ptr<santa::santad::process_tree::Annotator>> annotators;
 
   for (NSString *annotation in [configurator enabledProcessAnnotations]) {
     if ([[annotation lowercaseString] isEqualToString:@"originator"]) {
-      annotators.emplace_back(std::make_unique<process_tree::OriginatorAnnotator>());
+      annotators.emplace_back(std::make_unique<santa::santad::process_tree::OriginatorAnnotator>());
     } else {
       LOGW(@"Unrecognized process annotation %@", annotation);
     }
   }
 
-  auto tree_status = process_tree::CreateTree(std::move(annotators));
+  auto tree_status = santa::santad::process_tree::CreateTree(std::move(annotators));
   if (!tree_status.ok()) {
     LOGE(@"Failed to create process tree: %@", @(tree_status.status().ToString().c_str()));
     exit(EXIT_FAILURE);
@@ -183,11 +183,11 @@ std::unique_ptr<SantadDeps> SantadDeps::Create(SNTConfigurator *configurator,
 SantadDeps::SantadDeps(
   std::shared_ptr<EndpointSecurityAPI> esapi, std::unique_ptr<::Logger> logger,
   std::shared_ptr<::Metrics> metrics, std::shared_ptr<::WatchItems> watch_items,
-  std::shared_ptr<santa::santad::event_providers::AuthResultCache> auth_result_cache,
-  MOLXPCConnection *control_connection, SNTCompilerController *compiler_controller,
-  SNTNotificationQueue *notifier_queue, SNTSyncdQueue *syncd_queue,
-  SNTExecutionController *exec_controller, std::shared_ptr<::PrefixTree<Unit>> prefix_tree,
-  std::shared_ptr<::TTYWriter> tty_writer, std::shared_ptr<process_tree::ProcessTree> process_tree)
+  std::shared_ptr<santa::AuthResultCache> auth_result_cache, MOLXPCConnection *control_connection,
+  SNTCompilerController *compiler_controller, SNTNotificationQueue *notifier_queue,
+  SNTSyncdQueue *syncd_queue, SNTExecutionController *exec_controller,
+  std::shared_ptr<::PrefixTree<Unit>> prefix_tree, std::shared_ptr<::TTYWriter> tty_writer,
+  std::shared_ptr<santa::santad::process_tree::ProcessTree> process_tree)
     : esapi_(std::move(esapi)),
       logger_(std::move(logger)),
       metrics_(std::move(metrics)),
@@ -254,8 +254,8 @@ std::shared_ptr<::TTYWriter> SantadDeps::TTYWriter() {
   return tty_writer_;
 }
 
-std::shared_ptr<process_tree::ProcessTree> SantadDeps::ProcessTree() {
+std::shared_ptr<santa::santad::process_tree::ProcessTree> SantadDeps::ProcessTree() {
   return process_tree_;
 }
 
-}  // namespace santa::santad
+}  // namespace santa

--- a/Source/santad/SantadTest.mm
+++ b/Source/santad/SantadTest.mm
@@ -39,7 +39,7 @@
 #include "Source/santad/SantadDeps.h"
 
 using santa::Message;
-using santa::santad::SantadDeps;
+using santa::SantadDeps;
 
 static int HexCharToInt(char hex) {
   if (hex >= '0' && hex <= '9') {
@@ -196,7 +196,7 @@ static const char *kBlockedCDHash = "7218eddfee4d3eba4873dedf22d1391d79aea25f";
   });
 
   [authClient handleMessage:Message(mockESApi, &esMsg)
-         recordEventMetrics:^(santa::santad::EventDisposition d){
+         recordEventMetrics:^(santa::EventDisposition d){
            // This block intentionally left blank
          }];
 

--- a/Source/santad/TTYWriter.h
+++ b/Source/santad/TTYWriter.h
@@ -21,7 +21,7 @@
 
 #include <memory>
 
-namespace santa::santad {
+namespace santa {
 
 // Small helper class to synchronize writing to TTYs
 class TTYWriter {
@@ -46,6 +46,6 @@ class TTYWriter {
   dispatch_queue_t q_;
 };
 
-}  // namespace santa::santad
+}  // namespace santa
 
 #endif

--- a/Source/santad/TTYWriter.mm
+++ b/Source/santad/TTYWriter.mm
@@ -21,7 +21,7 @@
 #import "Source/common/SNTLogging.h"
 #include "Source/common/String.h"
 
-namespace santa::santad {
+namespace santa {
 
 std::unique_ptr<TTYWriter> TTYWriter::Create() {
   dispatch_queue_t q = dispatch_queue_create_with_target(
@@ -64,4 +64,4 @@ void TTYWriter::Write(const es_process_t *proc, NSString *msg) {
   });
 }
 
-}  // namespace santa::santad
+}  // namespace santa

--- a/Source/santad/main.mm
+++ b/Source/santad/main.mm
@@ -24,7 +24,7 @@
 #import "Source/santad/Santad.h"
 #include "Source/santad/SantadDeps.h"
 
-using santa::santad::SantadDeps;
+using santa::SantadDeps;
 
 // Number of seconds to wait between checks.
 const int kWatchdogTimeInterval = 30;


### PR DESCRIPTION
The style guide prefers that a projects do not overly nest namespace names, and note that unless necessary, a single top-level namespace per project is the most effective strategy to limit exposure to collisions.

This is the 4th and final part of a series of PRs to convert namespaces. This is being done piecemeal to keep PR sizes manageable. This PR converts the namespaces:

* `santa::santad::event_providers`
* `santa::santad`

Note: The namespace `santa::santad::process_tree` is being left alone for now as that piece will soon be split off to another standalone repo.

References:

* [Namespaces style guide](https://google.github.io/styleguide/cppguide.html#Namespaces)
* [Namespace names style guide](https://google.github.io/styleguide/cppguide.html#Namespace_Names)
* [Tip of the Week #130: Namespace Naming](https://abseil.io/tips/130)
* Part 1: #1384
* Part 2: #1385 
* Part 3: #1386 