### PR TITLE
Add machine_id to facilitate a GRPC version of the sync protocol

### DIFF
--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -56,7 +56,8 @@ using santa::NSStringToUTF8String;
 - (BOOL)uploadEvents:(NSArray *)events {
   google::protobuf::Arena arena;
   auto req = google::protobuf::Arena::Create<::pbv1::EventUploadRequest>(&arena);
-  req->set_machine_id(self.syncState.machineID);
+  req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
+
   google::protobuf::RepeatedPtrField<::pbv1::Event> *uploadEvents = req->mutable_events();
 
   NSMutableSet *eventIds = [NSMutableSet setWithCapacity:events.count];

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -56,6 +56,7 @@ using santa::NSStringToUTF8String;
 - (BOOL)uploadEvents:(NSArray *)events {
   google::protobuf::Arena arena;
   auto req = google::protobuf::Arena::Create<::pbv1::EventUploadRequest>(&arena);
+  req->set_machine_id(self.syncState.machineID);
   google::protobuf::RepeatedPtrField<::pbv1::Event> *uploadEvents = req->mutable_events();
 
   NSMutableSet *eventIds = [NSMutableSet setWithCapacity:events.count];

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -18,11 +18,14 @@
 
 #import "Source/common/SNTSyncConstants.h"
 #import "Source/common/SNTXPCControlInterface.h"
+#import "Source/common/String.h"
 #import "Source/santasyncservice/SNTSyncState.h"
 
 #include <google/protobuf/arena.h>
 #include "Source/santasyncservice/syncv1.pb.h"
 namespace pbv1 = ::santa::sync::v1;
+
+using santa::NSStringToUTF8String;
 
 @implementation SNTSyncPostflight
 
@@ -34,7 +37,7 @@ namespace pbv1 = ::santa::sync::v1;
 - (BOOL)sync {
   google::protobuf::Arena arena;
   auto req = google::protobuf::Arena::Create<::pbv1::PostflightRequest>(&arena);
-  req->set_machine_id(self.syncState.machineID);
+  req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
   req->set_rules_received(self.syncState.rulesReceived);
   req->set_rules_processed(self.syncState.rulesProcessed);
 

--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -34,6 +34,7 @@ namespace pbv1 = ::santa::sync::v1;
 - (BOOL)sync {
   google::protobuf::Arena arena;
   auto req = google::protobuf::Arena::Create<::pbv1::PostflightRequest>(&arena);
+  req->set_machine_id(self.syncState.machineID);
   req->set_rules_received(self.syncState.rulesReceived);
   req->set_rules_processed(self.syncState.rulesProcessed);
 

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -76,6 +76,7 @@ The following table expands upon the above logic to list most of the permutation
 - (BOOL)sync {
   google::protobuf::Arena arena;
   auto req = google::protobuf::Arena::Create<::pbv1::PreflightRequest>(&arena);
+  req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
   req->set_serial_number(NSStringToUTF8String([SNTSystemInfo serialNumber]));
   req->set_hostname(NSStringToUTF8String([SNTSystemInfo longHostname]));
   req->set_os_version(NSStringToUTF8String([SNTSystemInfo osVersion]));

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -29,6 +29,7 @@
 #include "Source/santasyncservice/syncv1.pb.h"
 namespace pbv1 = ::santa::sync::v1;
 
+using santa::NSStringToUTF8String;
 using santa::StringToNSString;
 
 SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
@@ -104,7 +105,7 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 
   do {
     auto req = google::protobuf::Arena::Create<::pbv1::RuleDownloadRequest>(&arena);
-    req->set_machine_id(self.syncState.machineID);
+    req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
 
     if (!cursor.empty()) {
       req->set_cursor(cursor);

--- a/Source/santasyncservice/SNTSyncRuleDownload.mm
+++ b/Source/santasyncservice/SNTSyncRuleDownload.mm
@@ -104,6 +104,8 @@ SNTRuleCleanup SyncTypeToRuleCleanup(SNTSyncType syncType) {
 
   do {
     auto req = google::protobuf::Arena::Create<::pbv1::RuleDownloadRequest>(&arena);
+    req->set_machine_id(self.syncState.machineID);
+
     if (!cursor.empty()) {
       req->set_cursor(cursor);
     }

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -199,7 +199,7 @@ message Event {
 
 message EventUploadRequest {
   repeated Event events = 1;
-  // The UUID of the machine that generated this event.
+  // The UUID of the machine where the event(s) occurred
   string machine_id = 2;
 }
 

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -262,7 +262,7 @@ message Rule {
 message RuleDownloadRequest {
   string cursor = 1;
   // The UUID of the machine that is requesting the rules.
-  string machined_id = 2;
+  string machine_id = 2;
 }
 
 message RuleDownloadResponse {

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -51,6 +51,8 @@ message PreflightRequest {
   uint32 teamid_rule_count = 15;
   uint32 signingid_rule_count = 16;
   uint32 cdhash_rule_count = 17;
+  // The UUID of the machine that is sending this preflight.
+  string machine_id = 18;
 }
 
 message PreflightResponse {
@@ -197,6 +199,8 @@ message Event {
 
 message EventUploadRequest {
   repeated Event events = 1;
+  // The UUID of the machine that generated this event.
+  string machine_id = 2;
 }
 
 message EventUploadResponse {
@@ -252,6 +256,8 @@ message Rule {
 
 message RuleDownloadRequest {
   string cursor = 1;
+  // The UUID of the machine that is requesting the rules.
+  string machined_id = 2;
 }
 
 message RuleDownloadResponse {
@@ -262,6 +268,8 @@ message RuleDownloadResponse {
 message PostflightRequest {
   uint64 rules_received = 1;
   uint64 rules_processed = 2;
+  // The UUID of the machine that is sending this postflight.
+  string machine_id = 3;
 }
 
 message PostflightResponse { }


### PR DESCRIPTION
This PR adds a `machine_id` field to all of the Request messages in the proto version of the sync protocol. 

This is to enable a GRPC based version of the sync protocol.