### PR TITLE
sync: Fix serial_num field name

### DIFF
--- a/Source/common/SNTSystemInfo.h
+++ b/Source/common/SNTSystemInfo.h
@@ -54,4 +54,19 @@
 ///
 + (NSString *)modelIdentifier;
 
+///
+///  @return The Santa product version, e.g. 2024.6
+///
++ (NSString *)santaProductVersion;
+
+///
+///  @return The Santa build version, e.g. 655965194
+///
++ (NSString *)santaBuildVersion;
+
+///
+///  @return The full Santa versoin, e.g. 2024.6.655965194
+///
++ (NSString *)santaFullVersion;
+
 @end

--- a/Source/common/SNTSystemInfo.m
+++ b/Source/common/SNTSystemInfo.m
@@ -74,6 +74,21 @@
   return @(model);
 }
 
++ (NSString *)santaProductVersion {
+  NSDictionary *info_dict = [[NSBundle mainBundle] infoDictionary];
+  return info_dict[@"CFBundleShortVersionString"];
+}
+
++ (NSString *)santaBuildVersion {
+  NSDictionary *info_dict = [[NSBundle mainBundle] infoDictionary];
+  return [[info_dict[@"CFBundleVersion"] componentsSeparatedByString:@"."] lastObject];
+}
+
++ (NSString *)santaFullVersion {
+  NSDictionary *info_dict = [[NSBundle mainBundle] infoDictionary];
+  return info_dict[@"CFBundleVersion"];
+}
+
 #pragma mark - Internal
 
 + (NSDictionary *)_systemVersionDictionary {

--- a/Source/santad/BUILD
+++ b/Source/santad/BUILD
@@ -823,6 +823,7 @@ objc_library(
         "//Source/common:SNTConfigurator",
         "//Source/common:SNTLogging",
         "//Source/common:SNTMetricSet",
+        "//Source/common:SNTSystemInfo",
         "//Source/common:SNTXPCControlInterface",
         "//Source/common:SystemResources",
     ],

--- a/Source/santad/main.mm
+++ b/Source/santad/main.mm
@@ -20,6 +20,7 @@
 #import "Source/common/SNTConfigurator.h"
 #import "Source/common/SNTLogging.h"
 #import "Source/common/SNTMetricSet.h"
+#import "Source/common/SNTSystemInfo.h"
 #import "Source/common/SystemResources.h"
 #import "Source/santad/Santad.h"
 #include "Source/santad/SantadDeps.h"
@@ -111,13 +112,10 @@ int main(int argc, char *argv[]) {
     // Do not wait on child processes
     signal(SIGCHLD, SIG_IGN);
 
-    NSDictionary *info_dict = [[NSBundle mainBundle] infoDictionary];
+    NSString *product_version = [SNTSystemInfo santaProductVersion];
+    NSString *build_version = [SNTSystemInfo santaBuildVersion];
+
     NSProcessInfo *pi = [NSProcessInfo processInfo];
-
-    NSString *product_version = info_dict[@"CFBundleShortVersionString"];
-    NSString *build_version =
-      [[info_dict[@"CFBundleVersion"] componentsSeparatedByString:@"."] lastObject];
-
     if ([pi.arguments containsObject:@"-v"]) {
       printf("%s (build %s)\n", [product_version UTF8String], [build_version UTF8String]);
       return 0;

--- a/Source/santasyncservice/SNTSyncPreflight.mm
+++ b/Source/santasyncservice/SNTSyncPreflight.mm
@@ -87,8 +87,7 @@ The following table expands upon the above logic to list most of the permutation
   req->set_os_version(NSStringToUTF8String([SNTSystemInfo osVersion]));
   req->set_os_build(NSStringToUTF8String([SNTSystemInfo osBuild]));
   req->set_model_identifier(NSStringToUTF8String([SNTSystemInfo modelIdentifier]));
-  req->set_santa_version(
-    NSStringToUTF8String([[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]));
+  req->set_santa_version(NSStringToUTF8String([SNTSystemInfo santaFullVersion]));
   req->set_primary_user(NSStringToUTF8String(self.syncState.machineOwner));
 
   if (self.syncState.pushNotificationsToken) {

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -74,10 +74,7 @@ using santa::NSStringToUTF8String;
                      contentType:@"application/x-protobuf"];
   }
 
-  google::protobuf::json::PrintOptions options{
-    .always_print_enums_as_ints = false,
-    .preserve_proto_field_names = true,
-  };
+  google::protobuf::json::PrintOptions options{};
   std::string json;
   absl::Status status = google::protobuf::json::MessageToJsonString(*message, &json, options);
 

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -35,27 +35,27 @@ enum ClientMode {
 }
 
 message PreflightRequest {
-  string serial_number = 1 [json_name="serial_num"];
-  string hostname = 2;
-  string os_version = 3;
-  string os_build = 4;
-  string model_identifier = 5;
-  string santa_version = 6;
-  string primary_user = 7;
-  string push_notification_token = 8;
+  string serial_number = 1           [json_name="serial_num"];
+  string hostname = 2                [json_name="hostname"];
+  string os_version = 3              [json_name="os_version"];
+  string os_build = 4                [json_name="os_build"];
+  string model_identifier = 5        [json_name="model_identifier"];
+  string santa_version = 6           [json_name="santa_version"];
+  string primary_user = 7            [json_name="primary_user"];
+  string push_notification_token = 8 [json_name="push_notification_token"];
 
-  ClientMode client_mode = 9;
-  bool request_clean_sync = 10;
+  ClientMode client_mode = 9         [json_name="client_mode"];
+  bool request_clean_sync = 10       [json_name="request_clean_sync"];
 
-  uint32 binary_rule_count = 11;
-  uint32 certificate_rule_count = 12;
-  uint32 compiler_rule_count = 13;
-  uint32 transitive_rule_count = 14;
-  uint32 teamid_rule_count = 15;
-  uint32 signingid_rule_count = 16;
-  uint32 cdhash_rule_count = 17;
+  uint32 binary_rule_count = 11      [json_name="binary_rule_count"];
+  uint32 certificate_rule_count = 12 [json_name="certificate_rule_count"];
+  uint32 compiler_rule_count = 13    [json_name="compiler_rule_count"];
+  uint32 transitive_rule_count = 14  [json_name="transitive_rule_count"];
+  uint32 teamid_rule_count = 15      [json_name="teamid_rule_count"];
+  uint32 signingid_rule_count = 16   [json_name="signingid_rule_count"];
+  uint32 cdhash_rule_count = 17      [json_name="cdhash_rule_count"];
   // The UUID of the machine that is sending this preflight.
-  string machine_id = 18;
+  string machine_id = 18             [json_name="machine_id"];
 }
 
 enum SyncType {
@@ -193,53 +193,53 @@ message Certificate {
   string cn = 2;
   string org = 3;
   string ou = 4;
-  uint32 valid_from = 5;
-  uint32 valid_until = 6;
+  uint32 valid_from = 5   [json_name="valid_from"];
+  uint32 valid_until = 6  [json_name="valid_until"];
 }
 
 message Event {
-  string file_sha256 = 1;
-  string file_path = 2;
-  string file_name = 3;
-  string executing_user = 4;
-  double execution_time = 5;
-  repeated string logged_in_users = 6;
-  repeated string current_sessions = 7;
-  Decision decision = 8;
+  string file_sha256 = 1                        [json_name="file_sha256"];
+  string file_path = 2                          [json_name="file_path"];
+  string file_name = 3                          [json_name="file_name"];
+  string executing_user = 4                     [json_name="executing_user"];
+  double execution_time = 5                     [json_name="execution_time"];
+  repeated string logged_in_users = 6           [json_name="logged_in_users"];
+  repeated string current_sessions = 7          [json_name="current_sessions"];
+  Decision decision = 8                         [json_name="decision"];
 
-  string file_bundle_id = 9;
-  string file_bundle_path = 10;
-  string file_bundle_executable_rel_path = 11;
-  string file_bundle_name = 12;
-  string file_bundle_version = 13;
-  string file_bundle_version_string = 14;
-  string file_bundle_hash = 15;
-  uint64 file_bundle_hash_millis = 16;
-  uint64 file_bundle_binary_count = 17;
+  string file_bundle_id = 9                     [json_name="file_bundle_id"];
+  string file_bundle_path = 10                  [json_name="file_bundle_path"];
+  string file_bundle_executable_rel_path = 11   [json_name="file_bundle_executable_rel_path"];
+  string file_bundle_name = 12                  [json_name="file_bundle_name"];
+  string file_bundle_version = 13               [json_name="file_bundle_version"];
+  string file_bundle_version_string = 14        [json_name="file_bundle_version_string"];
+  string file_bundle_hash = 15                  [json_name="file_bundle_hash"];
+  uint64 file_bundle_hash_millis = 16           [json_name="file_bundle_hash_millis"];
+  uint64 file_bundle_binary_count = 17          [json_name="file_bundle_binary_count"];
 
   // pid_t is an int32
-  int32 pid = 18;
-  int32 ppid = 19;
-  string parent_name = 20;
+  int32 pid = 18                                [json_name="pid"];
+  int32 ppid = 19                               [json_name="ppid"];
+  string parent_name = 20                       [json_name="parent_name"];
 
-  string team_id = 21;
-  string signing_id = 22;
-  string cdhash = 23;
+  string team_id = 21                           [json_name="team_id"];
+  string signing_id = 22                        [json_name="signing_id"];
+  string cdhash = 23                            [json_name="cdhash"];
 
-  string quarantine_data_url = 24;
-  string quarantine_referer_url = 25;
+  string quarantine_data_url = 24               [json_name="quarantine_data_url"];
+  string quarantine_referer_url = 25            [json_name="quarantine_referer_url"];
   // Seconds since UNIX epoch. This field would ideally be an int64 but the protobuf library
   // encodes that as a string, unlike NSJSONSerialization
-  uint32 quarantine_timestamp = 26;
-  string quarantine_agent_bundle_id = 27;
+  uint32 quarantine_timestamp = 26              [json_name="quarantine_timestamp"];
+  string quarantine_agent_bundle_id = 27        [json_name="quarantine_agent_bundle_id"];
 
-  repeated Certificate signing_chain = 28;
+  repeated Certificate signing_chain = 28       [json_name="signing_chain"];
 }
 
 message EventUploadRequest {
-  repeated Event events = 1;
+  repeated Event events = 1                     [json_name="events"];
   // The UUID of the machine where the event(s) occurred
-  string machine_id = 2;
+  string machine_id = 2                         [json_name="machine_id"];
 }
 
 message EventUploadResponse {
@@ -294,9 +294,9 @@ message Rule {
 }
 
 message RuleDownloadRequest {
-  string cursor = 1;
+  string cursor = 1       [json_name="cursor"];
   // The UUID of the machine that is requesting the rules.
-  string machine_id = 2;
+  string machine_id = 2   [json_name="machine_id"];
 }
 
 message RuleDownloadResponse {
@@ -305,10 +305,10 @@ message RuleDownloadResponse {
 }
 
 message PostflightRequest {
-  uint64 rules_received = 1;
-  uint64 rules_processed = 2;
+  uint64 rules_received = 1   [json_name="rules_received"];
+  uint64 rules_processed = 2  [json_name="rules_processed"];
   // The UUID of the machine that is sending this postflight.
-  string machine_id = 3;
+  string machine_id = 3       [json_name="machine_id"];
 }
 
 message PostflightResponse { }

--- a/Source/santasyncservice/testdata/sync_preflight_request.json
+++ b/Source/santasyncservice/testdata/sync_preflight_request.json
@@ -1,0 +1,1 @@
+{"serial_num":"QYGF4QM373","hostname":"full-hostname.example.com","os_version":"14.5","os_build":"23F79","model_identifier":"MacBookPro18,3","santa_version":"2024.6.655965194","primary_user":"username1","client_mode":"MONITOR","machine_id":"50C7E1EB-2EF5-42D4-A084-A7966FC45A95"}


### PR DESCRIPTION
Disable the `preserve_proto_field_names` option when marshalling JSON requests as this prevents the `json_name` attribute on fields from working properly. Add that attribute to all fields so that they marshal as expected. Stop setting the `always_print_enums_as_ints` option as the value we're setting to is the default anyway.

Also add a test that preflight request data looks as expected.