### PR TITLE
Use runtime platform binary check for exec evals

### DIFF
--- a/Source/santad/SNTPolicyProcessor.h
+++ b/Source/santad/SNTPolicyProcessor.h
@@ -47,12 +47,6 @@
 ///
 - (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
                                      targetProcess:(nonnull const es_process_t *)targetProc
-                        entitlementsFilterCallback:
-                          (NSDictionary *_Nullable (^_Nonnull)(
-                            const char *_Nullable teamID,
-                            NSDictionary *_Nullable entitlements))entitlementsFilterCallback;
-- (nonnull SNTCachedDecision *)decisionForFileInfo:(nonnull SNTFileInfo *)fileInfo
-                                     targetProcess:(nonnull const es_process_t *)targetProc
                           preCodesignCheckCallback:(void (^_Nullable)(void))preCodesignCheckCallback
                         entitlementsFilterCallback:
                           (NSDictionary *_Nullable (^_Nonnull)(


### PR DESCRIPTION
This changes Santa to use whether a current process is marked as a platform binary for the exec policy processing instead of static checks.

#1423 