### PR TITLE
-[SNTFileInfo initWithEndpointSecurityFile:error:] stat after open

### DIFF
--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -449,7 +449,7 @@ objc_library(
 
 santa_unit_test(
     name = "SNTFileInfoTest",
-    srcs = ["SNTFileInfoTest.m"],
+    srcs = ["SNTFileInfoTest.mm"],
     resources = [
         "testdata/32bitplist",
         "testdata/bad_pagezero",
@@ -459,7 +459,7 @@ santa_unit_test(
         "testdata/BundleExample.app/**",
         "testdata/DirectoryBundle/**",
     ]),
-    deps = [":SNTFileInfo"],
+    deps = [":SNTFileInfo", ":TestUtils"],
 )
 
 santa_unit_test(

--- a/Source/common/BUILD
+++ b/Source/common/BUILD
@@ -459,7 +459,10 @@ santa_unit_test(
         "testdata/BundleExample.app/**",
         "testdata/DirectoryBundle/**",
     ]),
-    deps = [":SNTFileInfo", ":TestUtils"],
+    deps = [
+        ":SNTFileInfo",
+        ":TestUtils",
+    ],
 )
 
 santa_unit_test(

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -12,7 +12,13 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
+#include <Foundation/Foundation.h>
+#include <Foundation/NSObjCRuntime.h>
+#import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <XCTest/XCTest.h>
+#include <objc/objc.h>
+#include <sys/stat.h>
+#include "Source/common/TestUtils.h"
 
 #import "Source/common/SNTFileInfo.h"
 
@@ -248,6 +254,23 @@
   // it should be available..
   sut = [[SNTFileInfo alloc] initWithPath:@"/usr/bin/csreq"];
   XCTAssertNotNil([sut infoPlist]);
+}
+
+- (void)testWithEndpointSecurityFile {
+  struct stat sb;
+  XCTAssertEqual(stat("/usr/bin/yes", &sb), 0);
+  es_file_t file = MakeESFile("/usr/bin/yes", sb);
+  NSError *error;
+  SNTFileInfo *sut = [[SNTFileInfo alloc] initWithEndpointSecurityFile:&file error:&error];
+  XCTAssertNotNil(sut);
+}
+
+- (void)testWithEndpointSecurityFileError {
+  // The constructed ES stat will not match `/usr/bin/yes` on disk stat values.
+  es_file_t file = MakeESFile("/usr/bin/yes");
+  NSError *error;
+  SNTFileInfo *sut = [[SNTFileInfo alloc] initWithEndpointSecurityFile:&file error:&error];
+  XCTAssertNil(sut);
 }
 
 @end

--- a/Source/common/SNTFileInfoTest.mm
+++ b/Source/common/SNTFileInfoTest.mm
@@ -12,11 +12,7 @@
 ///    See the License for the specific language governing permissions and
 ///    limitations under the License.
 
-#include <Foundation/Foundation.h>
-#include <Foundation/NSObjCRuntime.h>
-#import <MOLCodesignChecker/MOLCodesignChecker.h>
 #import <XCTest/XCTest.h>
-#include <objc/objc.h>
 #include <sys/stat.h>
 #include "Source/common/TestUtils.h"
 


### PR DESCRIPTION
SNTFileInfo: Do not rely on the stat provided by ES in the initializer. Instead, open the file, then stat. If the opened file's stat does not match the ES stat, return nil.

If there is a mismatch, handle it like a file that can not be opened:

https://github.com/google/santa/blob/ff0efe952b2456b52fad2a40e6eedb0931e6bdf7/Source/santad/SNTExecutionController.mm#L234