### PR TITLE
Handle non-200 HTTP responses in SNTSyncStage performRequest

### DIFF
--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -220,7 +220,7 @@ using santa::NSStringToUTF8String;
                     timeout:(NSTimeInterval)timeout {
   NSError *error;
   NSData *data = [self dataFromRequest:request timeout:timeout error:&error];
-  if (*error != NULL) {
+  if (error) {
     SLOGE(@"Error performing request: %@", error.localizedDescription);
     return error;
   }


### PR DESCRIPTION
If we receive a non-200 HTTP response, we should return an error instead of parsing the response to an empty protobuf message.