### PR TITLE
sync: Improve logging when connection restored, avoid retries.

### DIFF
--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -257,7 +257,7 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
     return [self eventUploadWithSyncState:syncState];
   }
 
-  LOGE(@"Preflight failed, will try again once %@ is reachable",
+  SLOGE(@"Preflight failed, will try again once %@ is reachable",
        [[SNTConfigurator configurator] syncBaseURL].absoluteString);
   [self startReachability];
   return SNTSyncStatusTypePreflightFailed;
@@ -386,6 +386,7 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
 - (void)setReachable:(BOOL)reachable {
   _reachable = reachable;
   if (reachable) {
+    LOGD(@"Internet connection has been restored, triggering a new sync.");
     [self stopReachability];
     [self sync];
   }

--- a/Source/santasyncservice/SNTSyncManager.m
+++ b/Source/santasyncservice/SNTSyncManager.m
@@ -258,7 +258,7 @@ static const uint8_t kMaxEnqueuedSyncs = 2;
   }
 
   SLOGE(@"Preflight failed, will try again once %@ is reachable",
-       [[SNTConfigurator configurator] syncBaseURL].absoluteString);
+        [[SNTConfigurator configurator] syncBaseURL].absoluteString);
   [self startReachability];
   return SNTSyncStatusTypePreflightFailed;
 }

--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -14,6 +14,7 @@
 
 #import "Source/santasyncservice/SNTSyncStage.h"
 
+#include <Foundation/Foundation.h>
 #import <MOLXPCConnection/MOLXPCConnection.h>
 
 #import "Source/common/SNTCommonEnums.h"
@@ -175,6 +176,11 @@ using santa::NSStringToUTF8String;
     SLOGD(@"Performing request, attempt %d (of %d maximum)...", attempt, maxAttempts);
     data = [self performRequest:request timeout:timeout response:&response error:&requestError];
     if (response.statusCode == 200) break;
+
+    // If the original request failed because of a "No network" error, break out of the loop,
+    // subsequent retries are pointless and the entire sync will be retried once a connection
+    // is established.
+    if (requestError.code == NSURLErrorNotConnectedToInternet) break;
 
     // If the original request failed because of an auth error, attempt to get a new XSRF token and
     // try again. Unfortunately some servers cause NSURLSession to return 'client cert required' or


### PR DESCRIPTION
Don't retry requests if the error is that the machine is offline