### PR TITLE
common: Remove debug log when signing ID is missing.

### DIFF
--- a/Source/common/SigningIDHelpers.m
+++ b/Source/common/SigningIDHelpers.m
@@ -17,7 +17,6 @@
 
 NSString *FormatSigningID(MOLCodesignChecker *csc) {
   if (!csc.signingID.length) {
-    LOGD(@"unable to format signing ID as it's missing");
     return nil;
   }
 


### PR DESCRIPTION
This log line gets spit out in santactl fileinfo output in a way that makes the command harder to use for various things