### PR TITLE
sync: Remove debug logging of request JSON.

### DIFF
--- a/Source/santasyncservice/SNTSyncStage.mm
+++ b/Source/santasyncservice/SNTSyncStage.mm
@@ -86,7 +86,6 @@ using santa::NSStringToUTF8String;
     return nil;
   }
 
-  SLOGD(@"Request JSON: %s", json.c_str());
   return [self requestWithData:[NSData dataWithBytes:json.data() length:json.size()]
                    contentType:@"application/json"];
 }


### PR DESCRIPTION
This was helpful while switching to the protobuf lib but due to the way SLOGD works it isn't limited to just debug invocations and is quite noisy