### PR TITLE
sync: Drop rules_* fields in postflight to uint32

### DIFF
--- a/Source/santasyncservice/SNTSyncPostflight.mm
+++ b/Source/santasyncservice/SNTSyncPostflight.mm
@@ -38,8 +38,8 @@ using santa::NSStringToUTF8String;
   google::protobuf::Arena arena;
   auto req = google::protobuf::Arena::Create<::pbv1::PostflightRequest>(&arena);
   req->set_machine_id(NSStringToUTF8String(self.syncState.machineID));
-  req->set_rules_received(self.syncState.rulesReceived);
-  req->set_rules_processed(self.syncState.rulesProcessed);
+  req->set_rules_received(static_cast<uint32_t>(self.syncState.rulesReceived));
+  req->set_rules_processed(static_cast<uint32_t>(self.syncState.rulesProcessed));
 
   ::pbv1::PostflightResponse response;
   [self performRequest:[self requestWithMessage:req] intoMessage:&response timeout:30];

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -305,8 +305,8 @@ message RuleDownloadResponse {
 }
 
 message PostflightRequest {
-  uint64 rules_received = 1   [json_name="rules_received"];
-  uint64 rules_processed = 2  [json_name="rules_processed"];
+  uint32 rules_received = 1   [json_name="rules_received"];
+  uint32 rules_processed = 2  [json_name="rules_processed"];
   // The UUID of the machine that is sending this postflight.
   string machine_id = 3       [json_name="machine_id"];
 }


### PR DESCRIPTION
This lets the protobuf json serializer to send the values as ints (like NSJSONSerialization did) instead of strings. This will cause problems if someone has 4B rules but that's probably a sign of bigger problems