### PR TITLE
Fix: Change uint64 fields in syncv1.proto to uint32 for backwards compatibility

### DIFF
--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
@@ -101,6 +101,7 @@ using santa::Message;
                               }];
 }
 
+// Entry point not async
 - (void)handleMessage:(Message &&)esMsg
    recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {
   if (unlikely(esMsg->event_type != ES_EVENT_TYPE_AUTH_EXEC)) {
@@ -115,7 +116,7 @@ using santa::Message;
     recordEventMetrics(EventDisposition::kDropped);
     return;
   }
-
+  // goes async
   [self processMessage:std::move(esMsg)
                handler:^(const Message &msg) {
                  [self processMessage:msg];

--- a/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
+++ b/Source/santad/EventProviders/SNTEndpointSecurityAuthorizer.mm
@@ -101,7 +101,6 @@ using santa::Message;
                               }];
 }
 
-// Entry point not async
 - (void)handleMessage:(Message &&)esMsg
    recordEventMetrics:(void (^)(EventDisposition))recordEventMetrics {
   if (unlikely(esMsg->event_type != ES_EVENT_TYPE_AUTH_EXEC)) {
@@ -116,7 +115,7 @@ using santa::Message;
     recordEventMetrics(EventDisposition::kDropped);
     return;
   }
-  // goes async
+
   [self processMessage:std::move(esMsg)
                handler:^(const Message &msg) {
                  [self processMessage:msg];

--- a/Source/santasyncservice/SNTSyncEventUpload.mm
+++ b/Source/santasyncservice/SNTSyncEventUpload.mm
@@ -150,8 +150,8 @@ using santa::NSStringToUTF8String;
   e->set_file_bundle_version(NSStringToUTF8String(event.fileBundleVersion));
   e->set_file_bundle_version_string(NSStringToUTF8String(event.fileBundleVersionString));
   e->set_file_bundle_hash(NSStringToUTF8String(event.fileBundleHash));
-  e->set_file_bundle_hash_millis([event.fileBundleHashMilliseconds longLongValue]);
-  e->set_file_bundle_binary_count([event.fileBundleBinaryCount longLongValue]);
+  e->set_file_bundle_hash_millis([event.fileBundleHashMilliseconds unsignedIntValue]);
+  e->set_file_bundle_binary_count([event.fileBundleBinaryCount unsignedIntValue]);
 
   e->set_pid([event.pid unsignedIntValue]);
   e->set_ppid([event.ppid unsignedIntValue]);

--- a/Source/santasyncservice/syncv1.proto
+++ b/Source/santasyncservice/syncv1.proto
@@ -125,16 +125,16 @@ message PreflightResponse {
   optional bool disable_unknown_event_upload = 7;
 
   // Specifies the time interval in seconds between full syncs. Defaults to 600 (10 minutes). Cannot be set lower than 60.
-  uint64 full_sync_interval_seconds = 8 [json_name="full_sync_interval"];
+  uint32 full_sync_interval_seconds = 8 [json_name="full_sync_interval"];
 
   // When push notifications are enabled, this overrides the full_sync_interval above. It is expected that Santa will not
   // need to perform a full sync as frequently when push notifications are working. Defaults to 14400 (6 hours).
-  uint64 push_notification_full_sync_interval_seconds = 9 [json_name="push_notification_full_sync_interval"];
+  uint32 push_notification_full_sync_interval_seconds = 9 [json_name="push_notification_full_sync_interval"];
 
   // The maximum number of seconds Santa can wait before triggering a rule sync after receiving a "global rule sync" notification.
   // As these notifications cause every Santa client to try and sync, we add a random delay to each client to try and spread the
   // load out on the sync server. This defaults to 600 (10 minutes).
-  uint64 push_notification_global_rule_sync_deadline_seconds = 10 [json_name="push_notification_global_rule_sync_deadline"];
+  uint32 push_notification_global_rule_sync_deadline_seconds = 10 [json_name="push_notification_global_rule_sync_deadline"];
 
   // These two regexes are used to allow/block executions whose path matches. The provided regex must conform to ICU format.
   // While this feature can be useful, its use should be very carefully considered as it is much riskier than real rules.
@@ -159,8 +159,8 @@ message PreflightResponse {
   optional bool deprecated_enabled_transitive_whitelisting = 1000 [json_name="enabled_transitive_whitelisting", deprecated=true];
   optional bool deprecated_transitive_whitelisting_enabled = 1001 [json_name="transitive_whitelisting_enabled", deprecated=true];
   optional bool deprecated_bundles_enabled = 1002 [json_name="bundles_enabled", deprecated=true];
-  optional uint64 deprecated_fcm_full_sync_interval_seconds = 1003 [json_name="fcm_full_sync_interval", deprecated=true];
-  optional uint64 deprecated_fcm_global_rule_sync_deadline_seconds = 1004 [json_name="fcm_global_rule_sync_deadline", deprecated=true];
+  optional uint32 deprecated_fcm_full_sync_interval_seconds = 1003 [json_name="fcm_full_sync_interval", deprecated=true];
+  optional uint32 deprecated_fcm_global_rule_sync_deadline_seconds = 1004 [json_name="fcm_global_rule_sync_deadline", deprecated=true];
   optional string deprecated_whitelist_regex = 1005 [json_name="whitelist_regex", deprecated=true];
   optional string deprecated_blacklist_regex = 1006 [json_name="blacklist_regex", deprecated=true];
 
@@ -214,8 +214,8 @@ message Event {
   string file_bundle_version = 13               [json_name="file_bundle_version"];
   string file_bundle_version_string = 14        [json_name="file_bundle_version_string"];
   string file_bundle_hash = 15                  [json_name="file_bundle_hash"];
-  uint64 file_bundle_hash_millis = 16           [json_name="file_bundle_hash_millis"];
-  uint64 file_bundle_binary_count = 17          [json_name="file_bundle_binary_count"];
+  uint32 file_bundle_hash_millis = 16           [json_name="file_bundle_hash_millis"];
+  uint32 file_bundle_binary_count = 17          [json_name="file_bundle_binary_count"];
 
   // pid_t is an int32
   int32 pid = 18                                [json_name="pid"];

--- a/docs/development/sync-protocol.md
+++ b/docs/development/sync-protocol.md
@@ -140,7 +140,7 @@ The JSON object has the following keys:
 | enable_bundles              | Use previous setting                        | boolean | Enable bundle scanning | true |
 | enable_transitive_rules     | Use previous setting                        | boolean | Whether or not to enable transitive allowlisting | true |
 | batch_size                  | Use a Santa-defined default value           | integer | Number of events to upload at a time | 128 |
-| full_sync_interval          | Defaults to 600 seconds                     | integer | Number of seconds between full syncs. Note: Santa enforces a minimum value of 60. The default value will be used if a smaller value is provided. | 600 |
+| full_sync_interval          | Defaults to 600 seconds                     | uint32 | Number of seconds between full syncs. Note: Santa enforces a minimum value of 60. The default value will be used if a smaller value is provided. | 600 |
 | client_mode                 | Use previous setting                        | string  | Operating mode to set for the client | either `MONITOR` or `LOCKDOWN` |
 | allowed_path_regex          | Use previous setting                        | string  | Regular expression to allow a binary to execute from a path | "/Users/markowsk/foo/.\*" |
 | blocked_path_regex          | Use previous setting                        | string  | Regular expression to block a binary from executing by path | "/tmp/" |
@@ -223,8 +223,8 @@ sequenceDiagram
 | file_bundle_version | NO | string | The bundle version string | "9999.1.1" |
 | file_bundle_version_string | NO | string | Bundle short version string | "2.3.4" |
 | file_bundle_hash | NO | string | SHA256 hash of all executables in the bundle | "7466e3687f540bcb7792c6d14d5a186667dbe18a85021857b42effe9f0370805" |
-| file_bundle_hash_millis | NO | float64 | The time in milliseconds it took to find all of the binaries, hash and produce the bundle_hash | 1234775 |
-| file_bundle_binary_count | NO | integer | The number of binaries in a bundle | 13 |
+| file_bundle_hash_millis | NO | uint32 | The time in milliseconds it took to find all of the binaries, hash and produce the bundle_hash | 1234775 |
+| file_bundle_binary_count | NO | uint32 | The number of binaries in a bundle | 13 |
 | pid | NO | int | Process id of the executable that was blocked | 1234 |
 | ppid | NO | int | Parent process id of the executable that was blocked | 456 |
 | parent_name | NO | Parent process short command name of the executable that was blocked | "bar" |


### PR DESCRIPTION
Change the uint64 fields in the syncv1.proto to uint32 to ensure backwards compatibility.

This also updates the SNTSyncEventUpload code to use the uint32 values and updates sync protocol docs to define the integer fields as `uint32` explicitly.